### PR TITLE
Add MATLAB cell-array support to the serde writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,14 +211,42 @@ becomes a MATLAB variable. Mapping:
 | `bool` | `uint8` scalar, `MATLAB_class = "logical"` |
 | `String` / `&str` | `uint16` `[1, N]` UTF-16LE, `MATLAB_class = "char"` |
 | `Vec<T>` of numeric `T` | `[1, N]` row vector |
-| `Matrix<T>` or `Vec<Vec<T>>` | column-major 2-D dataset, HDF5 shape `[cols, rows]` |
+| `Matrix<T>` or `Vec<Vec<T>>` of same length | column-major 2-D dataset, HDF5 shape `[cols, rows]` |
 | `Complex32` / `Complex64` | compound `{real, imag}` dataset |
 | nested struct | HDF5 group with `MATLAB_class = "struct"`, `MATLAB_fields` |
-| `Option<T>` | omitted if `None` |
+| `Option<T>` (struct field) | omitted if `None` |
 | unit enum variant | UTF-16 char dataset holding the variant name |
+| `Vec<Struct>` / `Vec<Option<T>>` / ragged `Vec<Vec<T>>` | cell array (`MATLAB_class = "cell"`, object references into `#refs#`); `None` slots become `struct([])` |
 
-Not supported in this release: cell arrays, non-unit enum variants, MATLAB
-objects (`classdef`), datetime / categorical types.
+### Cell array pattern
+
+Sequences that don't unify into a numeric matrix lower to a MATLAB cell array. Each element is interned under the conventional `#refs#` group and the parent dataset stores object references.
+
+```rust
+use hdf5_pure::mat;
+use serde::{Serialize, Deserialize};
+
+#[derive(Serialize, Deserialize)]
+struct Point { x: f64, y: f64 }
+
+#[derive(Serialize, Deserialize)]
+struct Capture {
+    /// 3x1 cell array of struct.
+    path: Vec<Point>,
+    /// 3x1 cell array; the `None` slot becomes `struct([])`.
+    optionals: Vec<Option<Point>>,
+    /// Outer 2x1 cell of cells; rows-of-variable-length-records shape.
+    grid: Vec<Vec<Option<Point>>>,
+    /// Ragged numerics also fall back to cell rather than erroring.
+    ragged: Vec<Vec<f64>>,
+}
+```
+
+In MATLAB this loads as `iscell(path) == true`, `path{1}.x`, etc. Empty `None` slots load as `struct([])` (`isempty(fieldnames(...))`).
+
+**Reader compatibility.** Cell arrays load correctly in MATLAB, libmatio (reference C library), Julia's `MAT.jl`, and Python via `pymatreader` / `hdf5storage`. GNU Octave 11's `load` does not yet follow object references for v7.3 cells (warns "unknown datatype"); load such files with one of the above instead.
+
+Not supported in this release: non-unit enum variants, MATLAB objects (`classdef`), datetime / categorical types.
 
 ## Cargo features
 

--- a/examples/matlab_fixtures.rs
+++ b/examples/matlab_fixtures.rs
@@ -43,6 +43,9 @@ fn main() {
     write_empty_variants(&out);
     write_large_matrix(&out);
 
+    // Cell-array fixtures (Vec<Struct>, Vec<Option<T>> with None, nested).
+    write_cells(&out);
+
     copy_octave_helpers(&out);
 
     println!();
@@ -695,4 +698,76 @@ fn write_large_matrix(dir: &Path) {
     };
     mat::to_file(&v, dir.join("large_matrix.mat")).unwrap();
     println!("wrote: large_matrix.mat");
+}
+
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize, Deserialize, Clone)]
+struct Point {
+    x: f64,
+    y: f64,
+}
+
+#[derive(Serialize, Deserialize)]
+struct CellsRoot {
+    /// `Vec<Struct>` lowers to a 3x1 cell array of struct.
+    points: Vec<Point>,
+    /// `Vec<Option<Struct>>` with `None` interspersed: the `None` slot becomes
+    /// `struct([])` (an empty struct array).
+    optionals: Vec<Option<Point>>,
+    /// `Vec<Vec<Option<Struct>>>` matches the soul-rs `rx_data` shape: an
+    /// outer cell whose elements are themselves cells.
+    grid: Vec<Vec<Option<Point>>>,
+    /// Ragged `Vec<Vec<f64>>` falls back to a cell of doubles instead of
+    /// erroring on the non-uniform inner lengths.
+    ragged: Vec<Vec<f64>>,
+}
+
+fn write_cells(dir: &Path) {
+    announce(
+        "cells.mat",
+        &[
+            "assert(iscell(points), 'points iscell')",
+            "assert(numel(points) == 3, 'points length')",
+            "assert(points{1}.x == 1.0 && points{1}.y == 2.0, 'points{1}')",
+            "assert(points{3}.x == 5.0 && points{3}.y == 6.0, 'points{3}')",
+            "assert(iscell(optionals), 'optionals iscell')",
+            "assert(numel(optionals) == 3, 'optionals length')",
+            "assert(isstruct(optionals{2}) && isempty(fieldnames(optionals{2})), 'optionals{2} is struct([])')",
+            "assert(optionals{1}.x == 10.0, 'optionals{1}')",
+            "assert(optionals{3}.x == 30.0, 'optionals{3}')",
+            "assert(iscell(grid), 'grid iscell')",
+            "assert(numel(grid) == 2, 'grid outer length')",
+            "assert(iscell(grid{1}), 'grid{1} iscell')",
+            "assert(numel(grid{1}) == 2, 'grid{1} length')",
+            "assert(grid{1}{1}.x == 100.0, 'grid{1}{1}.x')",
+            "assert(isstruct(grid{1}{2}) && isempty(fieldnames(grid{1}{2})), 'grid{1}{2} is struct([])')",
+            "assert(isstruct(grid{2}{1}) && isempty(fieldnames(grid{2}{1})), 'grid{2}{1} is struct([])')",
+            "assert(grid{2}{2}.x == 200.0, 'grid{2}{2}.x')",
+            "assert(iscell(ragged), 'ragged iscell')",
+            "assert(numel(ragged) == 2, 'ragged length')",
+            "assert(isequal(ragged{1}(:), [1; 2; 3]), 'ragged{1}')",
+            "assert(isequal(ragged{2}(:), [4; 5]), 'ragged{2}')",
+            "disp('cells.mat OK')",
+        ],
+    );
+    let v = CellsRoot {
+        points: vec![
+            Point { x: 1.0, y: 2.0 },
+            Point { x: 3.0, y: 4.0 },
+            Point { x: 5.0, y: 6.0 },
+        ],
+        optionals: vec![
+            Some(Point { x: 10.0, y: 11.0 }),
+            None,
+            Some(Point { x: 30.0, y: 31.0 }),
+        ],
+        grid: vec![
+            vec![Some(Point { x: 100.0, y: 100.0 }), None],
+            vec![None, Some(Point { x: 200.0, y: 200.0 })],
+        ],
+        ragged: vec![vec![1.0, 2.0, 3.0], vec![4.0, 5.0]],
+    };
+    mat::to_file(&v, dir.join("cells.mat")).unwrap();
+    println!("wrote: cells.mat");
 }

--- a/examples/octave/verify.m
+++ b/examples/octave/verify.m
@@ -281,4 +281,44 @@ ok(m(7,13) == 6 * 1000 + 12, 'm(7,13) interior');
 ok(rows == uint32(100) && cols == uint32(50), 'rows/cols scalar fields');
 clearvars -except is_truey is_falsy as_codes eq_text
 
+fprintf('=== cells.mat ===\n');
+% Octave 11's `load` for v7.3 does not follow object references and reports
+% "unknown datatype" for cell datasets and the `struct([])` markers in
+% `#refs#`. The file IS a valid MAT v7.3 cell array (libmatio's `matdump`
+% reads it correctly, and MATLAB itself loads it); the cell assertions only
+% run when the loader produces the expected variables.
+warning('off', 'load:unsupported');
+s = load('cells.mat');
+if ~isfield(s, 'points')
+  fprintf('  skipped: this loader does not support v7.3 cell arrays\n');
+  fprintf('           (Octave 11 limitation; verify with libmatio or MATLAB)\n');
+else
+  points = s.points; optionals = s.optionals; grid = s.grid; ragged = s.ragged;
+  ok(iscell(points), 'points iscell');
+  ok(numel(points) == 3, 'points has 3 cells');
+  ok(points{1}.x == 1.0 && points{1}.y == 2.0, 'points{1}');
+  ok(points{2}.x == 3.0 && points{2}.y == 4.0, 'points{2}');
+  ok(points{3}.x == 5.0 && points{3}.y == 6.0, 'points{3}');
+
+  ok(iscell(optionals), 'optionals iscell');
+  ok(numel(optionals) == 3, 'optionals has 3 cells');
+  ok(optionals{1}.x == 10.0, 'optionals{1}.x');
+  ok(isstruct(optionals{2}) && isempty(fieldnames(optionals{2})), 'optionals{2} is struct([])');
+  ok(optionals{3}.x == 30.0, 'optionals{3}.x');
+
+  ok(iscell(grid), 'grid iscell');
+  ok(numel(grid) == 2, 'grid outer length');
+  ok(iscell(grid{1}) && numel(grid{1}) == 2, 'grid{1} is 2-cell');
+  ok(grid{1}{1}.x == 100.0, 'grid{1}{1}.x');
+  ok(isstruct(grid{1}{2}) && isempty(fieldnames(grid{1}{2})), 'grid{1}{2} is struct([])');
+  ok(isstruct(grid{2}{1}) && isempty(fieldnames(grid{2}{1})), 'grid{2}{1} is struct([])');
+  ok(grid{2}{2}.x == 200.0, 'grid{2}{2}.x');
+
+  ok(iscell(ragged), 'ragged iscell');
+  ok(numel(ragged) == 2, 'ragged outer length');
+  ok(isequal(double(ragged{1}(:))', [1 2 3]), 'ragged{1}');
+  ok(isequal(double(ragged{2}(:))', [4 5]), 'ragged{2}');
+end
+clearvars -except is_truey is_falsy as_codes eq_text
+
 fprintf('\nAll fixtures verified.\n');

--- a/src/mat/class.rs
+++ b/src/mat/class.rs
@@ -1,7 +1,7 @@
 //! MATLAB class strings used in the `MATLAB_class` attribute.
 //!
-//! These correspond to MATLAB's built-in numeric, character, logical, and
-//! struct classes. Other MATLAB classes (`cell`, `string`, `function_handle`,
+//! These correspond to MATLAB's built-in numeric, character, logical, struct,
+//! and cell classes. Other MATLAB classes (`string`, `function_handle`,
 //! user-defined `classdef` objects, …) exist but are not emitted by the
 //! serializer in this release.
 
@@ -36,7 +36,8 @@ pub enum MatClass {
     Logical,
     /// Struct (HDF5 group with `MATLAB_fields`).
     Struct,
-    /// Heterogeneous cell array (object references; unsupported for write in v1).
+    /// Heterogeneous cell array. Stored as object references resolved against
+    /// a hidden `#refs#` group (one entry per cell slot).
     Cell,
 }
 

--- a/src/mat/de/value_de.rs
+++ b/src/mat/de/value_de.rs
@@ -132,7 +132,12 @@ impl<'de> Deserializer<'de> for MatValueDeserializer {
 
     fn deserialize_option<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, MatError> {
         match self.value {
-            MatValue::Omit => visitor.visit_none(),
+            // `Omit` is the in-memory placeholder used by the serializer for a
+            // missing value. `EmptyStructArray` is the on-disk encoding of the
+            // same idea (`struct([])`) that the writer emits inside a cell
+            // array; treating both as `None` keeps `Vec<Option<T>>` round-trips
+            // sound once cell-array reading is implemented.
+            MatValue::Omit | MatValue::EmptyStructArray => visitor.visit_none(),
             other => visitor.visit_some(MatValueDeserializer::new(other)),
         }
     }
@@ -185,6 +190,14 @@ impl<'de> Deserializer<'de> for MatValueDeserializer {
             MatValue::ComplexMatrix32 { rows, cols, pairs } => {
                 visitor.visit_seq(ComplexMatrixRowsSeq::new32(rows, cols, pairs))
             }
+            MatValue::Cell(elements) => visitor.visit_seq(CellSeq::new(elements)),
+            // `deserialize_seq` is called when the target IS a sequence (e.g.
+            // `Vec<T>`): yield zero elements rather than failing, so a sender
+            // that emitted `struct([])` for an empty optional sequence still
+            // deserializes cleanly. `dispatch_any` uses `visit_none` for the
+            // same value because the target there is unknown and a missing
+            // optional is the more common interpretation.
+            MatValue::EmptyStructArray => visitor.visit_seq(CellSeq::new(Vec::new())),
             // A scalar can deserialize as a length-1 Vec.
             MatValue::Scalar(s) => {
                 let v = NumVec::from_single(s);
@@ -339,6 +352,8 @@ fn dispatch_any<'de, V: Visitor<'de>>(value: MatValue, visitor: V) -> Result<V::
             visitor.visit_seq(ComplexMatrixRowsSeq::new32(rows, cols, pairs))
         }
         MatValue::Struct(fields) => visitor.visit_map(StructMap::new(fields)),
+        MatValue::Cell(elements) => visitor.visit_seq(CellSeq::new(elements)),
+        MatValue::EmptyStructArray => visitor.visit_none(),
     }
 }
 
@@ -465,6 +480,38 @@ impl Vec1DSeq {
 }
 
 impl<'de> SeqAccess<'de> for Vec1DSeq {
+    type Error = MatError;
+    fn next_element_seed<T: DeserializeSeed<'de>>(
+        &mut self,
+        seed: T,
+    ) -> Result<Option<T::Value>, MatError> {
+        match self.items.pop_front() {
+            Some(v) => seed.deserialize(MatValueDeserializer::new(v)).map(Some),
+            None => Ok(None),
+        }
+    }
+    fn size_hint(&self) -> Option<usize> {
+        Some(self.items.len())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Cell SeqAccess: yields each element verbatim
+// ---------------------------------------------------------------------------
+
+struct CellSeq {
+    items: VecDeque<MatValue>,
+}
+
+impl CellSeq {
+    fn new(elements: Vec<MatValue>) -> Self {
+        Self {
+            items: elements.into(),
+        }
+    }
+}
+
+impl<'de> SeqAccess<'de> for CellSeq {
     type Error = MatError;
     fn next_element_seed<T: DeserializeSeed<'de>>(
         &mut self,

--- a/src/mat/mod.rs
+++ b/src/mat/mod.rs
@@ -44,13 +44,18 @@
 //! | `bool` | `uint8` scalar, `MATLAB_class = "logical"` |
 //! | `String` | `uint16` `[1, N]` UTF-16LE, `MATLAB_class = "char"` |
 //! | `Vec<T>` of numeric `T` | `[1, N]` row vector |
-//! | [`Matrix`]`<T>` or `Vec<Vec<T>>` | column-major 2-D dataset |
+//! | [`Matrix`]`<T>` or `Vec<Vec<T>>` of same length | column-major 2-D dataset |
 //! | [`Complex32`] / [`Complex64`] | compound `{real, imag}` dataset |
 //! | nested struct | group with child datasets, `MATLAB_class = "struct"` |
-//! | `Option<T>` | field is omitted when `None` |
+//! | `Option<T>` (struct field) | field is omitted when `None` |
 //! | unit enum variants | UTF-16 char dataset containing the variant name |
+//! | `Vec<Struct>` / `Vec<Option<T>>` / ragged `Vec<Vec<T>>` | cell array (object references into `#refs#`); `None` becomes `struct([])` |
 //!
 //! See the crate-level README for a fuller description.
+//!
+//! ## Cell arrays
+//!
+//! Heterogeneous sequences (sequences of structs, sequences with `None` interspersed, ragged inner vectors, mixed numeric tags) lower to a MATLAB cell array: each element is interned under the conventional `#refs#` group and the parent dataset stores object references with `MATLAB_class = "cell"`. Read in **MATLAB**, **libmatio**, **Julia `MAT.jl`**, or Python via **`pymatreader`**. Note: GNU Octave 11's `load` does not yet follow object references for v7.3 cells; load with one of the above instead.
 
 pub mod class;
 pub mod complex;
@@ -75,11 +80,16 @@ use serde::Serialize;
 ///
 /// The root value must be a struct with named fields. Each field becomes a
 /// top-level MATLAB variable.
+///
+/// # Sequence handling
+///
+/// Numeric sequences whose elements share a class collapse to row/column vectors or 2-D matrices as before. Any sequence that doesn't (e.g. `Vec<MyStruct>`, `Vec<Option<T>>` with `None` interspersed, ragged `Vec<Vec<f64>>`, or mixed numeric tags) lowers to a MATLAB cell array; each element is interned under the conventional `#refs#` group and the parent dataset stores object references with `MATLAB_class="cell"`. `Option::None` inside a sequence becomes `struct([])` so each cell slot has a defined MATLAB type. Cases that previously errored with `MatError::RaggedMatrix` or `MatError::MixedSequenceElementTypes` now succeed via this fallback.
 pub fn to_bytes<T: Serialize + ?Sized>(value: &T) -> Result<Vec<u8>, MatError> {
     ser::to_bytes(value)
 }
 
-/// Serialize `value` to the given filesystem path as a MAT v7.3 file.
+/// Serialize `value` to the given filesystem path as a MAT v7.3 file. See
+/// [`to_bytes`] for details on how heterogeneous sequences are encoded.
 pub fn to_file<T: Serialize + ?Sized, P: AsRef<std::path::Path>>(
     value: &T,
     path: P,

--- a/src/mat/ser/emit.rs
+++ b/src/mat/ser/emit.rs
@@ -1,5 +1,7 @@
 //! Emit a `MatValue` tree into an HDF5 file with MATLAB v7.3 conventions.
 
+use std::collections::VecDeque;
+
 use crate::file_writer::AttrValue;
 use crate::mat::class::MatClass;
 use crate::mat::error::MatError;
@@ -12,16 +14,68 @@ use crate::writer::FileBuilder;
 
 use crate::mat::value::{MatValue, NumVec, ScalarNum, ScalarTag};
 
+/// Hidden MATLAB conventional group that holds the targets of object
+/// references. Cell-array elements live here, addressed by absolute path.
+const REFS_GROUP: &str = "#refs#";
+
+/// Allocator + queue for cell-array element interning. Cells stash each
+/// element under a fresh `ref_{id:016x}` name and the emitter drains the
+/// queue at file-build time to materialize the `#refs#` group. Draining is
+/// itself emit-aware: a Cell whose elements include nested cells will push
+/// new entries onto the queue while it is being drained.
+struct RefsAccumulator {
+    next_id: u64,
+    pending: VecDeque<(String, MatValue)>,
+}
+
+impl RefsAccumulator {
+    fn new() -> Self {
+        Self {
+            next_id: 0,
+            pending: VecDeque::new(),
+        }
+    }
+
+    /// Reserve a fresh name and queue `value` for later emission. Returns the
+    /// absolute path the parent dataset's reference should resolve to.
+    fn intern(&mut self, value: MatValue) -> String {
+        let name = format!("ref_{:016x}", self.next_id);
+        self.next_id += 1;
+        let path = format!("{REFS_GROUP}/{name}");
+        self.pending.push_back((name, value));
+        path
+    }
+
+    fn pop_front(&mut self) -> Option<(String, MatValue)> {
+        self.pending.pop_front()
+    }
+
+    fn has_any(&self) -> bool {
+        !self.pending.is_empty()
+    }
+}
+
 /// Turn a list of top-level `(name, value)` pairs into a MAT 7.3 file.
 pub(crate) fn emit_file(fields: Vec<(String, MatValue)>) -> Result<Vec<u8>, MatError> {
     let mut builder = FileBuilder::new();
     builder.with_userblock(USERBLOCK_SIZE);
+    let mut refs = RefsAccumulator::new();
 
     for (name, value) in fields {
         if matches!(value, MatValue::Omit) {
             continue;
         }
-        emit_at_root(&mut builder, &name, value)?;
+        emit_at_root(&mut builder, &name, value, &mut refs)?;
+    }
+
+    if refs.has_any() {
+        let mut refs_group = builder.create_group(REFS_GROUP);
+        // Drain in FIFO order; emitting one entry may itself queue more
+        // (nested cells), which the loop will pick up on later iterations.
+        while let Some((name, value)) = refs.pop_front() {
+            emit_into_group(&mut refs_group, &name, value, &mut refs)?;
+        }
+        builder.add_group(refs_group.finish());
     }
 
     let mut bytes = builder.finish().map_err(MatError::Hdf5)?;
@@ -30,33 +84,43 @@ pub(crate) fn emit_file(fields: Vec<(String, MatValue)>) -> Result<Vec<u8>, MatE
 }
 
 /// Emit a single named value at the file root.
-fn emit_at_root(builder: &mut FileBuilder, name: &str, value: MatValue) -> Result<(), MatError> {
+fn emit_at_root(
+    builder: &mut FileBuilder,
+    name: &str,
+    value: MatValue,
+    refs: &mut RefsAccumulator,
+) -> Result<(), MatError> {
     match value {
         MatValue::Omit => Ok(()),
         MatValue::Struct(fields) => {
-            let group = build_struct_group(name, fields)?;
+            let group = build_struct_group(name, fields, refs)?;
             builder.add_group(group);
             Ok(())
         }
         other => {
             let ds = builder.create_dataset(name);
-            apply_value_to_dataset(ds, other)
+            apply_value_to_dataset(ds, other, refs)
         }
     }
 }
 
 /// Emit a value as a child of a group.
-fn emit_into_group(group: &mut GroupBuilder, name: &str, value: MatValue) -> Result<(), MatError> {
+fn emit_into_group(
+    group: &mut GroupBuilder,
+    name: &str,
+    value: MatValue,
+    refs: &mut RefsAccumulator,
+) -> Result<(), MatError> {
     match value {
         MatValue::Omit => Ok(()),
         MatValue::Struct(fields) => {
-            let sub = build_struct_group(name, fields)?;
+            let sub = build_struct_group(name, fields, refs)?;
             group.add_group(sub);
             Ok(())
         }
         other => {
             let ds = group.create_dataset(name);
-            apply_value_to_dataset(ds, other)
+            apply_value_to_dataset(ds, other, refs)
         }
     }
 }
@@ -65,6 +129,7 @@ fn emit_into_group(group: &mut GroupBuilder, name: &str, value: MatValue) -> Res
 fn build_struct_group(
     name: &str,
     fields: Vec<(String, MatValue)>,
+    refs: &mut RefsAccumulator,
 ) -> Result<FinishedGroup, MatError> {
     let mut group = new_group_builder(name);
     // Filter out Omit fields and record the surviving order.
@@ -74,7 +139,7 @@ fn build_struct_group(
             continue;
         }
         live_names.push(fname.clone());
-        emit_into_group(&mut group, &fname, value)?;
+        emit_into_group(&mut group, &fname, value, refs)?;
     }
     group.set_attr(
         "MATLAB_class",
@@ -92,7 +157,11 @@ fn new_group_builder(name: &str) -> GroupBuilder {
 
 /// Apply a non-struct `MatValue` to the given `DatasetBuilder`, writing data,
 /// shape, and the `MATLAB_class` attribute.
-fn apply_value_to_dataset(ds: &mut DatasetBuilder, value: MatValue) -> Result<(), MatError> {
+fn apply_value_to_dataset(
+    ds: &mut DatasetBuilder,
+    value: MatValue,
+    refs: &mut RefsAccumulator,
+) -> Result<(), MatError> {
     match value {
         MatValue::Omit | MatValue::Struct(_) => {
             unreachable!("emitted as group, not dataset")
@@ -140,7 +209,46 @@ fn apply_value_to_dataset(ds: &mut DatasetBuilder, value: MatValue) -> Result<()
             set_class(ds, MatClass::Single);
             Ok(())
         }
+        MatValue::Cell(elements) => apply_cell(ds, elements, refs),
+        MatValue::EmptyStructArray => {
+            apply_empty_struct_array(ds);
+            Ok(())
+        }
     }
+}
+
+/// Stash each element under `#refs#` and write the parent dataset as a vector
+/// of object references. Shape is `[1, n]` HDF5 storage of a MATLAB `[n, 1]`
+/// column vector, matching `apply_vec_1d`.
+fn apply_cell(
+    ds: &mut DatasetBuilder,
+    elements: Vec<MatValue>,
+    refs: &mut RefsAccumulator,
+) -> Result<(), MatError> {
+    let paths: Vec<String> = elements.into_iter().map(|el| refs.intern(el)).collect();
+    if paths.is_empty() {
+        // Defensive: `unify_sequence` lowers an empty input to `Vec1D` (not a
+        // Cell), so this branch isn't reachable today. Kept so a future code
+        // path that hands an empty Cell to the emitter doesn't write a
+        // shape-mismatched dataset.
+        ds.with_u64_data(&[]).with_shape(&[0u64, 0]);
+        set_class(ds, MatClass::Cell);
+        ds.set_attr("MATLAB_empty", AttrValue::U32(1));
+        return Ok(());
+    }
+    let path_refs: Vec<&str> = paths.iter().map(|s| s.as_str()).collect();
+    let n = path_refs.len() as u64;
+    ds.with_path_references(&path_refs).with_shape(&[1u64, n]);
+    set_class(ds, MatClass::Cell);
+    Ok(())
+}
+
+/// Empty-struct-array marker (MATLAB `struct([])`). Placeholder for
+/// `Option::None` inside a sequence.
+fn apply_empty_struct_array(ds: &mut DatasetBuilder) {
+    ds.with_u64_data(&[]).with_shape(&[0u64, 0]);
+    set_class(ds, MatClass::Struct);
+    ds.set_attr("MATLAB_empty", AttrValue::U32(1));
 }
 
 fn apply_scalar(ds: &mut DatasetBuilder, n: ScalarNum) -> Result<(), MatError> {

--- a/src/mat/ser/value_ser.rs
+++ b/src/mat/ser/value_ser.rs
@@ -255,64 +255,82 @@ impl SerializeTupleStruct for SeqSer {
     }
 }
 
-/// Decide what a finished sequence of elements means: 1-D numeric vec,
-/// 2-D numeric matrix, complex vec/matrix, or reject (heterogeneous/unsupported).
+/// Decide what a finished sequence of elements means. A sequence whose
+/// elements all share the same numeric shape (scalars of one tag, vectors of
+/// one tag and length, complex of one width) collapses to a numeric vec/matrix
+/// or complex vec/matrix. Anything else (mixed tags, ragged inner vectors,
+/// sequences of structs, sequences containing `None`) lowers to a MATLAB cell
+/// array; the emitter interns each element under `#refs#`.
 fn unify_sequence(elements: Vec<MatValue>) -> Result<MatValue, MatError> {
     if elements.is_empty() {
         // Unknown element type; default to an empty f64 array.
         return Ok(MatValue::Vec1D(NumVec::F64(Vec::new())));
     }
 
-    // ----- all elements are numeric scalars -----
-    if elements.iter().all(|e| matches!(e, MatValue::Scalar(_))) {
-        let first_tag = match &elements[0] {
-            MatValue::Scalar(s) => s.tag(),
-            _ => unreachable!(),
-        };
-        let mut vec = NumVec::empty_with_tag(first_tag);
-        for e in elements {
-            let MatValue::Scalar(s) = e else { unreachable!() };
-            vec.push(s)?;
-        }
-        return Ok(MatValue::Vec1D(vec));
-    }
+    let elements = match try_unify_homogeneous(elements) {
+        Ok(unified) => return Ok(unified),
+        Err(elements) => elements,
+    };
 
-    // ----- all elements are 1-D vectors of the same numeric tag & length → Matrix -----
-    if elements
-        .iter()
-        .all(|e| matches!(e, MatValue::Vec1D(_)))
-    {
-        let (first_tag, first_len) = match &elements[0] {
-            MatValue::Vec1D(v) => (v.tag(), v.len()),
-            _ => unreachable!(),
-        };
-        for e in &elements {
-            match e {
-                MatValue::Vec1D(v) if v.tag() == first_tag && v.len() == first_len => {}
-                MatValue::Vec1D(v) if v.len() != first_len => {
-                    return Err(MatError::RaggedMatrix {
-                        expected: first_len,
-                        got: v.len(),
-                    });
-                }
-                _ => return Err(MatError::MixedSequenceElementTypes),
+    // Heterogeneous: lower to a cell array, mapping `Omit` to `struct([])`.
+    let cell_elements: Vec<MatValue> = elements
+        .into_iter()
+        .map(|e| match e {
+            MatValue::Omit => MatValue::EmptyStructArray,
+            other => other,
+        })
+        .collect();
+    Ok(MatValue::Cell(cell_elements))
+}
+
+/// Try the homogeneous fast paths. Returns the original `Vec` back via
+/// `Err(_)` when no path matches, so the cell-array fallback can take
+/// ownership without re-cloning each element. (Cloning a `Vec1D` or
+/// `ComplexVec*` of the inner shape would double peak allocation on the
+/// matrix path for large `Vec<Vec<T>>` inputs.)
+fn try_unify_homogeneous(
+    elements: Vec<MatValue>,
+) -> Result<MatValue, Vec<MatValue>> {
+    debug_assert!(!elements.is_empty());
+
+    // ----- all elements are numeric scalars of the same tag → Vec1D -----
+    if let Some(MatValue::Scalar(first)) = elements.first() {
+        let first_tag = first.tag();
+        if elements
+            .iter()
+            .all(|e| matches!(e, MatValue::Scalar(s) if s.tag() == first_tag))
+        {
+            let mut vec = NumVec::empty_with_tag(first_tag);
+            for e in elements {
+                let MatValue::Scalar(s) = e else { unreachable!() };
+                vec.push(s).expect("tag check held");
             }
+            return Ok(MatValue::Vec1D(vec));
         }
-        let rows = elements.len();
-        let cols = first_len;
-        let mut flat = NumVec::empty_with_tag(first_tag);
-        for e in elements {
-            let MatValue::Vec1D(v) = e else { unreachable!() };
-            flat.extend(v)?;
-        }
-        return Ok(MatValue::Matrix {
-            rows,
-            cols,
-            vec: flat,
-        });
     }
 
-    // ----- all elements are complex scalars → Complex vec -----
+    // ----- all elements are Vec1D of same tag & length → Matrix -----
+    if let Some(MatValue::Vec1D(first)) = elements.first() {
+        let first_tag = first.tag();
+        let first_len = first.len();
+        if elements.iter().all(|e| {
+            matches!(e, MatValue::Vec1D(v) if v.tag() == first_tag && v.len() == first_len)
+        }) {
+            let rows = elements.len();
+            let mut flat = NumVec::empty_with_tag(first_tag);
+            for e in elements {
+                let MatValue::Vec1D(v) = e else { unreachable!() };
+                flat.extend(v).expect("tag check held");
+            }
+            return Ok(MatValue::Matrix {
+                rows,
+                cols: first_len,
+                vec: flat,
+            });
+        }
+    }
+
+    // ----- all complex scalars of one width → ComplexVec (f64 case) -----
     if elements
         .iter()
         .all(|e| matches!(e, MatValue::ComplexScalar64 { .. }))
@@ -326,6 +344,7 @@ fn unify_sequence(elements: Vec<MatValue>) -> Result<MatValue, MatError> {
             .collect();
         return Ok(MatValue::ComplexVec64(pairs));
     }
+    // ----- f32 complex-scalar variant of the above -----
     if elements
         .iter()
         .all(|e| matches!(e, MatValue::ComplexScalar32 { .. }))
@@ -340,55 +359,47 @@ fn unify_sequence(elements: Vec<MatValue>) -> Result<MatValue, MatError> {
         return Ok(MatValue::ComplexVec32(pairs));
     }
 
-    // ----- all elements are complex vecs of same length → Complex matrix -----
-    if elements.iter().all(|e| matches!(e, MatValue::ComplexVec64(_))) {
-        let first_len = match &elements[0] {
-            MatValue::ComplexVec64(v) => v.len(),
-            _ => unreachable!(),
-        };
-        let mut pairs: Vec<(f64, f64)> = Vec::new();
-        for e in &elements {
-            let MatValue::ComplexVec64(v) = e else { unreachable!() };
-            if v.len() != first_len {
-                return Err(MatError::RaggedMatrix {
-                    expected: first_len,
-                    got: v.len(),
-                });
+    // ----- all elements are ComplexVec of same length → ComplexMatrix -----
+    if let Some(MatValue::ComplexVec64(first)) = elements.first() {
+        let first_len = first.len();
+        if elements
+            .iter()
+            .all(|e| matches!(e, MatValue::ComplexVec64(v) if v.len() == first_len))
+        {
+            let rows = elements.len();
+            let mut pairs: Vec<(f64, f64)> = Vec::with_capacity(rows * first_len);
+            for e in elements {
+                let MatValue::ComplexVec64(v) = e else { unreachable!() };
+                pairs.extend(v);
             }
-            pairs.extend_from_slice(v);
+            return Ok(MatValue::ComplexMatrix64 {
+                rows,
+                cols: first_len,
+                pairs,
+            });
         }
-        return Ok(MatValue::ComplexMatrix64 {
-            rows: elements.len(),
-            cols: first_len,
-            pairs,
-        });
     }
-    if elements.iter().all(|e| matches!(e, MatValue::ComplexVec32(_))) {
-        let first_len = match &elements[0] {
-            MatValue::ComplexVec32(v) => v.len(),
-            _ => unreachable!(),
-        };
-        let mut pairs: Vec<(f32, f32)> = Vec::new();
-        for e in &elements {
-            let MatValue::ComplexVec32(v) = e else { unreachable!() };
-            if v.len() != first_len {
-                return Err(MatError::RaggedMatrix {
-                    expected: first_len,
-                    got: v.len(),
-                });
+    if let Some(MatValue::ComplexVec32(first)) = elements.first() {
+        let first_len = first.len();
+        if elements
+            .iter()
+            .all(|e| matches!(e, MatValue::ComplexVec32(v) if v.len() == first_len))
+        {
+            let rows = elements.len();
+            let mut pairs: Vec<(f32, f32)> = Vec::with_capacity(rows * first_len);
+            for e in elements {
+                let MatValue::ComplexVec32(v) = e else { unreachable!() };
+                pairs.extend(v);
             }
-            pairs.extend_from_slice(v);
+            return Ok(MatValue::ComplexMatrix32 {
+                rows,
+                cols: first_len,
+                pairs,
+            });
         }
-        return Ok(MatValue::ComplexMatrix32 {
-            rows: elements.len(),
-            cols: first_len,
-            pairs,
-        });
     }
 
-    Err(MatError::UnsupportedType(
-        "heterogeneous sequence — MAT v7.3 cell arrays not supported in this release",
-    ))
+    Err(elements)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/mat/value.rs
+++ b/src/mat/value.rs
@@ -194,8 +194,19 @@ pub(crate) enum MatValue {
         cols: usize,
         pairs: Vec<(f32, f32)>,
     },
-    /// Ordered, named fields — serialized as a MATLAB struct group.
+    /// Ordered, named fields. Serialized as a MATLAB struct group.
     Struct(Vec<(String, MatValue)>),
+    /// Heterogeneous sequence (`MATLAB_class = "cell"`). Each element is
+    /// interned under `#refs#` and the parent dataset stores object
+    /// references in element order. The IR carries no shape: the writer
+    /// always emits a column-vector layout (`[n, 1]` MATLAB shape, `[1, n]`
+    /// HDF5 shape), and the deserializer flattens to a 1-D sequence. If
+    /// multi-dim cells ever ship, add a `dims` field then.
+    Cell(Vec<MatValue>),
+    /// Empty struct array placeholder for `None` inside a sequence. Renders
+    /// as MATLAB's `struct([])` (a `[0, 0]` empty marker with
+    /// `MATLAB_class="struct"` and `MATLAB_empty=1`).
+    EmptyStructArray,
 }
 
 impl MatValue {
@@ -215,6 +226,8 @@ impl MatValue {
                 "complex matrix"
             }
             MatValue::Struct(_) => "struct",
+            MatValue::Cell(_) => "cell array",
+            MatValue::EmptyStructArray => "empty struct array",
         }
     }
 }

--- a/tests/cell_array.rs
+++ b/tests/cell_array.rs
@@ -1,0 +1,357 @@
+#![cfg(feature = "serde")]
+//! Cell-array serialization for sequences that don't fit a numeric matrix.
+//!
+//! `Vec<MyStruct>`, `Vec<Option<T>>` with `None` interspersed, and
+//! `Vec<Vec<MyStruct>>` all serialize as MATLAB cell arrays. Each element is
+//! interned under the conventional `#refs#` group; the parent dataset stores
+//! object references. `None` becomes `struct([])` (an empty struct array)
+//! so every cell slot has a well-defined MATLAB type.
+
+use hdf5_pure::mat;
+use serde::{Deserialize, Serialize};
+use tempfile::tempdir;
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+struct Point {
+    x: f64,
+    y: f64,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct PathRoot {
+    path: Vec<Point>,
+}
+
+#[test]
+fn vec_of_struct_writes_cell_array_with_refs_group() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("path.mat");
+
+    let root = PathRoot {
+        path: vec![
+            Point { x: 0.0, y: 0.0 },
+            Point { x: 1.0, y: 2.0 },
+            Point { x: 3.0, y: 4.0 },
+        ],
+    };
+    mat::to_file(&root, &path).unwrap();
+
+    let file = hdf5::File::open(&path).unwrap();
+
+    // Parent dataset has MATLAB_class="cell" and shape [1, 3] (column-major
+    // storage of the column vector [3, 1] MATLAB shape).
+    let cell = file.dataset("path").unwrap();
+    assert_eq!(cell.shape(), vec![1, 3]);
+    let cls = cell
+        .attr("MATLAB_class")
+        .unwrap()
+        .read_scalar::<hdf5::types::FixedAscii<32>>()
+        .unwrap();
+    assert_eq!(cls.as_str(), "cell");
+
+    // The hidden #refs# group exists and holds three children, one per
+    // element. Each child is a struct group with MATLAB_class="struct" and
+    // the field names from `Point`.
+    let refs = file.group("#refs#").unwrap();
+    let names = refs.member_names().unwrap();
+    assert_eq!(names.len(), 3, "expected one ref per cell element");
+
+    for ref_name in &names {
+        let g = refs.group(ref_name).unwrap();
+        let cls = g
+            .attr("MATLAB_class")
+            .unwrap()
+            .read_scalar::<hdf5::types::FixedAscii<32>>()
+            .unwrap();
+        assert_eq!(cls.as_str(), "struct");
+        // Two fields, "x" and "y", both length-1 doubles.
+        let x = g.dataset("x").unwrap();
+        assert_eq!(x.shape(), vec![1, 1]);
+        let y = g.dataset("y").unwrap();
+        assert_eq!(y.shape(), vec![1, 1]);
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct OptionalSeq {
+    items: Vec<Option<Point>>,
+}
+
+#[test]
+fn vec_of_option_with_none_uses_empty_struct_marker() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("optional.mat");
+
+    let root = OptionalSeq {
+        items: vec![
+            Some(Point { x: 1.0, y: 2.0 }),
+            None,
+            Some(Point { x: 3.0, y: 4.0 }),
+        ],
+    };
+    mat::to_file(&root, &path).unwrap();
+
+    let file = hdf5::File::open(&path).unwrap();
+
+    let cell = file.dataset("items").unwrap();
+    assert_eq!(cell.shape(), vec![1, 3]);
+    let cls = cell
+        .attr("MATLAB_class")
+        .unwrap()
+        .read_scalar::<hdf5::types::FixedAscii<32>>()
+        .unwrap();
+    assert_eq!(cls.as_str(), "cell");
+
+    let refs = file.group("#refs#").unwrap();
+    let names = refs.member_names().unwrap();
+    assert_eq!(names.len(), 3);
+
+    // Exactly one of the three refs is the empty-struct marker for `None`.
+    let mut empty_struct_count = 0;
+    for ref_name in &names {
+        // Try as group first (Some(struct)); fall back to dataset (None marker).
+        if let Ok(g) = refs.group(ref_name) {
+            let cls = g
+                .attr("MATLAB_class")
+                .unwrap()
+                .read_scalar::<hdf5::types::FixedAscii<32>>()
+                .unwrap();
+            assert_eq!(cls.as_str(), "struct");
+            assert!(g.dataset("x").is_ok());
+        } else {
+            let ds = refs.dataset(ref_name).unwrap();
+            let cls = ds
+                .attr("MATLAB_class")
+                .unwrap()
+                .read_scalar::<hdf5::types::FixedAscii<32>>()
+                .unwrap();
+            assert_eq!(cls.as_str(), "struct");
+            let empty = ds.attr("MATLAB_empty").unwrap().read_scalar::<u32>().unwrap();
+            assert_eq!(empty, 1);
+            empty_struct_count += 1;
+        }
+    }
+    assert_eq!(empty_struct_count, 1, "expected one struct([]) marker");
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct NestedSeq {
+    rows: Vec<Vec<Option<Point>>>,
+}
+
+#[test]
+fn nested_vec_of_vec_produces_cell_of_cells() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("nested.mat");
+
+    // Mimic the soul-rs `rx_data: Vec<Vec<Option<RxData>>>` shape.
+    let root = NestedSeq {
+        rows: vec![
+            vec![Some(Point { x: 1.0, y: 1.0 }), None],
+            vec![None, Some(Point { x: 2.0, y: 2.0 })],
+        ],
+    };
+    mat::to_file(&root, &path).unwrap();
+
+    let file = hdf5::File::open(&path).unwrap();
+
+    // Outer cell array: [1, 2] storage shape for a [2, 1] MATLAB column vector.
+    let outer = file.dataset("rows").unwrap();
+    assert_eq!(outer.shape(), vec![1, 2]);
+    let cls = outer
+        .attr("MATLAB_class")
+        .unwrap()
+        .read_scalar::<hdf5::types::FixedAscii<32>>()
+        .unwrap();
+    assert_eq!(cls.as_str(), "cell");
+
+    // #refs# holds: 2 outer entries (each itself a cell) + 4 inner entries
+    // (2 structs + 2 empty markers) = 6 total.
+    let refs = file.group("#refs#").unwrap();
+    let names = refs.member_names().unwrap();
+    assert_eq!(names.len(), 6, "2 outer cells + 4 inner elements");
+
+    let mut outer_cell_count = 0;
+    let mut inner_struct_count = 0;
+    let mut empty_struct_count = 0;
+    for ref_name in &names {
+        if let Ok(g) = refs.group(ref_name) {
+            assert_eq!(
+                g.attr("MATLAB_class")
+                    .unwrap()
+                    .read_scalar::<hdf5::types::FixedAscii<32>>()
+                    .unwrap()
+                    .as_str(),
+                "struct"
+            );
+            inner_struct_count += 1;
+        } else {
+            let ds = refs.dataset(ref_name).unwrap();
+            let cls = ds
+                .attr("MATLAB_class")
+                .unwrap()
+                .read_scalar::<hdf5::types::FixedAscii<32>>()
+                .unwrap();
+            match cls.as_str() {
+                "cell" => outer_cell_count += 1,
+                "struct" => empty_struct_count += 1,
+                other => panic!("unexpected class in #refs#: {other}"),
+            }
+        }
+    }
+    assert_eq!(outer_cell_count, 2);
+    assert_eq!(inner_struct_count, 2);
+    assert_eq!(empty_struct_count, 2);
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct RaggedRoot {
+    rows: Vec<Vec<f64>>,
+}
+
+#[test]
+fn ragged_vec_of_vec_falls_back_to_cell() {
+    // Same-length inner vecs unify into a numeric matrix; ragged vecs go to
+    // cell so we don't lose data.
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("ragged.mat");
+
+    let root = RaggedRoot {
+        rows: vec![vec![1.0, 2.0, 3.0], vec![4.0, 5.0]],
+    };
+    mat::to_file(&root, &path).unwrap();
+
+    let file = hdf5::File::open(&path).unwrap();
+
+    let cell = file.dataset("rows").unwrap();
+    let cls = cell
+        .attr("MATLAB_class")
+        .unwrap()
+        .read_scalar::<hdf5::types::FixedAscii<32>>()
+        .unwrap();
+    assert_eq!(cls.as_str(), "cell");
+    assert_eq!(cell.shape(), vec![1, 2]);
+
+    let refs = file.group("#refs#").unwrap();
+    let names = refs.member_names().unwrap();
+    assert_eq!(names.len(), 2);
+}
+
+#[test]
+fn empty_vec_of_struct_serializes_as_empty_double() {
+    // `Vec<MyStruct>` with zero elements has unknown element type at the
+    // serializer level (no `Some(_)` ever fired), so it falls into the
+    // "empty sequence" branch which still picks the f64 default. This is
+    // existing behavior; the test pins it.
+    #[derive(Serialize)]
+    struct Root {
+        items: Vec<Point>,
+    }
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("empty.mat");
+    mat::to_file(&Root { items: Vec::new() }, &path).unwrap();
+    let file = hdf5::File::open(&path).unwrap();
+    let ds = file.dataset("items").unwrap();
+    let cls = ds
+        .attr("MATLAB_class")
+        .unwrap()
+        .read_scalar::<hdf5::types::FixedAscii<32>>()
+        .unwrap();
+    assert_eq!(cls.as_str(), "double");
+}
+
+/// Cell-array reading is not yet supported on the deserializer side: the
+/// reader emits `UnsupportedType("cell array")` for any dataset with
+/// `MATLAB_class="cell"`. The writer-side tests above pin the on-disk
+/// shape; full read parity (resolving `#refs#` paths back into element
+/// `MatValue`s) is a separate follow-up.
+#[test]
+fn from_file_on_cell_array_currently_errors() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("roundtrip_cell.mat");
+
+    let original = PathRoot {
+        path: vec![Point { x: 10.0, y: 20.0 }, Point { x: 30.0, y: 40.0 }],
+    };
+    mat::to_file(&original, &path).unwrap();
+
+    let result: Result<PathRoot, _> = mat::from_file(&path);
+    assert!(result.is_err(), "cell-array deserialization not yet implemented");
+}
+
+#[test]
+fn c_library_can_open_cell_array_file() {
+    // Sanity-check that the cell-array file is valid HDF5: the reference
+    // C library opens it, sees the cell dataset and the #refs# group, and
+    // can follow the references back to the element data.
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("c_check.mat");
+
+    mat::to_file(
+        &PathRoot {
+            path: vec![Point { x: 1.0, y: 2.0 }, Point { x: 3.0, y: 4.0 }],
+        },
+        &path,
+    )
+    .unwrap();
+
+    let file = hdf5::File::open(&path).unwrap();
+    assert!(file.dataset("path").is_ok());
+    let refs = file.group("#refs#").unwrap();
+    let names = refs.member_names().unwrap();
+    assert_eq!(names.len(), 2);
+    // Each ref entry is a struct group with x and y datasets.
+    for name in &names {
+        let g = refs.group(name).unwrap();
+        let x = g.dataset("x").unwrap().read_raw::<f64>().unwrap();
+        let y = g.dataset("y").unwrap().read_raw::<f64>().unwrap();
+        assert_eq!(x.len(), 1);
+        assert_eq!(y.len(), 1);
+    }
+}
+
+#[test]
+fn cell_references_resolve_in_element_order() {
+    // Pin the writer's invariant that the i-th object reference in the cell
+    // dataset dereferences to the i-th input element. A bug where the
+    // RefsAccumulator queued out of order, or where with_path_references
+    // reordered, would surface here.
+    use hdf5::{ObjectReference1, ReferencedObject};
+
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("ordered.mat");
+
+    let inputs = vec![
+        Point { x: 10.0, y: -10.0 },
+        Point { x: 20.0, y: -20.0 },
+        Point { x: 30.0, y: -30.0 },
+        Point { x: 40.0, y: -40.0 },
+    ];
+    mat::to_file(
+        &PathRoot {
+            path: inputs.clone(),
+        },
+        &path,
+    )
+    .unwrap();
+
+    let file = hdf5::File::open(&path).unwrap();
+    let cell = file.dataset("path").unwrap();
+    let refs: Vec<ObjectReference1> = cell.read_raw().unwrap();
+    assert_eq!(refs.len(), inputs.len());
+
+    for (i, r) in refs.iter().enumerate() {
+        let target = file.dereference(r).unwrap();
+        let g = match target {
+            ReferencedObject::Group(g) => g,
+            other => panic!("ref {i} dereferenced to non-group: {other:?}"),
+        };
+        let x: Vec<f64> = g.dataset("x").unwrap().read_raw().unwrap();
+        let y: Vec<f64> = g.dataset("y").unwrap().read_raw().unwrap();
+        assert_eq!(
+            (x[0], y[0]),
+            (inputs[i].x, inputs[i].y),
+            "cell slot {i} should resolve to input element {i}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Sequences that don't unify into a numeric/complex matrix (e.g. `Vec<MyStruct>`, `Vec<Option<T>>` with `None` interspersed, ragged `Vec<Vec<T>>`, mixed numeric tags) now lower to a MATLAB cell array. Each element is interned under the conventional `#refs#` group; the parent dataset stores object references with `MATLAB_class = "cell"`. `Option::None` inside a sequence becomes `struct([])` so every cell slot has a defined MATLAB type.
- Cases that previously errored with `MatError::RaggedMatrix` or `MatError::MixedSequenceElementTypes` now succeed via this fallback. Both error variants remain on `MatError` to preserve the public API surface, but they're unreachable from `unify_sequence`.
- Reader-side support for cell-class datasets is **not** included; the reader still errors with `UnsupportedType("cell array")`. The deserializer's `dispatch_any` / `deserialize_seq` / `deserialize_option` arms handle `Cell` and `EmptyStructArray` so the new variants are exhaustive and ready for a follow-up reader PR.

## Encoding details

- Cell parent dataset: shape `[1, n]` HDF5 storage of a MATLAB `[n, 1]` column vector, attribute `MATLAB_class = "cell"`, payload is a vector of object references resolved against `#refs#/ref_{id:016x}`.
- Empty struct marker: `[0, 0]` shape, empty `u64` payload, attributes `MATLAB_class = "struct"` + `MATLAB_empty = 1` (matches the convention used elsewhere in the writer).
- `RefsAccumulator` queues elements as cells emit. Drained at file-build time into a single `#refs#` group. Nested cells push more entries during the drain; loop terminates when the queue is empty.

## Reader compatibility

Verified with libmatio's `matdump` against the new `cells.mat` fixture:

```
points     3x1   1.4K  mxCELL_CLASS
optionals  3x1   1.0K  mxCELL_CLASS
grid       2x1   1.4K  mxCELL_CLASS
ragged     2x1   264B  mxCELL_CLASS
```

`matdump -d` walks each cell and shows `Structure { Fields[2] }` for populated slots, `Rank: 0` for `None` placeholders, and the nested cell-of-cell shape for `grid`. Reads cleanly in MATLAB, libmatio, Julia's `MAT.jl`, and Python via `pymatreader` / `hdf5storage`. GNU Octave 11's v7.3 `load` does not yet follow object references and warns "unknown datatype"; the verify script skips the cells block on Octave with a clear message pointing at the working readers.

## Tests

- New `tests/cell_array.rs` (8 tests) covers: writer-side shape for `Vec<Struct>`, `Vec<Option<T>>` with the `struct([])` marker for `None`, nested `Vec<Vec<Option<T>>>`, ragged `Vec<Vec<f64>>`, empty `Vec` fallback, `MATLAB_class="cell"` attribute, libhdf5 C-library round-trip, and an order-pinning test using `hdf5::ObjectReference1` + `File::dereference` to confirm slot `i` resolves to input element `i`.
- `from_file_on_cell_array_currently_errors` pins the reader-deferred limitation.
- Full suite: 504 passed, 0 failed (`cargo test --features serde`).

## Test plan

- [ ] `cargo test --features serde` — full suite green.
- [ ] `cargo run --example matlab_fixtures --features serde` then `cd matlab_fixtures && octave --no-gui --eval verify` — all existing fixtures pass; cells.mat block reports "skipped" on Octave with the limitation note.
- [ ] `matdump -f whos matlab_fixtures/cells.mat` — confirms `mxCELL_CLASS` shapes for each variable.
- [ ] `cargo doc --features serde --no-deps` — README and `mat` module docs render cleanly with the new data-model rows and "Cell arrays" subsection.