### PR TITLE
Bump to 0.3.0 for cell-array writer support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "hdf5-pure"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "byteorder",
  "crc32fast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdf5-pure"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 license = "MIT"
 description = "Pure-Rust HDF5 writer library (WASM-compatible, no C dependencies)"


### PR DESCRIPTION
## Summary

- Bump `Cargo.toml` from `0.2.0` to `0.3.0` and refresh `Cargo.lock`.
- Minor bump for the cell-array writer support added in #5: heterogeneous sequences, `Vec<Option<T>>` with `struct([])` markers, and ragged `Vec<Vec<T>>` now succeed where they previously errored.

## Test plan

- [ ] `cargo build --features serde` — clean build at 0.3.0.
- [ ] `cargo test --features serde` — full suite green (504 tests).
- [ ] `cargo publish --dry-run --features serde` — packaging succeeds, ready for `cargo publish`.