### PR TITLE
Fix chunk-cache aliasing across datasets (#4)

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -27,7 +27,6 @@ use crate::types::{attrs_to_map, classify_datatype, AttrValue, DType};
 pub struct File {
     data: Vec<u8>,
     superblock: Superblock,
-    chunk_cache: ChunkCache,
     /// Byte offset to add to all relative addresses (= original base_address).
     addr_offset: u64,
 }
@@ -49,7 +48,6 @@ impl File {
         Ok(Self {
             data,
             superblock,
-            chunk_cache: ChunkCache::new(),
             addr_offset,
         })
     }
@@ -73,6 +71,7 @@ impl File {
         Ok(Dataset {
             file: self,
             header: hdr,
+            chunk_cache: ChunkCache::new(),
         })
     }
 
@@ -192,6 +191,7 @@ impl<'f> Group<'f> {
         Ok(Dataset {
             file: self.file,
             header: hdr,
+            chunk_cache: ChunkCache::new(),
         })
     }
 
@@ -228,10 +228,20 @@ impl<'f> Group<'f> {
 // ---------------------------------------------------------------------------
 
 /// A lightweight handle to an HDF5 dataset.
-#[derive(Debug)]
 pub struct Dataset<'f> {
     file: &'f File,
     header: ObjectHeader,
+    // Held per-dataset: the chunk index is keyed only by chunk coordinate, so
+    // a file-level cache would alias chunk addresses across datasets.
+    chunk_cache: ChunkCache,
+}
+
+impl<'f> std::fmt::Debug for Dataset<'f> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Dataset")
+            .field("messages", &self.header.messages.len())
+            .finish()
+    }
 }
 
 impl<'f> Dataset<'f> {
@@ -390,7 +400,7 @@ impl<'f> Dataset<'f> {
             pipeline.as_ref(),
             self.file.offset_size(),
             self.file.length_size(),
-            &self.file.chunk_cache,
+            &self.chunk_cache,
         )?)
     }
 }

--- a/tests/csr_multi_dataset.rs
+++ b/tests/csr_multi_dataset.rs
@@ -1,0 +1,73 @@
+//! Regression test for issue #4: reading multiple chunked datasets in the
+//! same file (e.g. an h5ad CSR triple `X/data`, `X/indices`, `X/indptr`)
+//! returned wrong values for every dataset after the first because the
+//! file-level chunk-cache index was keyed by chunk coordinate only.
+
+use hdf5_pure::{File, FileBuilder};
+
+#[test]
+fn csr_triple_chunked_read() {
+    let mut builder = FileBuilder::new();
+    let mut grp = builder.create_group("X");
+
+    let data: Vec<f32> = (0..200).map(|i| i as f32 * 0.5).collect();
+    let indices: Vec<i32> = (0..200).map(|i| i + 1000).collect();
+    let indptr: Vec<i32> = (0..50).map(|i| i * 4).collect();
+
+    grp.create_dataset("data")
+        .with_f32_data(&data)
+        .with_chunks(&[64]);
+    grp.create_dataset("indices")
+        .with_i32_data(&indices)
+        .with_chunks(&[64]);
+    grp.create_dataset("indptr")
+        .with_i32_data(&indptr)
+        .with_chunks(&[16]);
+    builder.add_group(grp.finish());
+
+    let bytes = builder.finish().unwrap();
+    let file = File::from_bytes(bytes).unwrap();
+
+    let read_data = file.dataset("X/data").unwrap().read_f32().unwrap();
+    let read_indices = file.dataset("X/indices").unwrap().read_i32().unwrap();
+    let read_indptr = file.dataset("X/indptr").unwrap().read_i32().unwrap();
+
+    assert_eq!(read_data, data, "X/data mismatch");
+    assert_eq!(read_indices, indices, "X/indices mismatch (first regression)");
+    assert_eq!(read_indptr, indptr, "X/indptr mismatch (second regression)");
+}
+
+#[test]
+fn csr_triple_compressed_chunked_read() {
+    let mut builder = FileBuilder::new();
+    let mut grp = builder.create_group("X");
+
+    let data: Vec<f32> = (0..200).map(|i| i as f32 * 0.25).collect();
+    let indices: Vec<i32> = (0..200).map(|i| i + 5000).collect();
+    let indptr: Vec<i32> = (0..50).map(|i| i * 4).collect();
+
+    grp.create_dataset("data")
+        .with_f32_data(&data)
+        .with_chunks(&[64])
+        .with_deflate(4);
+    grp.create_dataset("indices")
+        .with_i32_data(&indices)
+        .with_chunks(&[64])
+        .with_deflate(4);
+    grp.create_dataset("indptr")
+        .with_i32_data(&indptr)
+        .with_chunks(&[16])
+        .with_deflate(4);
+    builder.add_group(grp.finish());
+
+    let bytes = builder.finish().unwrap();
+    let file = File::from_bytes(bytes).unwrap();
+
+    let read_data = file.dataset("X/data").unwrap().read_f32().unwrap();
+    let read_indices = file.dataset("X/indices").unwrap().read_i32().unwrap();
+    let read_indptr = file.dataset("X/indptr").unwrap().read_i32().unwrap();
+
+    assert_eq!(read_data, data);
+    assert_eq!(read_indices, indices);
+    assert_eq!(read_indptr, indptr);
+}


### PR DESCRIPTION
## Summary

Fixes #4. The `ChunkCache` lived on `File` but its chunk index is keyed only by chunk coordinate, so once one chunked dataset populated the index, every subsequent chunked dataset in the same file short-circuited the index build and reused the first dataset's chunk addresses. Reads after the first returned bytes from the wrong dataset's data region.

For the reporter's h5ad CSR triple this presented as: `X/data` (f32, chunked) read correctly; `X/indices` and `X/indptr` (i32, chunked) returned the f32 byte pattern of `X/data` reinterpreted as i32.

## Fix

Move `ChunkCache` from `File` to `Dataset`. Each `Dataset` handle now owns its index and decompressed-LRU. Repeated reads through the same handle still cache; reads of different datasets no longer alias.

## Test plan

- [x] New `tests/csr_multi_dataset.rs` reproduces the h5ad CSR layout (uncompressed and deflated). Both tests fail on `main` and pass with this change.
- [x] `cargo test --all-features` — 423 lib tests + integration suites all pass.
- [x] `cargo check --no-default-features --features checksum` clean (reader is std-only, unchanged).