### PR TITLE
Add MatBuilder mid-level writer API for MAT v7.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "hdf5-pure"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "byteorder",
  "crc32fast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdf5-pure"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 license = "MIT"
 description = "Pure-Rust HDF5 writer library (WASM-compatible, no C dependencies)"

--- a/examples/matlab_fixtures.rs
+++ b/examples/matlab_fixtures.rs
@@ -715,8 +715,8 @@ struct CellsRoot {
     /// `Vec<Option<Struct>>` with `None` interspersed: the `None` slot becomes
     /// `struct([])` (an empty struct array).
     optionals: Vec<Option<Point>>,
-    /// `Vec<Vec<Option<Struct>>>` matches the soul-rs `rx_data` shape: an
-    /// outer cell whose elements are themselves cells.
+    /// `Vec<Vec<Option<Struct>>>`: an outer cell whose elements are themselves
+    /// cells, with `None` slots becoming `struct([])` markers.
     grid: Vec<Vec<Option<Point>>>,
     /// Ragged `Vec<Vec<f64>>` falls back to a cell of doubles instead of
     /// erroring on the non-uniform inner lengths.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ pub mod types;
 #[cfg(feature = "std")]
 pub mod writer;
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "std")]
 pub mod mat;
 
 // ---------------------------------------------------------------------------

--- a/src/mat/builder.rs
+++ b/src/mat/builder.rs
@@ -1,0 +1,1562 @@
+//! Mid-level builder API for MAT v7.3 files.
+//!
+//! [`MatBuilder`] wraps [`crate::FileBuilder`] and applies MATLAB conventions:
+//! `MATLAB_class` attributes, `MATLAB_int_decode` flags, `MATLAB_empty`
+//! markers, the lazy `#refs#` group for object references, and the
+//! `#subsystem#/MCOS` opaque-class subsystem for `string` objects.
+//!
+//! Callers hand in MATLAB-shape `dims` (e.g. `[N, 1]` for a column vector);
+//! the builder transposes to HDF5 storage shape internally. Numeric data is
+//! taken by `&[T]` so callers don't need to allocate per dataset.
+//!
+//! Nested structs and cells use closures so the borrow checker can keep the
+//! call tree straight:
+//!
+//! ```ignore
+//! let mut mb = MatBuilder::new(Options::default());
+//! mb.struct_("payload", |s| {
+//!     s.write_scalar_f64("answer", 42.0)?;
+//!     s.cell("entries", &[2, 1], |c| {
+//!         c.push_scalar_f64(1.0)?;
+//!         c.push_string("hi")?;
+//!         Ok(())
+//!     })?;
+//!     Ok(())
+//! })?;
+//! let bytes = mb.finish()?;
+//! ```
+//!
+//! The builder allocates exactly one `#refs#/ref_{id:016x}` per cell element
+//! and one per string-object saveobj payload; both groups are created lazily
+//! on first use. No intermediate value tree is allocated.
+
+use std::collections::HashSet;
+
+use crate::file_writer::AttrValue;
+use crate::mat::class::MatClass;
+use crate::mat::dims::{matrix_dims, storage_dims_u64_into, vector_dims, STORAGE_DIMS_BUF_LEN};
+use crate::mat::error::MatError;
+use crate::mat::identifier::{dedupe_name, is_valid_name, sanitize_name};
+use crate::mat::options::{
+    Compression, EmptyMarkerEncoding, InvalidNamePolicy, Options,
+};
+use crate::mat::string_object;
+use crate::mat::userblock::{self, USERBLOCK_SIZE};
+use crate::mat::utf16;
+use crate::type_builders::{DatasetBuilder, GroupBuilder};
+use crate::writer::FileBuilder;
+
+const REFS_GROUP: &str = "#refs#";
+const SUBSYSTEM_GROUP: &str = "#subsystem#";
+
+/// Top-level MAT v7.3 writer.
+pub struct MatBuilder {
+    file: FileBuilder,
+    options: Options,
+    /// Lazy `#refs#` group, created on first use.
+    refs: Option<GroupBuilder>,
+    /// Monotonic counter for `ref_{id:016x}` names.
+    next_ref_id: u64,
+    /// Saveobj payload paths registered by `write_string_object`. Each entry
+    /// becomes one MCOS reference.
+    string_object_payload_paths: Vec<String>,
+    /// Names already used at the file root.
+    root_used_names: HashSet<String>,
+    /// Stack of open struct groups. The deepest is the current write target
+    /// when [`next_target`] is `None`.
+    open_structs: Vec<OpenStruct>,
+    /// Single-use override for the next `write_*` / `struct_` / `cell` call.
+    /// Set by [`CellWriter`] before pushing a cell element; consumed by the
+    /// next write to redirect the dataset/group into `#refs#`.
+    next_target: Option<NextTarget>,
+}
+
+struct OpenStruct {
+    group: GroupBuilder,
+    used_names: HashSet<String>,
+    fields: Vec<String>,
+    parent: ParentKind,
+}
+
+enum ParentKind {
+    /// Closing this struct attaches the finished group to the file root.
+    Root,
+    /// Closing this struct attaches the finished group to the open-struct at
+    /// the given index of `open_structs` (after this one is popped).
+    StructAt(usize),
+    /// Closing this struct attaches the finished group to the `#refs#` group
+    /// (using the group's own name, which is `ref_NNNN`).
+    Refs,
+}
+
+/// Single-use override consumed by the next write/open.
+struct NextTarget {
+    /// The ref name (e.g. `"ref_0000000000000000"`). The dataset/group will
+    /// be placed in `#refs#` with this name.
+    ref_name: String,
+}
+
+impl MatBuilder {
+    /// Construct a new MAT writer.
+    pub fn new(options: Options) -> Self {
+        let mut file = FileBuilder::new();
+        file.with_userblock(USERBLOCK_SIZE);
+        Self {
+            file,
+            options,
+            refs: None,
+            next_ref_id: 0,
+            string_object_payload_paths: Vec::new(),
+            root_used_names: HashSet::new(),
+            open_structs: Vec::new(),
+            next_target: None,
+        }
+    }
+
+    /// Borrow the configured options.
+    pub fn options(&self) -> &Options {
+        &self.options
+    }
+
+    /// Allocate a fresh `ref_{:016x}` name. Does not write anything.
+    pub fn alloc_ref_name(&mut self) -> String {
+        let name = format!("ref_{:016x}", self.next_ref_id);
+        self.next_ref_id += 1;
+        name
+    }
+
+    /// Get-or-create the `#refs#` group on the underlying file.
+    fn refs_mut(&mut self) -> &mut GroupBuilder {
+        if self.refs.is_none() {
+            self.refs = Some(self.file.create_group(REFS_GROUP));
+        }
+        self.refs.as_mut().unwrap()
+    }
+
+    fn normalize_name(
+        raw: &str,
+        used: &mut HashSet<String>,
+        policy: InvalidNamePolicy,
+    ) -> Result<String, MatError> {
+        let candidate = match policy {
+            InvalidNamePolicy::Error => {
+                if !is_valid_name(raw) {
+                    return Err(MatError::Custom(format!("invalid MATLAB name: {raw}")));
+                }
+                raw.to_owned()
+            }
+            InvalidNamePolicy::Sanitize => sanitize_name(raw),
+        };
+        let unique = dedupe_name(candidate, used);
+        used.insert(unique.clone());
+        Ok(unique)
+    }
+
+    /// Resolve a name in the current write scope and return the (resolved
+    /// name, write target) pair to use for the next dataset/group.
+    fn resolve_target(&mut self, raw_name: &str) -> Result<TargetForName, MatError> {
+        if let Some(t) = self.next_target.take() {
+            // Cell-element / explicit-ref target. The user-supplied name is
+            // ignored; the ref name is fixed.
+            return Ok(TargetForName::Ref(t.ref_name));
+        }
+        if let Some(top) = self.open_structs.last_mut() {
+            let name = Self::normalize_name(
+                raw_name,
+                &mut top.used_names,
+                self.options.invalid_name_policy,
+            )?;
+            top.fields.push(name.clone());
+            return Ok(TargetForName::Struct {
+                name,
+                index: self.open_structs.len() - 1,
+            });
+        }
+        let name = Self::normalize_name(
+            raw_name,
+            &mut self.root_used_names,
+            self.options.invalid_name_policy,
+        )?;
+        Ok(TargetForName::Root(name))
+    }
+
+    /// Mutably borrow a `DatasetBuilder` at the resolved target.
+    fn dataset_at_target<'a>(&'a mut self, target: &'a TargetForName) -> &'a mut DatasetBuilder {
+        match target {
+            TargetForName::Root(name) => self.file.create_dataset(name),
+            TargetForName::Struct { name, index } => {
+                self.open_structs[*index].group.create_dataset(name)
+            }
+            TargetForName::Ref(ref_name) => self.refs_mut().create_dataset(ref_name),
+        }
+    }
+
+    // -- public scalar writes ---------------------------------------------
+
+    pub fn write_scalar_logical(&mut self, name: &str, value: bool) -> Result<&mut Self, MatError> {
+        let target = self.resolve_target(name)?;
+        let ds = self.dataset_at_target(&target);
+        ds.with_u8_data(&[u8::from(value)]).with_shape(&[1, 1]);
+        ds.set_attr(
+            "MATLAB_class",
+            AttrValue::AsciiString(MatClass::Logical.as_str().into()),
+        );
+        ds.set_attr("MATLAB_int_decode", AttrValue::I32(1));
+        Ok(self)
+    }
+
+    pub fn write_scalar_f64(&mut self, name: &str, value: f64) -> Result<&mut Self, MatError> {
+        self.write_scalar_inner(name, MatClass::Double, |ds| {
+            ds.with_f64_data(&[value]).with_shape(&[1, 1]);
+        })
+    }
+    pub fn write_scalar_f32(&mut self, name: &str, value: f32) -> Result<&mut Self, MatError> {
+        self.write_scalar_inner(name, MatClass::Single, |ds| {
+            ds.with_f32_data(&[value]).with_shape(&[1, 1]);
+        })
+    }
+    pub fn write_scalar_i8(&mut self, name: &str, value: i8) -> Result<&mut Self, MatError> {
+        self.write_scalar_inner(name, MatClass::Int8, |ds| {
+            ds.with_i8_data(&[value]).with_shape(&[1, 1]);
+        })
+    }
+    pub fn write_scalar_i16(&mut self, name: &str, value: i16) -> Result<&mut Self, MatError> {
+        self.write_scalar_inner(name, MatClass::Int16, |ds| {
+            ds.with_i16_data(&[value]).with_shape(&[1, 1]);
+        })
+    }
+    pub fn write_scalar_i32(&mut self, name: &str, value: i32) -> Result<&mut Self, MatError> {
+        self.write_scalar_inner(name, MatClass::Int32, |ds| {
+            ds.with_i32_data(&[value]).with_shape(&[1, 1]);
+        })
+    }
+    pub fn write_scalar_i64(&mut self, name: &str, value: i64) -> Result<&mut Self, MatError> {
+        self.write_scalar_inner(name, MatClass::Int64, |ds| {
+            ds.with_i64_data(&[value]).with_shape(&[1, 1]);
+        })
+    }
+    pub fn write_scalar_u8(&mut self, name: &str, value: u8) -> Result<&mut Self, MatError> {
+        self.write_scalar_inner(name, MatClass::UInt8, |ds| {
+            ds.with_u8_data(&[value]).with_shape(&[1, 1]);
+        })
+    }
+    pub fn write_scalar_u16(&mut self, name: &str, value: u16) -> Result<&mut Self, MatError> {
+        self.write_scalar_inner(name, MatClass::UInt16, |ds| {
+            ds.with_u16_data(&[value]).with_shape(&[1, 1]);
+        })
+    }
+    pub fn write_scalar_u32(&mut self, name: &str, value: u32) -> Result<&mut Self, MatError> {
+        self.write_scalar_inner(name, MatClass::UInt32, |ds| {
+            ds.with_u32_data(&[value]).with_shape(&[1, 1]);
+        })
+    }
+    pub fn write_scalar_u64(&mut self, name: &str, value: u64) -> Result<&mut Self, MatError> {
+        self.write_scalar_inner(name, MatClass::UInt64, |ds| {
+            ds.with_u64_data(&[value]).with_shape(&[1, 1]);
+        })
+    }
+
+    fn write_scalar_inner<F>(
+        &mut self,
+        name: &str,
+        class: MatClass,
+        apply: F,
+    ) -> Result<&mut Self, MatError>
+    where
+        F: FnOnce(&mut DatasetBuilder),
+    {
+        let target = self.resolve_target(name)?;
+        let ds = self.dataset_at_target(&target);
+        apply(ds);
+        ds.set_attr("MATLAB_class", AttrValue::AsciiString(class.as_str().into()));
+        Ok(self)
+    }
+
+    // -- numeric arrays ----------------------------------------------------
+
+    pub fn write_f64(
+        &mut self,
+        name: &str,
+        matlab_dims: &[usize],
+        data: &[f64],
+    ) -> Result<&mut Self, MatError> {
+        self.write_array_inner(name, MatClass::Double, matlab_dims, data.len(), |ds, shape| {
+            ds.with_f64_data(data).with_shape(shape);
+        })
+    }
+    pub fn write_f32(
+        &mut self,
+        name: &str,
+        matlab_dims: &[usize],
+        data: &[f32],
+    ) -> Result<&mut Self, MatError> {
+        self.write_array_inner(name, MatClass::Single, matlab_dims, data.len(), |ds, shape| {
+            ds.with_f32_data(data).with_shape(shape);
+        })
+    }
+    pub fn write_i8(
+        &mut self,
+        name: &str,
+        matlab_dims: &[usize],
+        data: &[i8],
+    ) -> Result<&mut Self, MatError> {
+        self.write_array_inner(name, MatClass::Int8, matlab_dims, data.len(), |ds, shape| {
+            ds.with_i8_data(data).with_shape(shape);
+        })
+    }
+    pub fn write_i16(
+        &mut self,
+        name: &str,
+        matlab_dims: &[usize],
+        data: &[i16],
+    ) -> Result<&mut Self, MatError> {
+        self.write_array_inner(name, MatClass::Int16, matlab_dims, data.len(), |ds, shape| {
+            ds.with_i16_data(data).with_shape(shape);
+        })
+    }
+    pub fn write_i32(
+        &mut self,
+        name: &str,
+        matlab_dims: &[usize],
+        data: &[i32],
+    ) -> Result<&mut Self, MatError> {
+        self.write_array_inner(name, MatClass::Int32, matlab_dims, data.len(), |ds, shape| {
+            ds.with_i32_data(data).with_shape(shape);
+        })
+    }
+    pub fn write_i64(
+        &mut self,
+        name: &str,
+        matlab_dims: &[usize],
+        data: &[i64],
+    ) -> Result<&mut Self, MatError> {
+        self.write_array_inner(name, MatClass::Int64, matlab_dims, data.len(), |ds, shape| {
+            ds.with_i64_data(data).with_shape(shape);
+        })
+    }
+    pub fn write_u8(
+        &mut self,
+        name: &str,
+        matlab_dims: &[usize],
+        data: &[u8],
+    ) -> Result<&mut Self, MatError> {
+        self.write_array_inner(name, MatClass::UInt8, matlab_dims, data.len(), |ds, shape| {
+            ds.with_u8_data(data).with_shape(shape);
+        })
+    }
+    pub fn write_u16(
+        &mut self,
+        name: &str,
+        matlab_dims: &[usize],
+        data: &[u16],
+    ) -> Result<&mut Self, MatError> {
+        self.write_array_inner(name, MatClass::UInt16, matlab_dims, data.len(), |ds, shape| {
+            ds.with_u16_data(data).with_shape(shape);
+        })
+    }
+    pub fn write_u32(
+        &mut self,
+        name: &str,
+        matlab_dims: &[usize],
+        data: &[u32],
+    ) -> Result<&mut Self, MatError> {
+        self.write_array_inner(name, MatClass::UInt32, matlab_dims, data.len(), |ds, shape| {
+            ds.with_u32_data(data).with_shape(shape);
+        })
+    }
+    pub fn write_u64(
+        &mut self,
+        name: &str,
+        matlab_dims: &[usize],
+        data: &[u64],
+    ) -> Result<&mut Self, MatError> {
+        self.write_array_inner(name, MatClass::UInt64, matlab_dims, data.len(), |ds, shape| {
+            ds.with_u64_data(data).with_shape(shape);
+        })
+    }
+
+    /// Write a logical array (MATLAB `logical`, stored as `uint8`).
+    pub fn write_logical(
+        &mut self,
+        name: &str,
+        matlab_dims: &[usize],
+        data: &[u8],
+    ) -> Result<&mut Self, MatError> {
+        if data.is_empty() {
+            return self.write_empty_with_decode(name, MatClass::Logical, matlab_dims, Some(1));
+        }
+        self.write_array_inner(name, MatClass::Logical, matlab_dims, data.len(), |ds, shape| {
+            ds.with_u8_data(data).with_shape(shape);
+            ds.set_attr("MATLAB_int_decode", AttrValue::I32(1));
+        })
+    }
+
+    /// Write a `char` UTF-16 string (MATLAB `char`). Uses `[N, 1]` MATLAB
+    /// shape (a row vector when read back, since HDF5 storage transposes).
+    pub fn write_char(&mut self, name: &str, value: &str) -> Result<&mut Self, MatError> {
+        let units = utf16::encode_utf16(value);
+        if units.is_empty() {
+            return self.write_empty_with_decode(name, MatClass::Char, &[0, 0], Some(2));
+        }
+        let n = units.len() as u64;
+        let target = self.resolve_target(name)?;
+        let ds = self.dataset_at_target(&target);
+        ds.with_u16_data(&units).with_shape(&[n, 1]);
+        ds.set_attr(
+            "MATLAB_class",
+            AttrValue::AsciiString(MatClass::Char.as_str().into()),
+        );
+        ds.set_attr("MATLAB_int_decode", AttrValue::I32(2));
+        Ok(self)
+    }
+
+    /// Write a complex `f64` array.
+    ///
+    /// Empty inputs produce a zero-element compound dataset (no
+    /// `MATLAB_empty` marker): MATLAB reads this back as an empty complex
+    /// array of the right class. Non-empty inputs honor the configured
+    /// compression settings.
+    pub fn write_complex_f64(
+        &mut self,
+        name: &str,
+        matlab_dims: &[usize],
+        data: &[(f64, f64)],
+    ) -> Result<&mut Self, MatError> {
+        let mut storage_buf = [0u64; STORAGE_DIMS_BUF_LEN];
+        let storage = storage_dims_u64_into(matlab_dims, &mut storage_buf);
+        let compression = self.options.compression;
+        let target = self.resolve_target(name)?;
+        let ds = self.dataset_at_target(&target);
+        ds.with_complex64_data(data).with_shape(storage);
+        ds.set_attr(
+            "MATLAB_class",
+            AttrValue::AsciiString(MatClass::Double.as_str().into()),
+        );
+        if !data.is_empty() {
+            apply_deflate(ds, compression);
+        }
+        Ok(self)
+    }
+
+    /// Write a complex `f32` array. See [`write_complex_f64`] for empty-input
+    /// and compression semantics.
+    pub fn write_complex_f32(
+        &mut self,
+        name: &str,
+        matlab_dims: &[usize],
+        data: &[(f32, f32)],
+    ) -> Result<&mut Self, MatError> {
+        let mut storage_buf = [0u64; STORAGE_DIMS_BUF_LEN];
+        let storage = storage_dims_u64_into(matlab_dims, &mut storage_buf);
+        let compression = self.options.compression;
+        let target = self.resolve_target(name)?;
+        let ds = self.dataset_at_target(&target);
+        ds.with_complex32_data(data).with_shape(storage);
+        ds.set_attr(
+            "MATLAB_class",
+            AttrValue::AsciiString(MatClass::Single.as_str().into()),
+        );
+        if !data.is_empty() {
+            apply_deflate(ds, compression);
+        }
+        Ok(self)
+    }
+
+    /// Write a MATLAB `string` object. Allocates a `#refs#` payload entry and
+    /// registers the object in the MCOS subsystem.
+    pub fn write_string_object(
+        &mut self,
+        name: &str,
+        values: &[String],
+        matlab_dims: &[usize],
+    ) -> Result<&mut Self, MatError> {
+        // 1. Encode payload, write to #refs# under a fresh ref.
+        let payload = string_object::encode_string_saveobj_payload(values, matlab_dims)?;
+        let payload_ref = self.alloc_ref_name();
+        let payload_path = format!("{REFS_GROUP}/{payload_ref}");
+        let payload_shape: [u64; 2] = [1, payload.len() as u64];
+        {
+            let refs = self.refs_mut();
+            let ds = refs.create_dataset(&payload_ref);
+            ds.with_u64_data(&payload).with_shape(&payload_shape);
+            ds.set_attr(
+                "MATLAB_class",
+                AttrValue::AsciiString(MatClass::UInt64.as_str().into()),
+            );
+        }
+
+        // 2. Register the payload path; the resulting object id is 1-based.
+        self.string_object_payload_paths.push(payload_path);
+        let object_id = self.string_object_payload_paths.len() as u32;
+
+        // 3. Emit the parent metadata dataset at the current scope.
+        let metadata = string_object::create_string_object_metadata(object_id);
+        let target = self.resolve_target(name)?;
+        let ds = self.dataset_at_target(&target);
+        ds.with_u32_data(&metadata).with_shape(&[1, metadata.len() as u64]);
+        ds.set_attr(
+            "MATLAB_class",
+            AttrValue::AsciiString(string_object::MATLAB_CLASS_STRING.into()),
+        );
+        ds.set_attr(
+            "MATLAB_object_decode",
+            AttrValue::I32(string_object::MATLAB_OBJECT_DECODE_OPAQUE),
+        );
+        Ok(self)
+    }
+
+    /// Write an empty marker for the given class. `matlab_dims` is the
+    /// MATLAB-shape (e.g. `[0, 0]`).
+    pub fn write_empty(
+        &mut self,
+        name: &str,
+        class: MatClass,
+        matlab_dims: &[usize],
+    ) -> Result<&mut Self, MatError> {
+        let int_decode = match class {
+            MatClass::Logical => Some(1),
+            MatClass::Char => Some(2),
+            _ => None,
+        };
+        self.write_empty_with_decode(name, class, matlab_dims, int_decode)
+    }
+
+    /// Write a MATLAB `struct([])` empty marker.
+    pub fn write_empty_struct_array(&mut self, name: &str) -> Result<&mut Self, MatError> {
+        self.write_empty_with_decode(name, MatClass::Struct, &[0, 0], None)
+    }
+
+    fn write_empty_with_decode(
+        &mut self,
+        name: &str,
+        class: MatClass,
+        matlab_dims: &[usize],
+        int_decode: Option<i32>,
+    ) -> Result<&mut Self, MatError> {
+        let target = self.resolve_target(name)?;
+        let encoding = self.options.empty_marker_encoding;
+        let mut storage_buf = [0u64; STORAGE_DIMS_BUF_LEN];
+        let mut dim_buf = [0u64; STORAGE_DIMS_BUF_LEN];
+        let ds = self.dataset_at_target(&target);
+        match encoding {
+            EmptyMarkerEncoding::ZeroElement => {
+                let shape = storage_dims_u64_into(matlab_dims, &mut storage_buf);
+                emit_zero_element(ds, class, shape);
+            }
+            EmptyMarkerEncoding::DataAsDims => {
+                if matlab_dims.len() > STORAGE_DIMS_BUF_LEN {
+                    let dim_data: Vec<u64> = matlab_dims.iter().map(|&d| d as u64).collect();
+                    ds.with_u64_data(&dim_data)
+                        .with_shape(&[dim_data.len() as u64]);
+                } else {
+                    let n = matlab_dims.len();
+                    for (slot, &d) in dim_buf[..n].iter_mut().zip(matlab_dims) {
+                        *slot = d as u64;
+                    }
+                    ds.with_u64_data(&dim_buf[..n]).with_shape(&[n as u64]);
+                }
+            }
+        }
+        ds.set_attr(
+            "MATLAB_class",
+            AttrValue::AsciiString(class.as_str().into()),
+        );
+        ds.set_attr("MATLAB_empty", AttrValue::U32(1));
+        if let Some(d) = int_decode {
+            ds.set_attr("MATLAB_int_decode", AttrValue::I32(d));
+        }
+        Ok(self)
+    }
+
+    fn write_array_inner<F>(
+        &mut self,
+        name: &str,
+        class: MatClass,
+        matlab_dims: &[usize],
+        data_len: usize,
+        apply: F,
+    ) -> Result<&mut Self, MatError>
+    where
+        F: FnOnce(&mut DatasetBuilder, &[u64]),
+    {
+        if data_len == 0 {
+            return self.write_empty_with_decode(name, class, matlab_dims, None);
+        }
+        let mut storage_buf = [0u64; STORAGE_DIMS_BUF_LEN];
+        let storage = storage_dims_u64_into(matlab_dims, &mut storage_buf);
+        let compression = self.options.compression;
+        let target = self.resolve_target(name)?;
+        let ds = self.dataset_at_target(&target);
+        apply(ds, storage);
+        ds.set_attr(
+            "MATLAB_class",
+            AttrValue::AsciiString(class.as_str().into()),
+        );
+        apply_deflate(ds, compression);
+        Ok(self)
+    }
+
+    // -- struct nesting ----------------------------------------------------
+
+    /// Open a struct group at the current scope. Use [`StructWriter`] inside
+    /// the closure to write fields.
+    pub fn struct_<F>(&mut self, name: &str, fill: F) -> Result<&mut Self, MatError>
+    where
+        F: FnOnce(&mut StructWriter) -> Result<(), MatError>,
+    {
+        // Resolve target and parent kind.
+        let (group_name, parent) = match self.next_target.take() {
+            Some(t) => (t.ref_name.clone(), ParentKind::Refs),
+            None => {
+                if let Some(top) = self.open_structs.last_mut() {
+                    let resolved = Self::normalize_name(
+                        name,
+                        &mut top.used_names,
+                        self.options.invalid_name_policy,
+                    )?;
+                    top.fields.push(resolved.clone());
+                    (resolved, ParentKind::StructAt(self.open_structs.len() - 1))
+                } else {
+                    let resolved = Self::normalize_name(
+                        name,
+                        &mut self.root_used_names,
+                        self.options.invalid_name_policy,
+                    )?;
+                    (resolved, ParentKind::Root)
+                }
+            }
+        };
+
+        let group = GroupBuilder::new(&group_name);
+        self.open_structs.push(OpenStruct {
+            group,
+            used_names: HashSet::new(),
+            fields: Vec::new(),
+            parent,
+        });
+
+        let res = {
+            let mut sw = StructWriter { mb: self };
+            fill(&mut sw)
+        };
+
+        // Always close even if fill errored, to keep the stack consistent.
+        let close_res = self.close_struct();
+        res?;
+        close_res?;
+        Ok(self)
+    }
+
+    fn close_struct(&mut self) -> Result<(), MatError> {
+        let mut s = self.open_structs.pop().ok_or_else(|| {
+            MatError::Custom("close_struct called with no open struct".into())
+        })?;
+        s.group.set_attr(
+            "MATLAB_class",
+            AttrValue::AsciiString(MatClass::Struct.as_str().into()),
+        );
+        s.group.set_attr(
+            "MATLAB_fields",
+            AttrValue::VarLenAsciiArray(s.fields),
+        );
+        let finished = s.group.finish();
+        match s.parent {
+            ParentKind::Root => self.file.add_group(finished),
+            ParentKind::StructAt(idx) => self.open_structs[idx].group.add_group(finished),
+            ParentKind::Refs => self.refs_mut().add_group(finished),
+        }
+        Ok(())
+    }
+
+    // -- cell arrays -------------------------------------------------------
+
+    /// Write a cell array. The closure pushes elements; the parent dataset is
+    /// emitted with object references after the closure returns.
+    pub fn cell<F>(
+        &mut self,
+        name: &str,
+        matlab_dims: &[usize],
+        fill: F,
+    ) -> Result<&mut Self, MatError>
+    where
+        F: FnOnce(&mut CellWriter) -> Result<(), MatError>,
+    {
+        // Resolve where the cell parent dataset goes BEFORE running fill (so
+        // pushes from fill don't mutate the resolved scope).
+        let parent_target = self.resolve_target(name)?;
+
+        let mut paths: Vec<String> = Vec::new();
+        let res = {
+            let mut cw = CellWriter {
+                mb: self,
+                paths: &mut paths,
+            };
+            fill(&mut cw)
+        };
+        res?;
+
+        let mut storage_buf = [0u64; STORAGE_DIMS_BUF_LEN];
+        let storage = storage_dims_u64_into(matlab_dims, &mut storage_buf);
+        if paths.is_empty() {
+            // Empty cell: emit a class=cell empty marker at the resolved
+            // target. Reuse the empty-marker emit path.
+            let encoding = self.options.empty_marker_encoding;
+            let mut dim_buf = [0u64; STORAGE_DIMS_BUF_LEN];
+            let ds = self.dataset_at_target(&parent_target);
+            match encoding {
+                EmptyMarkerEncoding::ZeroElement => {
+                    emit_zero_element(ds, MatClass::Cell, storage);
+                }
+                EmptyMarkerEncoding::DataAsDims => {
+                    if matlab_dims.len() > STORAGE_DIMS_BUF_LEN {
+                        let dim_data: Vec<u64> =
+                            matlab_dims.iter().map(|&d| d as u64).collect();
+                        ds.with_u64_data(&dim_data)
+                            .with_shape(&[dim_data.len() as u64]);
+                    } else {
+                        let n = matlab_dims.len();
+                        for (slot, &d) in dim_buf[..n].iter_mut().zip(matlab_dims) {
+                            *slot = d as u64;
+                        }
+                        ds.with_u64_data(&dim_buf[..n]).with_shape(&[n as u64]);
+                    }
+                }
+            }
+            ds.set_attr(
+                "MATLAB_class",
+                AttrValue::AsciiString(MatClass::Cell.as_str().into()),
+            );
+            ds.set_attr("MATLAB_empty", AttrValue::U32(1));
+            return Ok(self);
+        }
+
+        let path_strs: Vec<&str> = paths.iter().map(|s| s.as_str()).collect();
+        let ds = self.dataset_at_target(&parent_target);
+        ds.with_path_references(&path_strs).with_shape(storage);
+        ds.set_attr(
+            "MATLAB_class",
+            AttrValue::AsciiString(MatClass::Cell.as_str().into()),
+        );
+        Ok(self)
+    }
+
+    // -- helpers -----------------------------------------------------------
+
+    /// MATLAB shape for a 1-D vector of length `len`, using the configured
+    /// 1-D mode. Returns a stack-allocated 2-element array.
+    #[inline]
+    pub fn vector_dims(&self, len: usize) -> [usize; 2] {
+        vector_dims(len, self.options.one_dimensional_mode)
+    }
+
+    /// MATLAB shape for a value with the given multi-dimensional `extents`.
+    /// Allocates only when `extents.len() > 2`; the 0/1/2-D cases construct
+    /// a `Vec<usize>` with capacity 2.
+    #[inline]
+    pub fn matrix_dims(&self, extents: &[usize]) -> Vec<usize> {
+        matrix_dims(extents, self.options.one_dimensional_mode)
+    }
+
+    // -- finalize ----------------------------------------------------------
+
+    /// Finalize the file. Writes the `#subsystem#/MCOS` group if any string
+    /// objects were written, the `#refs#` group if any refs were created,
+    /// the userblock, and returns the bytes.
+    pub fn finish(mut self) -> Result<Vec<u8>, MatError> {
+        if !self.open_structs.is_empty() {
+            return Err(MatError::Custom(format!(
+                "MatBuilder::finish called with {} open structs",
+                self.open_structs.len()
+            )));
+        }
+        if self.next_target.is_some() {
+            return Err(MatError::Custom(
+                "MatBuilder::finish called with a pending cell-element target".into(),
+            ));
+        }
+
+        if !self.string_object_payload_paths.is_empty() {
+            self.emit_subsystem()?;
+        }
+
+        if let Some(refs) = self.refs.take() {
+            self.file.add_group(refs.finish());
+        }
+
+        let mut bytes = self.file.finish().map_err(MatError::Hdf5)?;
+        userblock::write_header(&mut bytes, userblock::DEFAULT_DESCRIPTION);
+        Ok(bytes)
+    }
+
+    /// Build the MCOS subsystem. Lifts the layout from the beve writer
+    /// byte-for-byte: 5 helper refs (FileWrapper, canonical empty,
+    /// unknown-template-A, alias-int32, unknown-template-B) plus the
+    /// per-string saveobj payload paths.
+    fn emit_subsystem(&mut self) -> Result<(), MatError> {
+        // 1. FileWrapper__ metadata blob.
+        let metadata = string_object::build_string_filewrapper_metadata(
+            self.string_object_payload_paths.len(),
+        );
+        let metadata_ref = self.alloc_ref_name();
+        let metadata_path = format!("{REFS_GROUP}/{metadata_ref}");
+        let metadata_shape: [u64; 2] = [1, metadata.len() as u64];
+        {
+            let refs = self.refs_mut();
+            let ds = refs.create_dataset(&metadata_ref);
+            ds.with_u8_data(&metadata).with_shape(&metadata_shape);
+            ds.set_attr(
+                "MATLAB_class",
+                AttrValue::AsciiString(MatClass::UInt8.as_str().into()),
+            );
+        }
+
+        // 2. Canonical empty.
+        let canonical_ref = self.alloc_ref_name();
+        let canonical_path = format!("{REFS_GROUP}/{canonical_ref}");
+        self.write_subsystem_empty_marker(&canonical_ref, &[0, 0], "canonical empty", None);
+
+        // 3. Unknown template A: cell with two empty struct refs.
+        let empty_a1 = self.alloc_ref_name();
+        let empty_a1_path = format!("{REFS_GROUP}/{empty_a1}");
+        self.write_subsystem_empty_marker(&empty_a1, &[1, 0], "struct", None);
+
+        let empty_a2 = self.alloc_ref_name();
+        let empty_a2_path = format!("{REFS_GROUP}/{empty_a2}");
+        self.write_subsystem_empty_marker(&empty_a2, &[1, 0], "struct", None);
+
+        let template_a = self.alloc_ref_name();
+        let template_a_path = format!("{REFS_GROUP}/{template_a}");
+        self.write_subsystem_reference_array(
+            &template_a,
+            &[2, 1],
+            &[empty_a1_path.as_str(), empty_a2_path.as_str()],
+            "cell",
+        );
+
+        // 4. Alias int32 ref.
+        let alias_ref = self.alloc_ref_name();
+        let alias_path = format!("{REFS_GROUP}/{alias_ref}");
+        {
+            let refs = self.refs_mut();
+            let ds = refs.create_dataset(&alias_ref);
+            ds.with_i32_data(&[0i32, 0]).with_shape(&[1u64, 2]);
+            ds.set_attr(
+                "MATLAB_class",
+                AttrValue::AsciiString(MatClass::Int32.as_str().into()),
+            );
+        }
+
+        // 5. Unknown template B: cell with two empty struct refs.
+        let empty_b1 = self.alloc_ref_name();
+        let empty_b1_path = format!("{REFS_GROUP}/{empty_b1}");
+        self.write_subsystem_empty_marker(&empty_b1, &[1, 0], "struct", None);
+
+        let empty_b2 = self.alloc_ref_name();
+        let empty_b2_path = format!("{REFS_GROUP}/{empty_b2}");
+        self.write_subsystem_empty_marker(&empty_b2, &[1, 0], "struct", None);
+
+        let template_b = self.alloc_ref_name();
+        let template_b_path = format!("{REFS_GROUP}/{template_b}");
+        self.write_subsystem_reference_array(
+            &template_b,
+            &[2, 1],
+            &[empty_b1_path.as_str(), empty_b2_path.as_str()],
+            "cell",
+        );
+
+        // 6. Build the MCOS reference array.
+        let mut paths: Vec<String> =
+            Vec::with_capacity(5 + self.string_object_payload_paths.len());
+        paths.push(metadata_path);
+        paths.push(canonical_path);
+        paths.extend(self.string_object_payload_paths.iter().cloned());
+        paths.push(template_a_path);
+        paths.push(alias_path);
+        paths.push(template_b_path);
+
+        let path_refs: Vec<&str> = paths.iter().map(|s| s.as_str()).collect();
+        let mut subsystem_group = self.file.create_group(SUBSYSTEM_GROUP);
+        let ds = subsystem_group.create_dataset("MCOS");
+        ds.with_path_references(&path_refs)
+            .with_shape(&[1u64, paths.len() as u64]);
+        ds.set_attr(
+            "MATLAB_class",
+            AttrValue::AsciiString(string_object::MATLAB_CLASS_FILEWRAPPER.into()),
+        );
+        ds.set_attr(
+            "MATLAB_object_decode",
+            AttrValue::I32(string_object::MATLAB_OBJECT_DECODE_OPAQUE),
+        );
+        self.file.add_group(subsystem_group.finish());
+        Ok(())
+    }
+
+    /// Subsystem helper refs always use the data-as-dims encoding regardless
+    /// of `Options::empty_marker_encoding`: real MATLAB writes them this way
+    /// in the `mxOPAQUE_CLASS` machinery, and we lift the layout byte-for-byte.
+    fn write_subsystem_empty_marker(
+        &mut self,
+        ref_name: &str,
+        matlab_dims: &[usize],
+        class: &str,
+        int_decode: Option<i32>,
+    ) {
+        let mut dim_buf = [0u64; STORAGE_DIMS_BUF_LEN];
+        let n = matlab_dims.len();
+        let refs = self.refs_mut();
+        let ds = refs.create_dataset(ref_name);
+        if n > STORAGE_DIMS_BUF_LEN {
+            let dim_data: Vec<u64> = matlab_dims.iter().map(|&d| d as u64).collect();
+            ds.with_u64_data(&dim_data).with_shape(&[n as u64]);
+        } else {
+            for (slot, &d) in dim_buf[..n].iter_mut().zip(matlab_dims) {
+                *slot = d as u64;
+            }
+            ds.with_u64_data(&dim_buf[..n]).with_shape(&[n as u64]);
+        }
+        ds.set_attr("MATLAB_class", AttrValue::AsciiString(class.into()));
+        ds.set_attr("MATLAB_empty", AttrValue::U32(1));
+        if let Some(d) = int_decode {
+            ds.set_attr("MATLAB_int_decode", AttrValue::I32(d));
+        }
+    }
+
+    fn write_subsystem_reference_array(
+        &mut self,
+        ref_name: &str,
+        matlab_dims: &[usize],
+        paths: &[&str],
+        class: &str,
+    ) {
+        let mut storage_buf = [0u64; STORAGE_DIMS_BUF_LEN];
+        let storage = storage_dims_u64_into(matlab_dims, &mut storage_buf);
+        let refs = self.refs_mut();
+        let ds = refs.create_dataset(ref_name);
+        ds.with_path_references(paths).with_shape(storage);
+        ds.set_attr("MATLAB_class", AttrValue::AsciiString(class.into()));
+    }
+}
+
+/// Where to put the next dataset/group, as resolved from current scope and
+/// `next_target`.
+enum TargetForName {
+    Root(String),
+    Struct { name: String, index: usize },
+    Ref(String),
+}
+
+/// Apply the configured deflate compression to `ds`, if any.
+fn apply_deflate(ds: &mut DatasetBuilder, compression: Compression) {
+    if let Compression::Deflate { level, shuffle } = compression {
+        if shuffle {
+            ds.with_shuffle();
+        }
+        ds.with_deflate(level as u32);
+    }
+}
+
+fn emit_zero_element(ds: &mut DatasetBuilder, class: MatClass, shape: &[u64]) {
+    match class {
+        MatClass::Double => {
+            ds.with_f64_data(&[]).with_shape(shape);
+        }
+        MatClass::Single => {
+            ds.with_f32_data(&[]).with_shape(shape);
+        }
+        MatClass::Int8 => {
+            ds.with_i8_data(&[]).with_shape(shape);
+        }
+        MatClass::Int16 => {
+            ds.with_i16_data(&[]).with_shape(shape);
+        }
+        MatClass::Int32 => {
+            ds.with_i32_data(&[]).with_shape(shape);
+        }
+        MatClass::Int64 => {
+            ds.with_i64_data(&[]).with_shape(shape);
+        }
+        MatClass::UInt8 | MatClass::Logical | MatClass::Cell | MatClass::Struct => {
+            ds.with_u8_data(&[]).with_shape(shape);
+        }
+        MatClass::UInt16 | MatClass::Char => {
+            ds.with_u16_data(&[]).with_shape(shape);
+        }
+        MatClass::UInt32 => {
+            ds.with_u32_data(&[]).with_shape(shape);
+        }
+        MatClass::UInt64 => {
+            ds.with_u64_data(&[]).with_shape(shape);
+        }
+    }
+}
+
+/// Scoped writer inside a struct group. Mirrors [`MatBuilder`]'s public write
+/// methods but writes to the parent struct.
+pub struct StructWriter<'a> {
+    mb: &'a mut MatBuilder,
+}
+
+impl<'a> StructWriter<'a> {
+    /// Borrow the underlying [`MatBuilder`]. Use this when a generic walker
+    /// needs to write into the current scope without going through the
+    /// struct-specific forwarding methods. The builder's internal scope
+    /// stack ensures writes target the open struct group.
+    #[inline]
+    pub fn builder(&mut self) -> &mut MatBuilder {
+        self.mb
+    }
+
+    #[inline]
+    pub fn write_scalar_logical(&mut self, name: &str, value: bool) -> Result<&mut Self, MatError> {
+        self.mb.write_scalar_logical(name, value)?;
+        Ok(self)
+    }
+    #[inline]
+    pub fn write_scalar_f64(&mut self, name: &str, value: f64) -> Result<&mut Self, MatError> {
+        self.mb.write_scalar_f64(name, value)?;
+        Ok(self)
+    }
+    #[inline]
+    pub fn write_scalar_f32(&mut self, name: &str, value: f32) -> Result<&mut Self, MatError> {
+        self.mb.write_scalar_f32(name, value)?;
+        Ok(self)
+    }
+    #[inline]
+    pub fn write_scalar_i8(&mut self, name: &str, value: i8) -> Result<&mut Self, MatError> {
+        self.mb.write_scalar_i8(name, value)?;
+        Ok(self)
+    }
+    #[inline]
+    pub fn write_scalar_i16(&mut self, name: &str, value: i16) -> Result<&mut Self, MatError> {
+        self.mb.write_scalar_i16(name, value)?;
+        Ok(self)
+    }
+    #[inline]
+    pub fn write_scalar_i32(&mut self, name: &str, value: i32) -> Result<&mut Self, MatError> {
+        self.mb.write_scalar_i32(name, value)?;
+        Ok(self)
+    }
+    #[inline]
+    pub fn write_scalar_i64(&mut self, name: &str, value: i64) -> Result<&mut Self, MatError> {
+        self.mb.write_scalar_i64(name, value)?;
+        Ok(self)
+    }
+    #[inline]
+    pub fn write_scalar_u8(&mut self, name: &str, value: u8) -> Result<&mut Self, MatError> {
+        self.mb.write_scalar_u8(name, value)?;
+        Ok(self)
+    }
+    #[inline]
+    pub fn write_scalar_u16(&mut self, name: &str, value: u16) -> Result<&mut Self, MatError> {
+        self.mb.write_scalar_u16(name, value)?;
+        Ok(self)
+    }
+    #[inline]
+    pub fn write_scalar_u32(&mut self, name: &str, value: u32) -> Result<&mut Self, MatError> {
+        self.mb.write_scalar_u32(name, value)?;
+        Ok(self)
+    }
+    #[inline]
+    pub fn write_scalar_u64(&mut self, name: &str, value: u64) -> Result<&mut Self, MatError> {
+        self.mb.write_scalar_u64(name, value)?;
+        Ok(self)
+    }
+    #[inline]
+    pub fn write_f64(&mut self, name: &str, dims: &[usize], data: &[f64]) -> Result<&mut Self, MatError> {
+        self.mb.write_f64(name, dims, data)?;
+        Ok(self)
+    }
+    #[inline]
+    pub fn write_f32(&mut self, name: &str, dims: &[usize], data: &[f32]) -> Result<&mut Self, MatError> {
+        self.mb.write_f32(name, dims, data)?;
+        Ok(self)
+    }
+    #[inline]
+    pub fn write_i8(&mut self, name: &str, dims: &[usize], data: &[i8]) -> Result<&mut Self, MatError> {
+        self.mb.write_i8(name, dims, data)?;
+        Ok(self)
+    }
+    #[inline]
+    pub fn write_i16(&mut self, name: &str, dims: &[usize], data: &[i16]) -> Result<&mut Self, MatError> {
+        self.mb.write_i16(name, dims, data)?;
+        Ok(self)
+    }
+    #[inline]
+    pub fn write_i32(&mut self, name: &str, dims: &[usize], data: &[i32]) -> Result<&mut Self, MatError> {
+        self.mb.write_i32(name, dims, data)?;
+        Ok(self)
+    }
+    #[inline]
+    pub fn write_i64(&mut self, name: &str, dims: &[usize], data: &[i64]) -> Result<&mut Self, MatError> {
+        self.mb.write_i64(name, dims, data)?;
+        Ok(self)
+    }
+    #[inline]
+    pub fn write_u8(&mut self, name: &str, dims: &[usize], data: &[u8]) -> Result<&mut Self, MatError> {
+        self.mb.write_u8(name, dims, data)?;
+        Ok(self)
+    }
+    #[inline]
+    pub fn write_u16(&mut self, name: &str, dims: &[usize], data: &[u16]) -> Result<&mut Self, MatError> {
+        self.mb.write_u16(name, dims, data)?;
+        Ok(self)
+    }
+    #[inline]
+    pub fn write_u32(&mut self, name: &str, dims: &[usize], data: &[u32]) -> Result<&mut Self, MatError> {
+        self.mb.write_u32(name, dims, data)?;
+        Ok(self)
+    }
+    #[inline]
+    pub fn write_u64(&mut self, name: &str, dims: &[usize], data: &[u64]) -> Result<&mut Self, MatError> {
+        self.mb.write_u64(name, dims, data)?;
+        Ok(self)
+    }
+    #[inline]
+    pub fn write_logical(&mut self, name: &str, dims: &[usize], data: &[u8]) -> Result<&mut Self, MatError> {
+        self.mb.write_logical(name, dims, data)?;
+        Ok(self)
+    }
+    #[inline]
+    pub fn write_char(&mut self, name: &str, value: &str) -> Result<&mut Self, MatError> {
+        self.mb.write_char(name, value)?;
+        Ok(self)
+    }
+    #[inline]
+    pub fn write_complex_f64(
+        &mut self,
+        name: &str,
+        dims: &[usize],
+        data: &[(f64, f64)],
+    ) -> Result<&mut Self, MatError> {
+        self.mb.write_complex_f64(name, dims, data)?;
+        Ok(self)
+    }
+    #[inline]
+    pub fn write_complex_f32(
+        &mut self,
+        name: &str,
+        dims: &[usize],
+        data: &[(f32, f32)],
+    ) -> Result<&mut Self, MatError> {
+        self.mb.write_complex_f32(name, dims, data)?;
+        Ok(self)
+    }
+    #[inline]
+    pub fn write_string_object(
+        &mut self,
+        name: &str,
+        values: &[String],
+        dims: &[usize],
+    ) -> Result<&mut Self, MatError> {
+        self.mb.write_string_object(name, values, dims)?;
+        Ok(self)
+    }
+    #[inline]
+    pub fn write_empty(
+        &mut self,
+        name: &str,
+        class: MatClass,
+        dims: &[usize],
+    ) -> Result<&mut Self, MatError> {
+        self.mb.write_empty(name, class, dims)?;
+        Ok(self)
+    }
+    #[inline]
+    pub fn write_empty_struct_array(&mut self, name: &str) -> Result<&mut Self, MatError> {
+        self.mb.write_empty_struct_array(name)?;
+        Ok(self)
+    }
+    pub fn struct_<F>(&mut self, name: &str, fill: F) -> Result<&mut Self, MatError>
+    where
+        F: FnOnce(&mut StructWriter) -> Result<(), MatError>,
+    {
+        self.mb.struct_(name, fill)?;
+        Ok(self)
+    }
+    pub fn cell<F>(&mut self, name: &str, dims: &[usize], fill: F) -> Result<&mut Self, MatError>
+    where
+        F: FnOnce(&mut CellWriter) -> Result<(), MatError>,
+    {
+        self.mb.cell(name, dims, fill)?;
+        Ok(self)
+    }
+
+    /// MATLAB shape for a 1-D vector.
+    #[inline]
+    pub fn vector_dims(&self, len: usize) -> [usize; 2] {
+        self.mb.vector_dims(len)
+    }
+    /// MATLAB shape for multi-dimensional extents.
+    #[inline]
+    pub fn matrix_dims(&self, extents: &[usize]) -> Vec<usize> {
+        self.mb.matrix_dims(extents)
+    }
+    /// Access the underlying options.
+    #[inline]
+    pub fn options(&self) -> &Options {
+        self.mb.options()
+    }
+    /// Convenience: configured [`StringClass`].
+    #[inline]
+    pub fn string_class(&self) -> crate::mat::options::StringClass {
+        self.options().string_class
+    }
+}
+
+/// Scoped writer inside a cell array. Each `push_*` allocates a fresh
+/// `#refs#/ref_NNNN` and records its absolute path. The cell's parent dataset
+/// is emitted when the closure returns.
+pub struct CellWriter<'a> {
+    mb: &'a mut MatBuilder,
+    paths: &'a mut Vec<String>,
+}
+
+impl<'a> CellWriter<'a> {
+    fn arm(&mut self) -> String {
+        let ref_name = self.mb.alloc_ref_name();
+        self.mb.next_target = Some(NextTarget {
+            ref_name: ref_name.clone(),
+        });
+        ref_name
+    }
+
+    fn record(&mut self, ref_name: String) {
+        // Defensive: if the write didn't consume next_target (shouldn't
+        // happen), drop it so the next push starts clean.
+        let _ = self.mb.next_target.take();
+        self.paths.push(format!("{REFS_GROUP}/{ref_name}"));
+    }
+
+    pub fn push_scalar_logical(&mut self, value: bool) -> Result<&mut Self, MatError> {
+        let r = self.arm();
+        self.mb.write_scalar_logical(&r, value)?;
+        self.record(r);
+        Ok(self)
+    }
+    pub fn push_scalar_f64(&mut self, value: f64) -> Result<&mut Self, MatError> {
+        let r = self.arm();
+        self.mb.write_scalar_f64(&r, value)?;
+        self.record(r);
+        Ok(self)
+    }
+    pub fn push_scalar_f32(&mut self, value: f32) -> Result<&mut Self, MatError> {
+        let r = self.arm();
+        self.mb.write_scalar_f32(&r, value)?;
+        self.record(r);
+        Ok(self)
+    }
+    pub fn push_scalar_u8(&mut self, value: u8) -> Result<&mut Self, MatError> {
+        let r = self.arm();
+        self.mb.write_scalar_u8(&r, value)?;
+        self.record(r);
+        Ok(self)
+    }
+    pub fn push_scalar_u16(&mut self, value: u16) -> Result<&mut Self, MatError> {
+        let r = self.arm();
+        self.mb.write_scalar_u16(&r, value)?;
+        self.record(r);
+        Ok(self)
+    }
+    pub fn push_scalar_u32(&mut self, value: u32) -> Result<&mut Self, MatError> {
+        let r = self.arm();
+        self.mb.write_scalar_u32(&r, value)?;
+        self.record(r);
+        Ok(self)
+    }
+    pub fn push_scalar_u64(&mut self, value: u64) -> Result<&mut Self, MatError> {
+        let r = self.arm();
+        self.mb.write_scalar_u64(&r, value)?;
+        self.record(r);
+        Ok(self)
+    }
+    pub fn push_scalar_i8(&mut self, value: i8) -> Result<&mut Self, MatError> {
+        let r = self.arm();
+        self.mb.write_scalar_i8(&r, value)?;
+        self.record(r);
+        Ok(self)
+    }
+    pub fn push_scalar_i16(&mut self, value: i16) -> Result<&mut Self, MatError> {
+        let r = self.arm();
+        self.mb.write_scalar_i16(&r, value)?;
+        self.record(r);
+        Ok(self)
+    }
+    pub fn push_scalar_i32(&mut self, value: i32) -> Result<&mut Self, MatError> {
+        let r = self.arm();
+        self.mb.write_scalar_i32(&r, value)?;
+        self.record(r);
+        Ok(self)
+    }
+    pub fn push_scalar_i64(&mut self, value: i64) -> Result<&mut Self, MatError> {
+        let r = self.arm();
+        self.mb.write_scalar_i64(&r, value)?;
+        self.record(r);
+        Ok(self)
+    }
+    pub fn push_string(&mut self, value: &str) -> Result<&mut Self, MatError> {
+        // MATLAB string scalar: dims [1, 1].
+        let r = self.arm();
+        self.mb.write_string_object(&r, &[value.to_owned()], &[1, 1])?;
+        self.record(r);
+        Ok(self)
+    }
+    pub fn push_char(&mut self, value: &str) -> Result<&mut Self, MatError> {
+        let r = self.arm();
+        self.mb.write_char(&r, value)?;
+        self.record(r);
+        Ok(self)
+    }
+    pub fn push_f64(&mut self, dims: &[usize], data: &[f64]) -> Result<&mut Self, MatError> {
+        let r = self.arm();
+        self.mb.write_f64(&r, dims, data)?;
+        self.record(r);
+        Ok(self)
+    }
+    pub fn push_f32(&mut self, dims: &[usize], data: &[f32]) -> Result<&mut Self, MatError> {
+        let r = self.arm();
+        self.mb.write_f32(&r, dims, data)?;
+        self.record(r);
+        Ok(self)
+    }
+    pub fn push_i8(&mut self, dims: &[usize], data: &[i8]) -> Result<&mut Self, MatError> {
+        let r = self.arm();
+        self.mb.write_i8(&r, dims, data)?;
+        self.record(r);
+        Ok(self)
+    }
+    pub fn push_i16(&mut self, dims: &[usize], data: &[i16]) -> Result<&mut Self, MatError> {
+        let r = self.arm();
+        self.mb.write_i16(&r, dims, data)?;
+        self.record(r);
+        Ok(self)
+    }
+    pub fn push_i32(&mut self, dims: &[usize], data: &[i32]) -> Result<&mut Self, MatError> {
+        let r = self.arm();
+        self.mb.write_i32(&r, dims, data)?;
+        self.record(r);
+        Ok(self)
+    }
+    pub fn push_i64(&mut self, dims: &[usize], data: &[i64]) -> Result<&mut Self, MatError> {
+        let r = self.arm();
+        self.mb.write_i64(&r, dims, data)?;
+        self.record(r);
+        Ok(self)
+    }
+    pub fn push_u8(&mut self, dims: &[usize], data: &[u8]) -> Result<&mut Self, MatError> {
+        let r = self.arm();
+        self.mb.write_u8(&r, dims, data)?;
+        self.record(r);
+        Ok(self)
+    }
+    pub fn push_u16(&mut self, dims: &[usize], data: &[u16]) -> Result<&mut Self, MatError> {
+        let r = self.arm();
+        self.mb.write_u16(&r, dims, data)?;
+        self.record(r);
+        Ok(self)
+    }
+    pub fn push_u32(&mut self, dims: &[usize], data: &[u32]) -> Result<&mut Self, MatError> {
+        let r = self.arm();
+        self.mb.write_u32(&r, dims, data)?;
+        self.record(r);
+        Ok(self)
+    }
+    pub fn push_u64(&mut self, dims: &[usize], data: &[u64]) -> Result<&mut Self, MatError> {
+        let r = self.arm();
+        self.mb.write_u64(&r, dims, data)?;
+        self.record(r);
+        Ok(self)
+    }
+    pub fn push_logical(&mut self, dims: &[usize], data: &[u8]) -> Result<&mut Self, MatError> {
+        let r = self.arm();
+        self.mb.write_logical(&r, dims, data)?;
+        self.record(r);
+        Ok(self)
+    }
+    pub fn push_complex_f64(
+        &mut self,
+        dims: &[usize],
+        data: &[(f64, f64)],
+    ) -> Result<&mut Self, MatError> {
+        let r = self.arm();
+        self.mb.write_complex_f64(&r, dims, data)?;
+        self.record(r);
+        Ok(self)
+    }
+    pub fn push_complex_f32(
+        &mut self,
+        dims: &[usize],
+        data: &[(f32, f32)],
+    ) -> Result<&mut Self, MatError> {
+        let r = self.arm();
+        self.mb.write_complex_f32(&r, dims, data)?;
+        self.record(r);
+        Ok(self)
+    }
+    pub fn push_string_object(
+        &mut self,
+        values: &[String],
+        dims: &[usize],
+    ) -> Result<&mut Self, MatError> {
+        let r = self.arm();
+        self.mb.write_string_object(&r, values, dims)?;
+        self.record(r);
+        Ok(self)
+    }
+    pub fn push_empty(&mut self, class: MatClass, dims: &[usize]) -> Result<&mut Self, MatError> {
+        let r = self.arm();
+        self.mb.write_empty(&r, class, dims)?;
+        self.record(r);
+        Ok(self)
+    }
+    pub fn push_empty_struct_array(&mut self) -> Result<&mut Self, MatError> {
+        let r = self.arm();
+        self.mb.write_empty_struct_array(&r)?;
+        self.record(r);
+        Ok(self)
+    }
+    pub fn push_struct<F>(&mut self, fill: F) -> Result<&mut Self, MatError>
+    where
+        F: FnOnce(&mut StructWriter) -> Result<(), MatError>,
+    {
+        let r = self.arm();
+        self.mb.struct_(&r, fill)?;
+        self.record(r);
+        Ok(self)
+    }
+    pub fn push_cell<F>(&mut self, dims: &[usize], fill: F) -> Result<&mut Self, MatError>
+    where
+        F: FnOnce(&mut CellWriter) -> Result<(), MatError>,
+    {
+        let r = self.arm();
+        self.mb.cell(&r, dims, fill)?;
+        self.record(r);
+        Ok(self)
+    }
+
+    /// Push an explicit reference to an existing path (e.g. a previously
+    /// allocated `#refs#/ref_NNNN` written via [`MatBuilder::alloc_ref_name`]
+    /// and out-of-band logic). For advanced use only.
+    pub fn push_path(&mut self, path: String) -> &mut Self {
+        self.paths.push(path);
+        self
+    }
+
+    /// Allocate a fresh ref and run `build` with the underlying `MatBuilder`,
+    /// armed so the next `write_*` / `struct_` / `cell` call inside `build`
+    /// targets `#refs#/ref_NNNN`. The build closure is responsible for
+    /// performing exactly one write/struct/cell operation.
+    pub fn push_with<F>(&mut self, build: F) -> Result<&mut Self, MatError>
+    where
+        F: FnOnce(&mut MatBuilder) -> Result<(), MatError>,
+    {
+        let r = self.arm();
+        let res = build(self.mb);
+        // `record` clears any leftover next_target as a safety net.
+        self.record(r);
+        res?;
+        Ok(self)
+    }
+
+    /// Access the configured options.
+    #[inline]
+    pub fn options(&self) -> &Options {
+        self.mb.options()
+    }
+
+    /// MATLAB shape for a 1-D vector under the configured mode.
+    #[inline]
+    pub fn vector_dims(&self, len: usize) -> [usize; 2] {
+        self.mb.vector_dims(len)
+    }
+
+    /// MATLAB shape for multi-dimensional extents under the configured mode.
+    #[inline]
+    pub fn matrix_dims(&self, extents: &[usize]) -> Vec<usize> {
+        self.mb.matrix_dims(extents)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::reader::File;
+    use crate::types::AttrValue as ReaderAttr;
+
+    fn temp_path(name: &str) -> std::path::PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("hdf5pure-mat-{name}-{nanos}.mat"))
+    }
+
+    fn read_class(file: &File, ds_path: &str) -> String {
+        let ds = file.dataset(ds_path).unwrap();
+        let attrs = ds.attrs().unwrap();
+        match &attrs["MATLAB_class"] {
+            ReaderAttr::AsciiString(s) | ReaderAttr::String(s) => s.clone(),
+            other => panic!("unexpected class: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn scalar_f64_at_root() {
+        let mut mb = MatBuilder::new(Options::default());
+        mb.write_scalar_f64("x", 1.5).unwrap();
+        let bytes = mb.finish().unwrap();
+
+        let path = temp_path("scalar-f64");
+        std::fs::write(&path, &bytes).unwrap();
+        let file = File::open(&path).unwrap();
+        let ds = file.dataset("x").unwrap();
+        assert_eq!(ds.read_f64().unwrap(), vec![1.5]);
+        assert_eq!(read_class(&file, "x"), "double");
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn nested_struct_writes_fields() {
+        let mut mb = MatBuilder::new(Options::default());
+        mb.struct_("payload", |s| {
+            s.write_scalar_u32("answer", 7)?;
+            s.write_char("label", "hello")?;
+            Ok(())
+        })
+        .unwrap();
+        let bytes = mb.finish().unwrap();
+
+        let path = temp_path("struct");
+        std::fs::write(&path, &bytes).unwrap();
+        let file = File::open(&path).unwrap();
+        let group = file.group("payload").unwrap();
+        let attrs = group.attrs().unwrap();
+        let class = match &attrs["MATLAB_class"] {
+            ReaderAttr::AsciiString(s) | ReaderAttr::String(s) => s.clone(),
+            other => panic!("unexpected: {other:?}"),
+        };
+        assert_eq!(class, "struct");
+        assert_eq!(read_class(&file, "payload/answer"), "uint32");
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn cell_with_two_refs() {
+        let mut mb = MatBuilder::new(Options::default());
+        mb.cell("c", &[2, 1], |cw| {
+            cw.push_scalar_u8(1)?;
+            cw.push_scalar_u8(2)?;
+            Ok(())
+        })
+        .unwrap();
+        let bytes = mb.finish().unwrap();
+
+        let path = temp_path("cell");
+        std::fs::write(&path, &bytes).unwrap();
+        let file = File::open(&path).unwrap();
+        let cls = read_class(&file, "c");
+        assert_eq!(cls, "cell");
+        assert_eq!(read_class(&file, "#refs#/ref_0000000000000000"), "uint8");
+        assert_eq!(read_class(&file, "#refs#/ref_0000000000000001"), "uint8");
+        std::fs::remove_file(path).unwrap();
+    }
+}

--- a/src/mat/dims.rs
+++ b/src/mat/dims.rs
@@ -1,0 +1,136 @@
+//! Dimension helpers used to map between Rust shape vectors, MATLAB workspace
+//! shapes, and HDF5 on-disk shapes.
+//!
+//! HDF5 stores datasets in C/row-major order; MATLAB sees them in
+//! Fortran/column-major order. Concretely: a MATLAB matrix of shape
+//! `[rows, cols]` is laid out on disk with HDF5 shape `[cols, rows]`. The
+//! helpers in this module exist to keep that translation in one place.
+//!
+//! The hot path (scalars and 1-D vectors) returns `[usize; 2]` directly so
+//! leaf writes don't allocate. The HDF5 storage shape conversion takes a
+//! caller-provided buffer for the same reason.
+
+use super::options::OneDimensionalMode;
+
+/// Maximum number of dimensions any helper here will write into a stack
+/// buffer. MATLAB v7.3 datasets are practically capped well below this.
+pub const STORAGE_DIMS_BUF_LEN: usize = 8;
+
+/// Return the MATLAB shape of a 1-D vector of length `len`, given the
+/// configured 1-D mode (column or row vector).
+#[inline]
+pub fn vector_dims(len: usize, mode: OneDimensionalMode) -> [usize; 2] {
+    match mode {
+        OneDimensionalMode::ColumnVector => [len, 1],
+        OneDimensionalMode::RowVector => [1, len],
+    }
+}
+
+/// Return the MATLAB shape for a value with the given multi-dimensional
+/// `extents`. Empty extents collapse to `[1, 1]` (scalar); 1-D extents follow
+/// [`vector_dims`]; everything else is returned as-is.
+///
+/// Returns `Vec<usize>` because the >2-D path needs to copy out of `extents`
+/// regardless. For the 2-D-or-shorter common case, prefer constructing
+/// `[usize; 2]` directly.
+#[inline]
+pub fn matrix_dims(extents: &[usize], mode: OneDimensionalMode) -> Vec<usize> {
+    match extents {
+        [] => vec![1, 1],
+        [len] => vector_dims(*len, mode).to_vec(),
+        _ => extents.to_vec(),
+    }
+}
+
+/// Convert MATLAB-shape dimensions to HDF5 storage shape (`u64`) into a
+/// caller-provided buffer; returns the populated slice. Pads to ≥ 2 dims with
+/// 1s and reverses so MATLAB column-major appears row-major on disk.
+///
+/// Panics if `buf.len()` is smaller than `matlab_dims.len().max(2)`.
+#[inline]
+pub fn storage_dims_u64_into<'a>(
+    matlab_dims: &[usize],
+    buf: &'a mut [u64],
+) -> &'a [u64] {
+    let n = matlab_dims.len().max(2);
+    assert!(
+        n <= buf.len(),
+        "storage_dims_u64_into: need {n} slots, buf has {}",
+        buf.len()
+    );
+    if matlab_dims.is_empty() {
+        buf[0] = 1;
+        buf[1] = 1;
+    } else if matlab_dims.len() == 1 {
+        buf[0] = 1;
+        buf[1] = matlab_dims[0] as u64;
+    } else {
+        for (i, &d) in matlab_dims.iter().enumerate() {
+            buf[n - 1 - i] = d as u64;
+        }
+    }
+    &buf[..n]
+}
+
+/// Convert MATLAB-shape dimensions to HDF5 storage shape, allocating a
+/// `Vec<u64>`. Convenience for callers who don't care about the allocation
+/// (e.g., one-shot finish-time emission).
+#[inline]
+pub fn storage_dims_u64(matlab_dims: &[usize]) -> Vec<u64> {
+    let mut buf = [0u64; STORAGE_DIMS_BUF_LEN];
+    if matlab_dims.len() > STORAGE_DIMS_BUF_LEN {
+        return storage_dims_u64_heap(matlab_dims);
+    }
+    storage_dims_u64_into(matlab_dims, &mut buf).to_vec()
+}
+
+#[cold]
+fn storage_dims_u64_heap(matlab_dims: &[usize]) -> Vec<u64> {
+    let n = matlab_dims.len().max(2);
+    let mut out = vec![0u64; n];
+    storage_dims_u64_into(matlab_dims, &mut out);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vector_dims_modes() {
+        assert_eq!(vector_dims(5, OneDimensionalMode::ColumnVector), [5, 1]);
+        assert_eq!(vector_dims(5, OneDimensionalMode::RowVector), [1, 5]);
+    }
+
+    #[test]
+    fn matrix_dims_handles_special_cases() {
+        assert_eq!(matrix_dims(&[], OneDimensionalMode::ColumnVector), vec![1, 1]);
+        assert_eq!(
+            matrix_dims(&[7], OneDimensionalMode::ColumnVector),
+            vec![7, 1]
+        );
+        assert_eq!(
+            matrix_dims(&[3, 4], OneDimensionalMode::ColumnVector),
+            vec![3, 4]
+        );
+    }
+
+    #[test]
+    fn storage_dims_u64_pads_and_reverses() {
+        let mut buf = [0u64; STORAGE_DIMS_BUF_LEN];
+        assert_eq!(storage_dims_u64_into(&[], &mut buf), &[1u64, 1]);
+        assert_eq!(storage_dims_u64_into(&[5], &mut buf), &[1u64, 5]);
+        assert_eq!(storage_dims_u64_into(&[3, 4], &mut buf), &[4u64, 3]);
+        assert_eq!(
+            storage_dims_u64_into(&[2, 3, 4], &mut buf),
+            &[4u64, 3, 2]
+        );
+    }
+
+    #[test]
+    fn storage_dims_u64_alloc_path_matches() {
+        assert_eq!(storage_dims_u64(&[5]), vec![1u64, 5]);
+        assert_eq!(storage_dims_u64(&[3, 4]), vec![4u64, 3]);
+        assert_eq!(storage_dims_u64(&[2, 3, 4]), vec![4u64, 3, 2]);
+    }
+}

--- a/src/mat/error.rs
+++ b/src/mat/error.rs
@@ -102,12 +102,14 @@ impl From<std::io::Error> for MatError {
     }
 }
 
+#[cfg(feature = "serde")]
 impl serde::ser::Error for MatError {
     fn custom<T: fmt::Display>(msg: T) -> Self {
         MatError::Custom(msg.to_string())
     }
 }
 
+#[cfg(feature = "serde")]
 impl serde::de::Error for MatError {
     fn custom<T: fmt::Display>(msg: T) -> Self {
         MatError::Custom(msg.to_string())

--- a/src/mat/identifier.rs
+++ b/src/mat/identifier.rs
@@ -1,0 +1,185 @@
+//! MATLAB identifier validation, sanitization, and deduplication.
+//!
+//! MATLAB workspace variable names and struct field names must:
+//! - Be 1 to 2048 ASCII characters long.
+//! - Begin with an ASCII alphabetic character.
+//! - Contain only ASCII alphanumerics and `_` after the first character.
+//! - Not collide with a MATLAB keyword.
+//!
+//! Names that fail these rules either error out or get rewritten, depending on
+//! the policy passed to the writer. Duplicate names within the same scope
+//! always get a numeric suffix.
+
+use std::collections::HashSet;
+
+/// Maximum length of a MATLAB identifier.
+pub const MATLAB_NAME_MAX: usize = 2048;
+
+/// Reserved MATLAB keywords. Names equal to any of these are not valid
+/// identifiers. Sorted for binary search.
+pub const MATLAB_KEYWORDS: &[&str] = &[
+    "break",
+    "case",
+    "catch",
+    "classdef",
+    "continue",
+    "else",
+    "elseif",
+    "end",
+    "events",
+    "for",
+    "function",
+    "global",
+    "if",
+    "methods",
+    "otherwise",
+    "parfor",
+    "persistent",
+    "properties",
+    "return",
+    "spmd",
+    "switch",
+    "try",
+    "while",
+];
+
+/// Returns `true` if `name` is a valid MATLAB identifier (length, alphabet,
+/// and not a keyword).
+pub fn is_valid_name(name: &str) -> bool {
+    if name.is_empty() || name.len() > MATLAB_NAME_MAX || is_keyword(name) {
+        return false;
+    }
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(ch) if ch.is_ascii_alphabetic() => {}
+        _ => return false,
+    }
+    chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+}
+
+/// Returns `true` if `name` is a reserved MATLAB keyword.
+pub fn is_keyword(name: &str) -> bool {
+    MATLAB_KEYWORDS.binary_search(&name).is_ok()
+}
+
+/// Rewrite a non-identifier `name` into a valid MATLAB identifier.
+///
+/// Strategy:
+/// - Replace an invalid first character with `'x'` followed by the original
+///   char (or `'_'` if the original wasn't alphanumeric or `_`).
+/// - Replace other invalid chars with `'_'`.
+/// - If the result is empty, return `"x"`.
+/// - If the result is a MATLAB keyword, append `'_'`.
+/// - Truncate to [`MATLAB_NAME_MAX`] characters.
+pub fn sanitize_name(name: &str) -> String {
+    let mut out = String::new();
+    for (idx, ch) in name.chars().enumerate() {
+        let valid = if idx == 0 {
+            ch.is_ascii_alphabetic()
+        } else {
+            ch.is_ascii_alphanumeric() || ch == '_'
+        };
+        if valid {
+            out.push(ch);
+        } else if idx == 0 {
+            out.push('x');
+            if ch.is_ascii_alphanumeric() || ch == '_' {
+                out.push(ch);
+            } else {
+                out.push('_');
+            }
+        } else {
+            out.push('_');
+        }
+    }
+    if out.is_empty() {
+        out.push('x');
+    }
+    if is_keyword(&out) {
+        out.push('_');
+    }
+    if out.len() > MATLAB_NAME_MAX {
+        out.truncate(MATLAB_NAME_MAX);
+    }
+    out
+}
+
+/// Maximum number of dedupe iterations before we give up. With suffix
+/// `_<usize>` and a 2048-char cap, you have to truly try to hit this; it
+/// exists to fail loudly instead of looping in pathological inputs.
+const MAX_DEDUPE_ATTEMPTS: usize = 1_000_000;
+
+/// Append a numeric suffix to `candidate` until it is not present in `used`.
+/// The suffix is `_1`, `_2`, ...; the base is truncated as needed to keep the
+/// total length under [`MATLAB_NAME_MAX`]. Panics after
+/// [`MAX_DEDUPE_ATTEMPTS`] collisions.
+pub fn dedupe_name(mut candidate: String, used: &HashSet<String>) -> String {
+    if !used.contains(&candidate) {
+        return candidate;
+    }
+    let base = candidate.clone();
+    for suffix in 1..=MAX_DEDUPE_ATTEMPTS {
+        let suffix_str = format!("_{suffix}");
+        let max_base_len = MATLAB_NAME_MAX.saturating_sub(suffix_str.len());
+        if max_base_len == 0 {
+            let tail_len = MATLAB_NAME_MAX.saturating_sub(1);
+            let start = suffix_str.len().saturating_sub(tail_len);
+            candidate.clear();
+            candidate.push('x');
+            candidate.push_str(&suffix_str[start..]);
+        } else {
+            let prefix = if base.len() > max_base_len {
+                &base[..max_base_len]
+            } else {
+                &base
+            };
+            candidate.clear();
+            candidate.push_str(prefix);
+            candidate.push_str(&suffix_str);
+        }
+        if !used.contains(&candidate) {
+            return candidate;
+        }
+    }
+    panic!("dedupe_name: exceeded {MAX_DEDUPE_ATTEMPTS} attempts for base name {base:?}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_names_pass() {
+        assert!(is_valid_name("foo"));
+        assert!(is_valid_name("foo_bar"));
+        assert!(is_valid_name("a1"));
+        assert!(is_valid_name("ABC"));
+    }
+
+    #[test]
+    fn invalid_names_rejected() {
+        assert!(!is_valid_name(""));
+        assert!(!is_valid_name("1foo"));
+        assert!(!is_valid_name("foo bar"));
+        assert!(!is_valid_name("foo-bar"));
+        assert!(!is_valid_name("end"));
+        assert!(!is_valid_name("for"));
+    }
+
+    #[test]
+    fn sanitize_inserts_x_prefix() {
+        assert_eq!(sanitize_name("1 bad"), "x1_bad");
+        assert_eq!(sanitize_name(""), "x");
+        assert_eq!(sanitize_name("foo bar"), "foo_bar");
+        assert_eq!(sanitize_name("end"), "end_");
+    }
+
+    #[test]
+    fn dedupe_appends_numeric_suffix() {
+        let mut used = HashSet::new();
+        used.insert("foo".to_owned());
+        assert_eq!(dedupe_name("foo".to_owned(), &used), "foo_1");
+        used.insert("foo_1".to_owned());
+        assert_eq!(dedupe_name("foo".to_owned(), &used), "foo_2");
+    }
+}

--- a/src/mat/mod.rs
+++ b/src/mat/mod.rs
@@ -1,20 +1,29 @@
-//! Serde-based reading and writing of MATLAB v7.3 `.mat` files.
+//! MATLAB v7.3 (`.mat`) file conventions on top of HDF5.
 //!
 //! MAT v7.3 files are HDF5 files with MATLAB conventions:
 //! - A 512-byte userblock starting with the `MATLAB 7.3 MAT-file...` signature
 //! - Every dataset and group carries a `MATLAB_class` attribute (`"double"`,
 //!   `"char"`, `"struct"`, ...)
-//! - Strings are stored as `uint16` datasets encoding UTF-16LE
+//! - Strings are stored as `uint16` datasets encoding UTF-16LE (legacy `char`
+//!   class) or as opaque-class objects via `#subsystem#/MCOS` (modern `string`
+//!   class)
 //! - 2-D arrays are laid out column-major (Fortran order); HDF5 shape is
 //!   `[cols, rows]` so that MATLAB sees the intended `[rows, cols]`
 //!
-//! # Required top-level shape
+//! This module exposes three layers of API:
 //!
-//! The outer Rust value must be a **struct with named fields**. Each field
-//! becomes a top-level MATLAB variable. This matches `scipy.io.savemat` and
-//! MATLAB's workspace model.
+//! 1. **Low-level conventions helpers** (always available): [`class::MatClass`],
+//!    [`userblock`], [`utf16`], [`identifier`], [`dims`], [`string_object`].
+//! 2. **Mid-level builder** (always available): [`builder::MatBuilder`] wraps
+//!    [`crate::FileBuilder`] and applies MATLAB conventions automatically.
+//!    Use this for one-pass writers that walk a custom value tree (e.g. a
+//!    BEVE wire-format walker).
+//! 3. **High-level serde** (gated on `feature = "serde"`): [`to_file`],
+//!    [`to_bytes`], [`from_file`], [`from_bytes`] for `#[derive(Serialize,
+//!    Deserialize)]` types.
 //!
 //! ```no_run
+//! # #[cfg(feature = "serde")] {
 //! use hdf5_pure::mat;
 //! use serde::{Serialize, Deserialize};
 //!
@@ -34,46 +43,52 @@
 //! let bytes = mat::to_bytes(&e).unwrap();
 //! let back: Experiment = mat::from_bytes(&bytes).unwrap();
 //! assert_eq!(back, e);
+//! # }
 //! ```
-//!
-//! # Data model
-//!
-//! | Rust | HDF5 / MATLAB |
-//! |---|---|
-//! | `f64`, `f32`, `i*`, `u*` | scalar dataset `[1,1]`, `MATLAB_class` = `"double"` etc. |
-//! | `bool` | `uint8` scalar, `MATLAB_class = "logical"` |
-//! | `String` | `uint16` `[1, N]` UTF-16LE, `MATLAB_class = "char"` |
-//! | `Vec<T>` of numeric `T` | `[1, N]` row vector |
-//! | [`Matrix`]`<T>` or `Vec<Vec<T>>` of same length | column-major 2-D dataset |
-//! | [`Complex32`] / [`Complex64`] | compound `{real, imag}` dataset |
-//! | nested struct | group with child datasets, `MATLAB_class = "struct"` |
-//! | `Option<T>` (struct field) | field is omitted when `None` |
-//! | unit enum variants | UTF-16 char dataset containing the variant name |
-//! | `Vec<Struct>` / `Vec<Option<T>>` / ragged `Vec<Vec<T>>` | cell array (object references into `#refs#`); `None` becomes `struct([])` |
-//!
-//! See the crate-level README for a fuller description.
-//!
-//! ## Cell arrays
-//!
-//! Heterogeneous sequences (sequences of structs, sequences with `None` interspersed, ragged inner vectors, mixed numeric tags) lower to a MATLAB cell array: each element is interned under the conventional `#refs#` group and the parent dataset stores object references with `MATLAB_class = "cell"`. Read in **MATLAB**, **libmatio**, **Julia `MAT.jl`**, or Python via **`pymatreader`**. Note: GNU Octave 11's `load` does not yet follow object references for v7.3 cells; load with one of the above instead.
 
 pub mod class;
-pub mod complex;
 pub mod error;
-pub mod matrix;
 pub mod userblock;
 pub mod utf16;
+
+// Convention helpers and builder. Available without serde so downstream
+// crates can drive a MatBuilder directly.
+pub mod builder;
+pub mod dims;
+pub mod identifier;
+pub mod options;
+pub mod string_object;
+
+// Complex/Matrix types and the serde-driven (de)serializer. Only meaningful
+// when serde is in scope.
+#[cfg(feature = "serde")]
+pub mod complex;
+#[cfg(feature = "serde")]
+pub mod matrix;
+#[cfg(feature = "serde")]
 pub(crate) mod value;
 
+#[cfg(feature = "serde")]
 pub mod de;
+#[cfg(feature = "serde")]
 pub mod ser;
 
+pub use builder::{CellWriter, MatBuilder, StructWriter};
 pub use class::MatClass;
-pub use complex::{Complex32, Complex64};
 pub use error::MatError;
+pub use options::{
+    Compression, EmptyMarkerEncoding, InvalidNamePolicy, NullPolicy, OneDimensionalMode, Options,
+    RowMajorPolicy, StringClass, UnsupportedPolicy,
+};
+
+#[cfg(feature = "serde")]
+pub use complex::{Complex32, Complex64};
+#[cfg(feature = "serde")]
 pub use matrix::Matrix;
 
+#[cfg(feature = "serde")]
 use serde::de::DeserializeOwned;
+#[cfg(feature = "serde")]
 use serde::Serialize;
 
 /// Serialize `value` to a MAT v7.3 byte vector.
@@ -84,12 +99,14 @@ use serde::Serialize;
 /// # Sequence handling
 ///
 /// Numeric sequences whose elements share a class collapse to row/column vectors or 2-D matrices as before. Any sequence that doesn't (e.g. `Vec<MyStruct>`, `Vec<Option<T>>` with `None` interspersed, ragged `Vec<Vec<f64>>`, or mixed numeric tags) lowers to a MATLAB cell array; each element is interned under the conventional `#refs#` group and the parent dataset stores object references with `MATLAB_class="cell"`. `Option::None` inside a sequence becomes `struct([])` so each cell slot has a defined MATLAB type. Cases that previously errored with `MatError::RaggedMatrix` or `MatError::MixedSequenceElementTypes` now succeed via this fallback.
+#[cfg(feature = "serde")]
 pub fn to_bytes<T: Serialize + ?Sized>(value: &T) -> Result<Vec<u8>, MatError> {
     ser::to_bytes(value)
 }
 
 /// Serialize `value` to the given filesystem path as a MAT v7.3 file. See
 /// [`to_bytes`] for details on how heterogeneous sequences are encoded.
+#[cfg(feature = "serde")]
 pub fn to_file<T: Serialize + ?Sized, P: AsRef<std::path::Path>>(
     value: &T,
     path: P,
@@ -98,12 +115,35 @@ pub fn to_file<T: Serialize + ?Sized, P: AsRef<std::path::Path>>(
     std::fs::write(path, bytes).map_err(MatError::Io)
 }
 
+/// Like [`to_bytes`] but with explicit options. Use for opting into the
+/// modern `string` class, name sanitization, compression, etc.
+#[cfg(feature = "serde")]
+pub fn to_bytes_with_options<T: Serialize + ?Sized>(
+    value: &T,
+    options: &Options,
+) -> Result<Vec<u8>, MatError> {
+    ser::to_bytes_with_options(value, options)
+}
+
+/// Like [`to_file`] but with explicit options.
+#[cfg(feature = "serde")]
+pub fn to_file_with_options<T: Serialize + ?Sized, P: AsRef<std::path::Path>>(
+    value: &T,
+    path: P,
+    options: &Options,
+) -> Result<(), MatError> {
+    let bytes = to_bytes_with_options(value, options)?;
+    std::fs::write(path, bytes).map_err(MatError::Io)
+}
+
 /// Deserialize a MAT v7.3 file from a byte slice.
+#[cfg(feature = "serde")]
 pub fn from_bytes<T: DeserializeOwned>(bytes: &[u8]) -> Result<T, MatError> {
     de::from_bytes(bytes)
 }
 
 /// Deserialize a MAT v7.3 file from the filesystem.
+#[cfg(feature = "serde")]
 pub fn from_file<T: DeserializeOwned, P: AsRef<std::path::Path>>(path: P) -> Result<T, MatError> {
     let bytes = std::fs::read(path).map_err(MatError::Io)?;
     from_bytes(&bytes)

--- a/src/mat/options.rs
+++ b/src/mat/options.rs
@@ -1,0 +1,190 @@
+//! Configuration knobs for MAT v7.3 writers.
+//!
+//! [`Options`] groups every policy a MATLAB writer might need to flex on:
+//! string class (`char` vs `string`), 1-D vector orientation, name validation
+//! behavior, compression, and more.
+//!
+//! The defaults match the historical hdf5-pure serde writer (`String -> char`,
+//! no name sanitization, no compression, column vectors). Callers wanting the
+//! richer "modern MATLAB" output should construct an `Options` with explicit
+//! `string_class: StringClass::String`, `invalid_name_policy: Sanitize`, etc.
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+/// MATLAB class to use when emitting Rust `String` (or BEVE string) values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub enum StringClass {
+    /// Encode as `char` (UTF-16 row vector). Compatible with `strcmp`, but
+    /// not with the `==` operator.
+    Char,
+    /// Encode as the modern MATLAB `string` class via `mxOPAQUE_CLASS`.
+    /// Supports `==` semantics. Costs a `#refs#` payload and a
+    /// `#subsystem#/MCOS` entry per writer.
+    String,
+}
+
+/// Encoding for 1-D vectors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub enum OneDimensionalMode {
+    /// MATLAB shape `[N, 1]`.
+    ColumnVector,
+    /// MATLAB shape `[1, N]`.
+    RowVector,
+}
+
+/// Behavior for `null` / `Option::None` values inside sequences and at the
+/// dataset root.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub enum NullPolicy {
+    /// Map `None` to MATLAB `struct([])` (an empty struct array).
+    EmptyStructArray,
+    /// Reject `None` with an error.
+    Error,
+}
+
+/// Behavior when a Rust struct field name or BEVE key is not a valid MATLAB
+/// identifier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub enum InvalidNamePolicy {
+    /// Return an error with the offending name.
+    Error,
+    /// Rewrite the name into a valid identifier and deduplicate.
+    Sanitize,
+}
+
+/// Behavior for BEVE values that have no direct MATLAB encoding (bf16, f16,
+/// 128-bit integers, unknown extensions).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub enum UnsupportedPolicy {
+    /// Reject unsupported values with an error.
+    Error,
+    /// Convert unsupported scalar values to their string representation and
+    /// emit them as MATLAB `string` objects.
+    StringFallback,
+    /// Widen low-precision floats (bf16, f16) to MATLAB `single`.
+    LossyNumericWidening,
+}
+
+/// HDF5 dataset compression settings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub enum Compression {
+    /// No compression (no chunking).
+    None,
+    /// HDF5 deflate compression.
+    Deflate {
+        /// zlib level (0-9).
+        level: u8,
+        /// Apply HDF5 byte-shuffle filter before deflate.
+        shuffle: bool,
+    },
+}
+
+/// Behavior for row-major matrix payloads (e.g. BEVE `MatrixLayout::Right`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub enum RowMajorPolicy {
+    /// Reorder row-major payloads into MATLAB column-major layout.
+    ReorderToColumnMajor,
+    /// Return an error rather than reordering.
+    Error,
+}
+
+/// Marker encoding to use for empty values (`Vec<T>` of length 0,
+/// `struct([])`, etc.).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub enum EmptyMarkerEncoding {
+    /// Zero-element dataset of shape `[0, 0]` with `MATLAB_empty=1`.
+    /// (hdf5-pure 0.3 historical default.)
+    ZeroElement,
+    /// One-element-per-dim `uint64` dataset whose payload is the dimension
+    /// vector, with `MATLAB_empty=1`. (beve historical default.)
+    DataAsDims,
+}
+
+/// Aggregated options for MAT v7.3 writers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub struct Options {
+    /// MATLAB class for string values.
+    pub string_class: StringClass,
+    /// HDF5 dataset compression settings.
+    pub compression: Compression,
+    /// Policy for invalid MATLAB names.
+    pub invalid_name_policy: InvalidNamePolicy,
+    /// Policy for `null`.
+    pub null_policy: NullPolicy,
+    /// Policy for unsupported numeric/BEVE types.
+    pub unsupported_policy: UnsupportedPolicy,
+    /// 1-D vector orientation.
+    pub one_dimensional_mode: OneDimensionalMode,
+    /// Row-major matrix payload handling.
+    pub row_major_policy: RowMajorPolicy,
+    /// Empty marker encoding.
+    pub empty_marker_encoding: EmptyMarkerEncoding,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            string_class: StringClass::Char,
+            compression: Compression::None,
+            invalid_name_policy: InvalidNamePolicy::Error,
+            null_policy: NullPolicy::EmptyStructArray,
+            unsupported_policy: UnsupportedPolicy::Error,
+            one_dimensional_mode: OneDimensionalMode::ColumnVector,
+            row_major_policy: RowMajorPolicy::ReorderToColumnMajor,
+            empty_marker_encoding: EmptyMarkerEncoding::ZeroElement,
+        }
+    }
+}
+
+impl Options {
+    /// Construct options that emit the modern MATLAB `string` class via
+    /// `mxOPAQUE_CLASS` and use the data-as-dims empty marker encoding.
+    /// Matches what real MATLAB's `save -v7.3` produces (and what the BEVE
+    /// → MAT walker has historically used).
+    pub fn with_modern_strings() -> Self {
+        Self {
+            string_class: StringClass::String,
+            empty_marker_encoding: EmptyMarkerEncoding::DataAsDims,
+            ..Self::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_matches_legacy_serde_writer() {
+        let o = Options::default();
+        assert_eq!(o.string_class, StringClass::Char);
+        assert_eq!(o.invalid_name_policy, InvalidNamePolicy::Error);
+        assert_eq!(o.empty_marker_encoding, EmptyMarkerEncoding::ZeroElement);
+    }
+
+    #[test]
+    fn modern_strings_constructor() {
+        let o = Options::with_modern_strings();
+        assert_eq!(o.string_class, StringClass::String);
+        assert_eq!(o.empty_marker_encoding, EmptyMarkerEncoding::DataAsDims);
+    }
+}

--- a/src/mat/ser/emit_with_builder.rs
+++ b/src/mat/ser/emit_with_builder.rs
@@ -1,0 +1,564 @@
+//! Emit a `MatValue` tree into HDF5 bytes through the public [`MatBuilder`]
+//! mid-level API.
+//!
+//! Used by [`super::root::to_bytes_with_options`]. The default-options path
+//! (`to_bytes`) keeps the legacy `emit_file` for backwards compatibility.
+
+use crate::mat::builder::{CellWriter, MatBuilder, StructWriter};
+use crate::mat::class::MatClass;
+use crate::mat::error::MatError;
+use crate::mat::options::{Options, StringClass};
+use crate::mat::value::{MatValue, NumVec, ScalarNum, ScalarTag};
+
+/// Walk top-level fields and emit through a `MatBuilder`.
+pub(crate) fn emit_file_with_options(
+    fields: Vec<(String, MatValue)>,
+    options: &Options,
+) -> Result<Vec<u8>, MatError> {
+    let mut mb = MatBuilder::new(options.clone());
+    for (name, value) in fields {
+        if matches!(value, MatValue::Omit) {
+            continue;
+        }
+        emit_at_root(&mut mb, &name, value)?;
+    }
+    mb.finish()
+}
+
+fn emit_at_root(mb: &mut MatBuilder, name: &str, value: MatValue) -> Result<(), MatError> {
+    match value {
+        MatValue::Omit => Ok(()),
+        MatValue::Struct(fields) => mb
+            .struct_(name, |sw| emit_struct_fields(sw, fields))
+            .map(|_| ()),
+        MatValue::Cell(elements) => mb
+            .cell(name, &cell_dims(elements.len()), |cw| {
+                emit_cell_elements(cw, elements)
+            })
+            .map(|_| ()),
+        other => emit_leaf_at_builder(mb, name, other),
+    }
+}
+
+fn emit_struct_fields(
+    sw: &mut StructWriter,
+    fields: Vec<(String, MatValue)>,
+) -> Result<(), MatError> {
+    for (name, value) in fields {
+        if matches!(value, MatValue::Omit) {
+            continue;
+        }
+        emit_at_struct(sw, &name, value)?;
+    }
+    Ok(())
+}
+
+fn emit_at_struct(sw: &mut StructWriter, name: &str, value: MatValue) -> Result<(), MatError> {
+    match value {
+        MatValue::Omit => Ok(()),
+        MatValue::Struct(fields) => sw
+            .struct_(name, |inner| emit_struct_fields(inner, fields))
+            .map(|_| ()),
+        MatValue::Cell(elements) => sw
+            .cell(name, &cell_dims(elements.len()), |cw| {
+                emit_cell_elements(cw, elements)
+            })
+            .map(|_| ()),
+        other => emit_leaf_at_struct(sw, name, other),
+    }
+}
+
+fn emit_cell_elements(
+    cw: &mut CellWriter,
+    elements: Vec<MatValue>,
+) -> Result<(), MatError> {
+    for value in elements {
+        emit_cell_element(cw, value)?;
+    }
+    Ok(())
+}
+
+fn emit_cell_element(cw: &mut CellWriter, value: MatValue) -> Result<(), MatError> {
+    match value {
+        MatValue::Omit => {
+            cw.push_empty_struct_array()?;
+        }
+        MatValue::Struct(fields) => {
+            cw.push_struct(|sw| emit_struct_fields(sw, fields))?;
+        }
+        MatValue::Cell(elements) => {
+            let dims = cell_dims(elements.len());
+            cw.push_cell(&dims, |inner| emit_cell_elements(inner, elements))?;
+        }
+        MatValue::Scalar(n) => emit_cell_scalar(cw, n)?,
+        MatValue::Vec1D(v) => emit_cell_vec(cw, v)?,
+        MatValue::Matrix { rows, cols, vec } => emit_cell_matrix(cw, rows, cols, vec)?,
+        MatValue::String(s) => {
+            cw.push_char(&s)?;
+        }
+        MatValue::ComplexScalar64 { re, im } => {
+            cw.push_complex_f64(&[1, 1], &[(re, im)])?;
+        }
+        MatValue::ComplexScalar32 { re, im } => {
+            cw.push_complex_f32(&[1, 1], &[(re, im)])?;
+        }
+        MatValue::ComplexVec64(pairs) => {
+            cw.push_complex_f64(&[1, pairs.len()], &pairs)?;
+        }
+        MatValue::ComplexVec32(pairs) => {
+            cw.push_complex_f32(&[1, pairs.len()], &pairs)?;
+        }
+        MatValue::ComplexMatrix64 { rows, cols, pairs } => {
+            let col_major = transpose_pairs(rows, cols, &pairs);
+            cw.push_complex_f64(&[rows, cols], &col_major)?;
+        }
+        MatValue::ComplexMatrix32 { rows, cols, pairs } => {
+            let col_major = transpose_pairs(rows, cols, &pairs);
+            cw.push_complex_f32(&[rows, cols], &col_major)?;
+        }
+        MatValue::EmptyStructArray => {
+            cw.push_empty_struct_array()?;
+        }
+    }
+    Ok(())
+}
+
+fn emit_cell_scalar(cw: &mut CellWriter, scalar: ScalarNum) -> Result<(), MatError> {
+    match scalar {
+        ScalarNum::Bool(b) => {
+            cw.push_scalar_logical(b)?;
+        }
+        ScalarNum::F64(x) => {
+            cw.push_scalar_f64(x)?;
+        }
+        ScalarNum::F32(x) => {
+            cw.push_scalar_f32(x)?;
+        }
+        ScalarNum::I64(x) => {
+            cw.push_scalar_i64(x)?;
+        }
+        ScalarNum::I32(x) => {
+            cw.push_scalar_i32(x)?;
+        }
+        ScalarNum::I16(x) => {
+            cw.push_scalar_i16(x)?;
+        }
+        ScalarNum::I8(x) => {
+            cw.push_scalar_i8(x)?;
+        }
+        ScalarNum::U64(x) => {
+            cw.push_scalar_u64(x)?;
+        }
+        ScalarNum::U32(x) => {
+            cw.push_scalar_u32(x)?;
+        }
+        ScalarNum::U16(x) => {
+            cw.push_scalar_u16(x)?;
+        }
+        ScalarNum::U8(x) => {
+            cw.push_scalar_u8(x)?;
+        }
+    }
+    Ok(())
+}
+
+fn emit_cell_vec(cw: &mut CellWriter, v: NumVec) -> Result<(), MatError> {
+    // 1-D cell-element vectors honor the configured OneDimensionalMode
+    // (default ColumnVector → MATLAB shape `[N, 1]`).
+    let dims = cw.vector_dims(v.len());
+    match v {
+        NumVec::Bool(vec) => {
+            let bytes: Vec<u8> = vec.into_iter().map(u8::from).collect();
+            cw.push_logical(&dims, &bytes)?;
+        }
+        NumVec::F64(vec) => {
+            cw.push_f64(&dims, &vec)?;
+        }
+        NumVec::F32(vec) => {
+            cw.push_f32(&dims, &vec)?;
+        }
+        NumVec::I64(vec) => {
+            cw.push_i64(&dims, &vec)?;
+        }
+        NumVec::I32(vec) => {
+            cw.push_i32(&dims, &vec)?;
+        }
+        NumVec::I16(vec) => {
+            cw.push_i16(&dims, &vec)?;
+        }
+        NumVec::I8(vec) => {
+            cw.push_i8(&dims, &vec)?;
+        }
+        NumVec::U64(vec) => {
+            cw.push_u64(&dims, &vec)?;
+        }
+        NumVec::U32(vec) => {
+            cw.push_u32(&dims, &vec)?;
+        }
+        NumVec::U16(vec) => {
+            cw.push_u16(&dims, &vec)?;
+        }
+        NumVec::U8(vec) => {
+            cw.push_u8(&dims, &vec)?;
+        }
+    }
+    Ok(())
+}
+
+fn emit_cell_matrix(
+    cw: &mut CellWriter,
+    rows: usize,
+    cols: usize,
+    v: NumVec,
+) -> Result<(), MatError> {
+    let dims = [rows, cols];
+    match v {
+        NumVec::Bool(vec) => {
+            let col_major = transpose_scalars(rows, cols, &vec);
+            let bytes: Vec<u8> = col_major.into_iter().map(u8::from).collect();
+            cw.push_logical(&dims, &bytes)?;
+        }
+        NumVec::F64(vec) => {
+            cw.push_f64(&dims, &transpose_scalars(rows, cols, &vec))?;
+        }
+        NumVec::F32(vec) => {
+            cw.push_f32(&dims, &transpose_scalars(rows, cols, &vec))?;
+        }
+        NumVec::I64(vec) => {
+            cw.push_i64(&dims, &transpose_scalars(rows, cols, &vec))?;
+        }
+        NumVec::I32(vec) => {
+            cw.push_i32(&dims, &transpose_scalars(rows, cols, &vec))?;
+        }
+        NumVec::I16(vec) => {
+            cw.push_i16(&dims, &transpose_scalars(rows, cols, &vec))?;
+        }
+        NumVec::I8(vec) => {
+            cw.push_i8(&dims, &transpose_scalars(rows, cols, &vec))?;
+        }
+        NumVec::U64(vec) => {
+            cw.push_u64(&dims, &transpose_scalars(rows, cols, &vec))?;
+        }
+        NumVec::U32(vec) => {
+            cw.push_u32(&dims, &transpose_scalars(rows, cols, &vec))?;
+        }
+        NumVec::U16(vec) => {
+            cw.push_u16(&dims, &transpose_scalars(rows, cols, &vec))?;
+        }
+        NumVec::U8(vec) => {
+            cw.push_u8(&dims, &transpose_scalars(rows, cols, &vec))?;
+        }
+    }
+    Ok(())
+}
+
+fn emit_leaf_at_builder(
+    mb: &mut MatBuilder,
+    name: &str,
+    value: MatValue,
+) -> Result<(), MatError> {
+    match value {
+        MatValue::Omit | MatValue::Struct(_) | MatValue::Cell(_) => {
+            // Handled by the caller.
+            Ok(())
+        }
+        MatValue::Scalar(n) => emit_scalar_at_builder(mb, name, n),
+        MatValue::Vec1D(v) => emit_vec_at_builder(mb, name, v),
+        MatValue::Matrix { rows, cols, vec } => emit_matrix_at_builder(mb, name, rows, cols, vec),
+        MatValue::String(s) => emit_string_at_builder(mb, name, &s),
+        MatValue::ComplexScalar64 { re, im } => {
+            mb.write_complex_f64(name, &[1, 1], &[(re, im)]).map(|_| ())
+        }
+        MatValue::ComplexScalar32 { re, im } => {
+            mb.write_complex_f32(name, &[1, 1], &[(re, im)]).map(|_| ())
+        }
+        MatValue::ComplexVec64(pairs) => mb
+            .write_complex_f64(name, &[1, pairs.len()], &pairs)
+            .map(|_| ()),
+        MatValue::ComplexVec32(pairs) => mb
+            .write_complex_f32(name, &[1, pairs.len()], &pairs)
+            .map(|_| ()),
+        MatValue::ComplexMatrix64 { rows, cols, pairs } => {
+            let col_major = transpose_pairs(rows, cols, &pairs);
+            mb.write_complex_f64(name, &[rows, cols], &col_major).map(|_| ())
+        }
+        MatValue::ComplexMatrix32 { rows, cols, pairs } => {
+            let col_major = transpose_pairs(rows, cols, &pairs);
+            mb.write_complex_f32(name, &[rows, cols], &col_major).map(|_| ())
+        }
+        MatValue::EmptyStructArray => mb.write_empty_struct_array(name).map(|_| ()),
+    }
+}
+
+fn emit_leaf_at_struct(
+    sw: &mut StructWriter,
+    name: &str,
+    value: MatValue,
+) -> Result<(), MatError> {
+    match value {
+        MatValue::Omit | MatValue::Struct(_) | MatValue::Cell(_) => Ok(()),
+        MatValue::Scalar(n) => emit_scalar_at_struct(sw, name, n),
+        MatValue::Vec1D(v) => emit_vec_at_struct(sw, name, v),
+        MatValue::Matrix { rows, cols, vec } => emit_matrix_at_struct(sw, name, rows, cols, vec),
+        MatValue::String(s) => emit_string_at_struct(sw, name, &s),
+        MatValue::ComplexScalar64 { re, im } => {
+            sw.write_complex_f64(name, &[1, 1], &[(re, im)]).map(|_| ())
+        }
+        MatValue::ComplexScalar32 { re, im } => {
+            sw.write_complex_f32(name, &[1, 1], &[(re, im)]).map(|_| ())
+        }
+        MatValue::ComplexVec64(pairs) => sw
+            .write_complex_f64(name, &[1, pairs.len()], &pairs)
+            .map(|_| ()),
+        MatValue::ComplexVec32(pairs) => sw
+            .write_complex_f32(name, &[1, pairs.len()], &pairs)
+            .map(|_| ()),
+        MatValue::ComplexMatrix64 { rows, cols, pairs } => {
+            let col_major = transpose_pairs(rows, cols, &pairs);
+            sw.write_complex_f64(name, &[rows, cols], &col_major).map(|_| ())
+        }
+        MatValue::ComplexMatrix32 { rows, cols, pairs } => {
+            let col_major = transpose_pairs(rows, cols, &pairs);
+            sw.write_complex_f32(name, &[rows, cols], &col_major).map(|_| ())
+        }
+        MatValue::EmptyStructArray => sw.write_empty_struct_array(name).map(|_| ()),
+    }
+}
+
+fn emit_scalar_at_builder(
+    mb: &mut MatBuilder,
+    name: &str,
+    scalar: ScalarNum,
+) -> Result<(), MatError> {
+    match scalar {
+        ScalarNum::Bool(b) => mb.write_scalar_logical(name, b),
+        ScalarNum::F64(x) => mb.write_scalar_f64(name, x),
+        ScalarNum::F32(x) => mb.write_scalar_f32(name, x),
+        ScalarNum::I64(x) => mb.write_scalar_i64(name, x),
+        ScalarNum::I32(x) => mb.write_scalar_i32(name, x),
+        ScalarNum::I16(x) => mb.write_scalar_i16(name, x),
+        ScalarNum::I8(x) => mb.write_scalar_i8(name, x),
+        ScalarNum::U64(x) => mb.write_scalar_u64(name, x),
+        ScalarNum::U32(x) => mb.write_scalar_u32(name, x),
+        ScalarNum::U16(x) => mb.write_scalar_u16(name, x),
+        ScalarNum::U8(x) => mb.write_scalar_u8(name, x),
+    }
+    .map(|_| ())
+}
+
+fn emit_scalar_at_struct(
+    sw: &mut StructWriter,
+    name: &str,
+    scalar: ScalarNum,
+) -> Result<(), MatError> {
+    match scalar {
+        ScalarNum::Bool(b) => sw.write_scalar_logical(name, b),
+        ScalarNum::F64(x) => sw.write_scalar_f64(name, x),
+        ScalarNum::F32(x) => sw.write_scalar_f32(name, x),
+        ScalarNum::I64(x) => sw.write_scalar_i64(name, x),
+        ScalarNum::I32(x) => sw.write_scalar_i32(name, x),
+        ScalarNum::I16(x) => sw.write_scalar_i16(name, x),
+        ScalarNum::I8(x) => sw.write_scalar_i8(name, x),
+        ScalarNum::U64(x) => sw.write_scalar_u64(name, x),
+        ScalarNum::U32(x) => sw.write_scalar_u32(name, x),
+        ScalarNum::U16(x) => sw.write_scalar_u16(name, x),
+        ScalarNum::U8(x) => sw.write_scalar_u8(name, x),
+    }
+    .map(|_| ())
+}
+
+fn emit_vec_at_builder(mb: &mut MatBuilder, name: &str, v: NumVec) -> Result<(), MatError> {
+    let dims = mb.vector_dims(v.len());
+    if v.len() == 0 {
+        return mb.write_empty(name, scalar_class(v.tag()), &dims).map(|_| ());
+    }
+    match v {
+        NumVec::Bool(vec) => {
+            let bytes: Vec<u8> = vec.into_iter().map(u8::from).collect();
+            mb.write_logical(name, &dims, &bytes)
+        }
+        NumVec::F64(vec) => mb.write_f64(name, &dims, &vec),
+        NumVec::F32(vec) => mb.write_f32(name, &dims, &vec),
+        NumVec::I64(vec) => mb.write_i64(name, &dims, &vec),
+        NumVec::I32(vec) => mb.write_i32(name, &dims, &vec),
+        NumVec::I16(vec) => mb.write_i16(name, &dims, &vec),
+        NumVec::I8(vec) => mb.write_i8(name, &dims, &vec),
+        NumVec::U64(vec) => mb.write_u64(name, &dims, &vec),
+        NumVec::U32(vec) => mb.write_u32(name, &dims, &vec),
+        NumVec::U16(vec) => mb.write_u16(name, &dims, &vec),
+        NumVec::U8(vec) => mb.write_u8(name, &dims, &vec),
+    }
+    .map(|_| ())
+}
+
+fn emit_vec_at_struct(sw: &mut StructWriter, name: &str, v: NumVec) -> Result<(), MatError> {
+    let dims = sw.vector_dims(v.len());
+    if v.len() == 0 {
+        return sw.write_empty(name, scalar_class(v.tag()), &dims).map(|_| ());
+    }
+    match v {
+        NumVec::Bool(vec) => {
+            let bytes: Vec<u8> = vec.into_iter().map(u8::from).collect();
+            sw.write_logical(name, &dims, &bytes)
+        }
+        NumVec::F64(vec) => sw.write_f64(name, &dims, &vec),
+        NumVec::F32(vec) => sw.write_f32(name, &dims, &vec),
+        NumVec::I64(vec) => sw.write_i64(name, &dims, &vec),
+        NumVec::I32(vec) => sw.write_i32(name, &dims, &vec),
+        NumVec::I16(vec) => sw.write_i16(name, &dims, &vec),
+        NumVec::I8(vec) => sw.write_i8(name, &dims, &vec),
+        NumVec::U64(vec) => sw.write_u64(name, &dims, &vec),
+        NumVec::U32(vec) => sw.write_u32(name, &dims, &vec),
+        NumVec::U16(vec) => sw.write_u16(name, &dims, &vec),
+        NumVec::U8(vec) => sw.write_u8(name, &dims, &vec),
+    }
+    .map(|_| ())
+}
+
+fn emit_matrix_at_builder(
+    mb: &mut MatBuilder,
+    name: &str,
+    rows: usize,
+    cols: usize,
+    v: NumVec,
+) -> Result<(), MatError> {
+    let dims = [rows, cols];
+    match v {
+        NumVec::Bool(vec) => {
+            let col_major = transpose_scalars(rows, cols, &vec);
+            let bytes: Vec<u8> = col_major.into_iter().map(u8::from).collect();
+            mb.write_logical(name, &dims, &bytes)
+        }
+        NumVec::F64(vec) => mb.write_f64(name, &dims, &transpose_scalars(rows, cols, &vec)),
+        NumVec::F32(vec) => mb.write_f32(name, &dims, &transpose_scalars(rows, cols, &vec)),
+        NumVec::I64(vec) => mb.write_i64(name, &dims, &transpose_scalars(rows, cols, &vec)),
+        NumVec::I32(vec) => mb.write_i32(name, &dims, &transpose_scalars(rows, cols, &vec)),
+        NumVec::I16(vec) => mb.write_i16(name, &dims, &transpose_scalars(rows, cols, &vec)),
+        NumVec::I8(vec) => mb.write_i8(name, &dims, &transpose_scalars(rows, cols, &vec)),
+        NumVec::U64(vec) => mb.write_u64(name, &dims, &transpose_scalars(rows, cols, &vec)),
+        NumVec::U32(vec) => mb.write_u32(name, &dims, &transpose_scalars(rows, cols, &vec)),
+        NumVec::U16(vec) => mb.write_u16(name, &dims, &transpose_scalars(rows, cols, &vec)),
+        NumVec::U8(vec) => mb.write_u8(name, &dims, &transpose_scalars(rows, cols, &vec)),
+    }
+    .map(|_| ())
+}
+
+fn emit_matrix_at_struct(
+    sw: &mut StructWriter,
+    name: &str,
+    rows: usize,
+    cols: usize,
+    v: NumVec,
+) -> Result<(), MatError> {
+    let dims = [rows, cols];
+    match v {
+        NumVec::Bool(vec) => {
+            let col_major = transpose_scalars(rows, cols, &vec);
+            let bytes: Vec<u8> = col_major.into_iter().map(u8::from).collect();
+            sw.write_logical(name, &dims, &bytes)
+        }
+        NumVec::F64(vec) => sw.write_f64(name, &dims, &transpose_scalars(rows, cols, &vec)),
+        NumVec::F32(vec) => sw.write_f32(name, &dims, &transpose_scalars(rows, cols, &vec)),
+        NumVec::I64(vec) => sw.write_i64(name, &dims, &transpose_scalars(rows, cols, &vec)),
+        NumVec::I32(vec) => sw.write_i32(name, &dims, &transpose_scalars(rows, cols, &vec)),
+        NumVec::I16(vec) => sw.write_i16(name, &dims, &transpose_scalars(rows, cols, &vec)),
+        NumVec::I8(vec) => sw.write_i8(name, &dims, &transpose_scalars(rows, cols, &vec)),
+        NumVec::U64(vec) => sw.write_u64(name, &dims, &transpose_scalars(rows, cols, &vec)),
+        NumVec::U32(vec) => sw.write_u32(name, &dims, &transpose_scalars(rows, cols, &vec)),
+        NumVec::U16(vec) => sw.write_u16(name, &dims, &transpose_scalars(rows, cols, &vec)),
+        NumVec::U8(vec) => sw.write_u8(name, &dims, &transpose_scalars(rows, cols, &vec)),
+    }
+    .map(|_| ())
+}
+
+fn emit_string_at_builder(
+    mb: &mut MatBuilder,
+    name: &str,
+    s: &str,
+) -> Result<(), MatError> {
+    match mb.options().string_class {
+        StringClass::Char => mb.write_char(name, s).map(|_| ()),
+        StringClass::String => mb.write_string_object(name, &[s.to_owned()], &[1, 1]).map(|_| ()),
+    }
+}
+
+fn emit_string_at_struct(
+    sw: &mut StructWriter,
+    name: &str,
+    s: &str,
+) -> Result<(), MatError> {
+    match sw.string_class() {
+        StringClass::Char => sw.write_char(name, s).map(|_| ()),
+        StringClass::String => sw
+            .write_string_object(name, &[s.to_owned()], &[1, 1])
+            .map(|_| ()),
+    }
+}
+
+fn cell_dims(n: usize) -> [usize; 2] {
+    // Mirror the legacy emit.rs behavior: 1-D cell is `[n, 1]`.
+    if n == 0 { [0, 0] } else { [n, 1] }
+}
+
+fn scalar_class(tag: ScalarTag) -> MatClass {
+    match tag {
+        ScalarTag::Bool => MatClass::Logical,
+        ScalarTag::F64 => MatClass::Double,
+        ScalarTag::F32 => MatClass::Single,
+        ScalarTag::I64 => MatClass::Int64,
+        ScalarTag::I32 => MatClass::Int32,
+        ScalarTag::I16 => MatClass::Int16,
+        ScalarTag::I8 => MatClass::Int8,
+        ScalarTag::U64 => MatClass::UInt64,
+        ScalarTag::U32 => MatClass::UInt32,
+        ScalarTag::U16 => MatClass::UInt16,
+        ScalarTag::U8 => MatClass::UInt8,
+    }
+}
+
+/// Transpose a row-major matrix of shape `[rows, cols]` into column-major.
+/// Tiled to keep both reads and writes cache-resident on large matrices.
+fn transpose_2d<T: Copy>(rows: usize, cols: usize, row_major: &[T]) -> Vec<T> {
+    debug_assert_eq!(row_major.len(), rows * cols);
+    let n = rows * cols;
+    let mut out: Vec<T> = Vec::with_capacity(n);
+    if n == 0 {
+        return out;
+    }
+
+    const BLK: usize = 32;
+    let dst = out.as_mut_ptr();
+    for cb in (0..cols).step_by(BLK) {
+        let c_end = (cb + BLK).min(cols);
+        for rb in (0..rows).step_by(BLK) {
+            let r_end = (rb + BLK).min(rows);
+            for r in rb..r_end {
+                let src_row_base = r * cols;
+                for c in cb..c_end {
+                    let value = row_major[src_row_base + c];
+                    // SAFETY: c < cols and r < rows so c*rows + r < cols*rows = n,
+                    // and out has capacity n.
+                    unsafe {
+                        dst.add(c * rows + r).write(value);
+                    }
+                }
+            }
+        }
+    }
+    // SAFETY: every index 0..n was written above (each (r, c) maps to a unique
+    // c * rows + r in 0..n).
+    unsafe {
+        out.set_len(n);
+    }
+    out
+}
+
+#[inline]
+fn transpose_pairs<T: Copy>(rows: usize, cols: usize, row_major: &[(T, T)]) -> Vec<(T, T)> {
+    transpose_2d(rows, cols, row_major)
+}
+
+#[inline]
+fn transpose_scalars<T: Copy>(rows: usize, cols: usize, row_major: &[T]) -> Vec<T> {
+    transpose_2d(rows, cols, row_major)
+}

--- a/src/mat/ser/mod.rs
+++ b/src/mat/ser/mod.rs
@@ -1,7 +1,8 @@
 //! Serializer implementation for MATLAB v7.3 `.mat` files.
 
 mod emit;
+mod emit_with_builder;
 mod root;
 mod value_ser;
 
-pub use root::to_bytes;
+pub use root::{to_bytes, to_bytes_with_options};

--- a/src/mat/ser/root.rs
+++ b/src/mat/ser/root.rs
@@ -9,8 +9,10 @@ use serde::ser::{
 };
 
 use crate::mat::error::MatError;
+use crate::mat::options::Options;
 
 use super::emit::emit_file;
+use super::emit_with_builder::emit_file_with_options;
 use super::value_ser::{to_value, ValueSerializer};
 use crate::mat::value::MatValue;
 
@@ -18,6 +20,16 @@ use crate::mat::value::MatValue;
 pub fn to_bytes<T: Serialize + ?Sized>(value: &T) -> Result<Vec<u8>, MatError> {
     let fields = value.serialize(RootSerializer)?;
     emit_file(fields)
+}
+
+/// Like [`to_bytes`] but with explicit options. Use this to opt into the
+/// modern `string` class, name sanitization, deflate compression, etc.
+pub fn to_bytes_with_options<T: Serialize + ?Sized>(
+    value: &T,
+    options: &Options,
+) -> Result<Vec<u8>, MatError> {
+    let fields = value.serialize(RootSerializer)?;
+    emit_file_with_options(fields, options)
 }
 
 /// The root serializer. Produces `Vec<(field_name, MatValue)>`.

--- a/src/mat/string_object.rs
+++ b/src/mat/string_object.rs
@@ -1,0 +1,209 @@
+//! `mxOPAQUE_CLASS` machinery for MATLAB `string` objects.
+//!
+//! MATLAB's modern `string` class is encoded by reference into `#refs#` and
+//! `#subsystem#/MCOS`. This module implements the byte-level layout that
+//! MATLAB itself produces (reverse-engineered against fixtures in the beve
+//! test suite). Treat the constants and offsets in this file as load-bearing:
+//! changing them is observable to MATLAB on the read side.
+//!
+//! The layout has three pieces:
+//! 1. A `uint64` "saveobj" payload per string scalar/array (lives in `#refs#`).
+//!    Encodes a version, the dimensions, the per-string lengths, and packed
+//!    UTF-16 code units.
+//! 2. A `uint32` 6-element metadata array on the parent dataset:
+//!    `[MCOS_MAGIC=0xDD000000, 2, 1, 1, object_id, 1]`. Carries the
+//!    `MATLAB_class="string"` and `MATLAB_object_decode=3` attributes.
+//! 3. A `#subsystem#/MCOS` reference dataset that points to a `FileWrapper__`
+//!    metadata blob, a canonical empty placeholder, every per-string saveobj
+//!    payload, an alias `int32` blob, and two "unknown template" cell arrays.
+//!    Carries the `MATLAB_class="FileWrapper__"` and
+//!    `MATLAB_object_decode=3` attributes.
+
+use crate::mat::error::MatError;
+
+/// Magic constant in the metadata header on every MATLAB string-object
+/// dataset.
+pub const MCOS_MAGIC_NUMBER: u32 = 0xDD00_0000;
+
+/// Version word at the start of `FileWrapper__` blobs.
+pub const FILEWRAPPER_VERSION: u32 = 4;
+
+/// Version word at the start of the saveobj payload.
+pub const MATLAB_STRING_SAVEOBJ_VERSION: u64 = 1;
+
+/// Value of `MATLAB_object_decode` for opaque-class datasets.
+pub const MATLAB_OBJECT_DECODE_OPAQUE: i32 = 3;
+
+/// `MATLAB_class` value on the parent dataset of a string object.
+pub const MATLAB_CLASS_STRING: &str = "string";
+
+/// `MATLAB_class` value on the `#subsystem#/MCOS` reference dataset.
+pub const MATLAB_CLASS_FILEWRAPPER: &str = "FileWrapper__";
+
+/// 6-element metadata array on a string-object parent dataset.
+pub fn create_string_object_metadata(object_id: u32) -> [u32; 6] {
+    [MCOS_MAGIC_NUMBER, 2, 1, 1, object_id, 1]
+}
+
+/// Build the saveobj payload (a `uint64` array) for one or more string
+/// values arranged in `matlab_dims` shape.
+///
+/// Layout: `[VERSION, ndims, dim0, dim1, ..., len0, len1, ..., utf16 packed
+/// as u64]`.
+pub fn encode_string_saveobj_payload(
+    values: &[String],
+    matlab_dims: &[usize],
+) -> Result<Vec<u64>, MatError> {
+    let expected = product(matlab_dims).ok_or(MatError::Custom(
+        "string saveobj dims overflow usize".to_owned(),
+    ))?;
+    if expected != values.len() {
+        return Err(MatError::Custom(format!(
+            "string payload length {} does not match product of dims {}",
+            values.len(),
+            expected
+        )));
+    }
+
+    // UTF-16 unit count is bounded above by UTF-8 byte count for every string,
+    // so a single up-front sum sizes both the units scratch and the final
+    // payload exactly.
+    let max_utf16_units: usize = values.iter().map(|s| s.len()).sum();
+    let header_count = 2 + matlab_dims.len() + values.len();
+
+    let mut payload = Vec::with_capacity(header_count + max_utf16_units.div_ceil(4));
+    payload.push(MATLAB_STRING_SAVEOBJ_VERSION);
+    payload.push(matlab_dims.len() as u64);
+    payload.extend(matlab_dims.iter().map(|&dim| dim as u64));
+
+    let mut units: Vec<u16> = Vec::with_capacity(max_utf16_units);
+    for value in values {
+        let before = units.len();
+        units.extend(value.encode_utf16());
+        payload.push((units.len() - before) as u64);
+    }
+    // Pad to a multiple of 4 u16s so we can pack 4 per u64 word.
+    units.resize(units.len().next_multiple_of(4), 0);
+
+    for chunk in units.chunks_exact(4) {
+        let v = (chunk[0] as u64)
+            | ((chunk[1] as u64) << 16)
+            | ((chunk[2] as u64) << 32)
+            | ((chunk[3] as u64) << 48);
+        payload.push(v);
+    }
+    Ok(payload)
+}
+
+/// Build the `FileWrapper__` metadata blob. Stored as a `uint8` dataset and
+/// referenced first from `#subsystem#/MCOS`.
+pub fn build_string_filewrapper_metadata(object_count: usize) -> Vec<u8> {
+    let mut names_bytes = b"any\0string\0".to_vec();
+    while !names_bytes.len().is_multiple_of(8) {
+        names_bytes.push(0);
+    }
+
+    let mut region_offsets = [0u32; 8];
+    let mut regions = Vec::new();
+
+    let version = u32_bytes(&[FILEWRAPPER_VERSION]);
+    let num_names = u32_bytes(&[2]);
+    let class_id_metadata = u32_bytes(&[0, 0, 0, 0, 0, 2, 0, 0]);
+
+    let mut saveobj_metadata = Vec::with_capacity(2 + object_count * 4);
+    saveobj_metadata.extend_from_slice(&[0, 0]);
+    for idx in 0..object_count {
+        saveobj_metadata.extend_from_slice(&[1, 1, 1, idx as u32]);
+    }
+    let saveobj_metadata = u32_bytes(&saveobj_metadata);
+
+    let mut object_id_metadata = Vec::with_capacity(6 + object_count * 6);
+    object_id_metadata.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
+    for id in 1..=object_count as u32 {
+        object_id_metadata.extend_from_slice(&[1, 0, 0, id, 0, id]);
+    }
+    let object_id_metadata = u32_bytes(&object_id_metadata);
+
+    let nobj_metadata = u32_bytes(&[0, 0]);
+
+    let mut dynprop_metadata = Vec::with_capacity(2 + object_count * 2);
+    dynprop_metadata.extend_from_slice(&[0, 0]);
+    for _ in 0..object_count {
+        dynprop_metadata.extend_from_slice(&[0, 0]);
+    }
+    let dynprop_metadata = u32_bytes(&dynprop_metadata);
+
+    let region6 = Vec::new();
+    let region7 = vec![0u8; 8];
+
+    let mut offset = 40u32 + names_bytes.len() as u32;
+    region_offsets[0] = offset;
+    offset += class_id_metadata.len() as u32;
+    region_offsets[1] = offset;
+    offset += saveobj_metadata.len() as u32;
+    region_offsets[2] = offset;
+    offset += object_id_metadata.len() as u32;
+    region_offsets[3] = offset;
+    offset += nobj_metadata.len() as u32;
+    region_offsets[4] = offset;
+    offset += dynprop_metadata.len() as u32;
+    region_offsets[5] = offset;
+    offset += region6.len() as u32;
+    region_offsets[6] = offset;
+    offset += region7.len() as u32;
+    region_offsets[7] = offset;
+
+    regions.extend_from_slice(&version);
+    regions.extend_from_slice(&num_names);
+    regions.extend_from_slice(&u32_bytes(&region_offsets));
+    regions.extend_from_slice(&names_bytes);
+    regions.extend_from_slice(&class_id_metadata);
+    regions.extend_from_slice(&saveobj_metadata);
+    regions.extend_from_slice(&object_id_metadata);
+    regions.extend_from_slice(&nobj_metadata);
+    regions.extend_from_slice(&dynprop_metadata);
+    regions.extend_from_slice(&region6);
+    regions.extend_from_slice(&region7);
+    regions
+}
+
+fn u32_bytes(values: &[u32]) -> Vec<u8> {
+    values
+        .iter()
+        .flat_map(|value| value.to_le_bytes())
+        .collect()
+}
+
+fn product(extents: &[usize]) -> Option<usize> {
+    extents.iter().try_fold(1usize, |acc, &dim| acc.checked_mul(dim))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metadata_layout_matches_matlab() {
+        assert_eq!(
+            create_string_object_metadata(7),
+            [MCOS_MAGIC_NUMBER, 2, 1, 1, 7, 1]
+        );
+    }
+
+    #[test]
+    fn saveobj_roundtrips_one_string() {
+        let payload = encode_string_saveobj_payload(&["hello".to_owned()], &[1, 1]).unwrap();
+        // [VERSION=1, ndims=2, dim0=1, dim1=1, len0=5, then UTF-16 packed]
+        assert_eq!(&payload[..5], &[1, 2, 1, 1, 5]);
+    }
+
+    #[test]
+    fn saveobj_validates_dim_product() {
+        let err = encode_string_saveobj_payload(
+            &["a".to_owned(), "b".to_owned()],
+            &[3, 1],
+        )
+        .unwrap_err();
+        assert!(matches!(err, MatError::Custom(_)));
+    }
+}

--- a/tests/cell_array.rs
+++ b/tests/cell_array.rs
@@ -144,7 +144,9 @@ fn nested_vec_of_vec_produces_cell_of_cells() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("nested.mat");
 
-    // Mimic the soul-rs `rx_data: Vec<Vec<Option<RxData>>>` shape.
+    // `Vec<Vec<Option<Struct>>>`: rows of optional points. Each outer
+    // entry is a cell of inner refs; missing inner elements become
+    // `struct([])` markers.
     let root = NestedSeq {
         rows: vec![
             vec![Some(Point { x: 1.0, y: 1.0 }), None],

--- a/tests/mat_builder.rs
+++ b/tests/mat_builder.rs
@@ -1,0 +1,233 @@
+//! Direct tests for the public `mat::MatBuilder` API.
+
+use hdf5_pure::mat::{MatBuilder, MatClass, Options, StringClass};
+use hdf5_pure::{AttrValue, File};
+
+fn temp_path(name: &str) -> std::path::PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!("hdf5pure-mat-builder-{name}-{nanos}.mat"))
+}
+
+fn read_class(file: &File, ds_path: &str) -> String {
+    let ds = file.dataset(ds_path).unwrap();
+    let attrs = ds.attrs().unwrap();
+    match &attrs["MATLAB_class"] {
+        AttrValue::AsciiString(s) | AttrValue::String(s) => s.clone(),
+        other => panic!("unexpected class: {other:?}"),
+    }
+}
+
+#[test]
+fn scalar_numeric_classes() {
+    let mut mb = MatBuilder::new(Options::default());
+    mb.write_scalar_f64("d", 1.0).unwrap();
+    mb.write_scalar_f32("s", 2.0).unwrap();
+    mb.write_scalar_i32("i", -3).unwrap();
+    mb.write_scalar_u8("b", 7).unwrap();
+    mb.write_scalar_logical("flag", true).unwrap();
+    let bytes = mb.finish().unwrap();
+
+    let path = temp_path("scalars");
+    std::fs::write(&path, &bytes).unwrap();
+    let f = File::open(&path).unwrap();
+    assert_eq!(read_class(&f, "d"), "double");
+    assert_eq!(read_class(&f, "s"), "single");
+    assert_eq!(read_class(&f, "i"), "int32");
+    assert_eq!(read_class(&f, "b"), "uint8");
+    assert_eq!(read_class(&f, "flag"), "logical");
+    std::fs::remove_file(path).unwrap();
+}
+
+#[test]
+fn vector_round_trips_with_class() {
+    let mut mb = MatBuilder::new(Options::default());
+    let dims = mb.vector_dims(4);
+    mb.write_f64("v", &dims, &[1.0, 2.0, 3.0, 4.0]).unwrap();
+    let bytes = mb.finish().unwrap();
+
+    let path = temp_path("vec");
+    std::fs::write(&path, &bytes).unwrap();
+    let f = File::open(&path).unwrap();
+    let ds = f.dataset("v").unwrap();
+    assert_eq!(ds.read_f64().unwrap(), vec![1.0, 2.0, 3.0, 4.0]);
+    assert_eq!(read_class(&f, "v"), "double");
+    std::fs::remove_file(path).unwrap();
+}
+
+#[test]
+fn struct_with_fields() {
+    let mut mb = MatBuilder::new(Options::default());
+    mb.struct_("payload", |s| {
+        s.write_scalar_u32("answer", 7)?;
+        s.write_char("label", "ready")?;
+        Ok(())
+    })
+    .unwrap();
+    let bytes = mb.finish().unwrap();
+
+    let path = temp_path("struct");
+    std::fs::write(&path, &bytes).unwrap();
+    let f = File::open(&path).unwrap();
+    let group = f.group("payload").unwrap();
+    let attrs = group.attrs().unwrap();
+    let class = match &attrs["MATLAB_class"] {
+        AttrValue::AsciiString(s) | AttrValue::String(s) => s.clone(),
+        other => panic!("unexpected: {other:?}"),
+    };
+    assert_eq!(class, "struct");
+    let fields: Vec<String> = match &attrs["MATLAB_fields"] {
+        AttrValue::AsciiStringArray(arr) | AttrValue::StringArray(arr) => arr.clone(),
+        other => panic!("unexpected: {other:?}"),
+    };
+    assert_eq!(fields, vec!["answer", "label"]);
+    assert_eq!(read_class(&f, "payload/answer"), "uint32");
+    assert_eq!(read_class(&f, "payload/label"), "char");
+    std::fs::remove_file(path).unwrap();
+}
+
+#[test]
+fn cell_with_mixed_elements() {
+    let mut mb = MatBuilder::new(Options::default());
+    mb.cell("c", &[3, 1], |cw| {
+        cw.push_scalar_u8(1)?;
+        cw.push_scalar_f64(3.14)?;
+        cw.push_char("hi")?;
+        Ok(())
+    })
+    .unwrap();
+    let bytes = mb.finish().unwrap();
+
+    let path = temp_path("cell");
+    std::fs::write(&path, &bytes).unwrap();
+    let f = File::open(&path).unwrap();
+    assert_eq!(read_class(&f, "c"), "cell");
+    assert_eq!(read_class(&f, "#refs#/ref_0000000000000000"), "uint8");
+    assert_eq!(read_class(&f, "#refs#/ref_0000000000000001"), "double");
+    assert_eq!(read_class(&f, "#refs#/ref_0000000000000002"), "char");
+    std::fs::remove_file(path).unwrap();
+}
+
+#[test]
+fn nested_struct_and_cell() {
+    let mut mb = MatBuilder::new(Options::default());
+    mb.struct_("root", |s| {
+        s.cell("entries", &[2, 1], |cw| {
+            cw.push_struct(|inner| {
+                inner.write_scalar_u32("x", 1)?;
+                Ok(())
+            })?;
+            cw.push_scalar_u32(2)?;
+            Ok(())
+        })?;
+        Ok(())
+    })
+    .unwrap();
+    let bytes = mb.finish().unwrap();
+
+    let path = temp_path("nested");
+    std::fs::write(&path, &bytes).unwrap();
+    let f = File::open(&path).unwrap();
+    assert_eq!(read_class(&f, "root/entries"), "cell");
+    // First ref is the inner struct (ref_0).
+    let g = f.group("#refs#/ref_0000000000000000").unwrap();
+    let attrs = g.attrs().unwrap();
+    let class = match &attrs["MATLAB_class"] {
+        AttrValue::AsciiString(s) | AttrValue::String(s) => s.clone(),
+        _ => panic!(),
+    };
+    assert_eq!(class, "struct");
+    assert_eq!(read_class(&f, "#refs#/ref_0000000000000000/x"), "uint32");
+    // Second ref is the scalar.
+    assert_eq!(read_class(&f, "#refs#/ref_0000000000000001"), "uint32");
+    std::fs::remove_file(path).unwrap();
+}
+
+#[test]
+fn string_object_emits_subsystem() {
+    let mut options = Options::default();
+    options.string_class = StringClass::String;
+    let mut mb = MatBuilder::new(options);
+    mb.write_string_object("greeting", &["hello".to_owned()], &[1, 1])
+        .unwrap();
+    let bytes = mb.finish().unwrap();
+
+    let path = temp_path("string-obj");
+    std::fs::write(&path, &bytes).unwrap();
+    let f = File::open(&path).unwrap();
+    assert_eq!(read_class(&f, "greeting"), "string");
+    let ds = f.dataset("greeting").unwrap();
+    let attrs = ds.attrs().unwrap();
+    let decode = match &attrs["MATLAB_object_decode"] {
+        AttrValue::I64(v) => *v,
+        AttrValue::I32(v) => *v as i64,
+        other => panic!("unexpected: {other:?}"),
+    };
+    assert_eq!(decode, 3);
+    // Subsystem must be present.
+    let sub = f.dataset("#subsystem#/MCOS").unwrap();
+    let sub_attrs = sub.attrs().unwrap();
+    let sub_class = match &sub_attrs["MATLAB_class"] {
+        AttrValue::AsciiString(s) | AttrValue::String(s) => s.clone(),
+        _ => panic!(),
+    };
+    assert_eq!(sub_class, "FileWrapper__");
+    // 5 helpers + 1 string payload = 6 entries total.
+    assert_eq!(sub.shape().unwrap(), vec![1, 6]);
+    std::fs::remove_file(path).unwrap();
+}
+
+#[test]
+fn name_sanitization_handles_keyword() {
+    let mut options = Options::default();
+    options.invalid_name_policy = hdf5_pure::mat::InvalidNamePolicy::Sanitize;
+    let mut mb = MatBuilder::new(options);
+    mb.struct_("payload", |s| {
+        // `end` is a MATLAB keyword and must be sanitized.
+        s.write_scalar_u32("end", 1)?;
+        Ok(())
+    })
+    .unwrap();
+    let bytes = mb.finish().unwrap();
+
+    let path = temp_path("sanitize");
+    std::fs::write(&path, &bytes).unwrap();
+    let f = File::open(&path).unwrap();
+    // Sanitize appends `_` to keyword.
+    assert_eq!(read_class(&f, "payload/end_"), "uint32");
+    std::fs::remove_file(path).unwrap();
+}
+
+#[test]
+fn invalid_name_errors_by_default() {
+    let mut mb = MatBuilder::new(Options::default());
+    let err = mb.struct_("payload", |s| {
+        s.write_scalar_u32("end", 1)?;
+        Ok(())
+    });
+    assert!(err.is_err());
+}
+
+#[test]
+fn empty_marker_zero_element_default() {
+    let mut mb = MatBuilder::new(Options::default());
+    mb.write_empty("empty", MatClass::Double, &[0, 0]).unwrap();
+    let bytes = mb.finish().unwrap();
+
+    let path = temp_path("empty");
+    std::fs::write(&path, &bytes).unwrap();
+    let f = File::open(&path).unwrap();
+    let ds = f.dataset("empty").unwrap();
+    assert_eq!(ds.shape().unwrap(), vec![0, 0]);
+    let attrs = ds.attrs().unwrap();
+    let empty = match &attrs["MATLAB_empty"] {
+        AttrValue::U32(v) => *v as u64,
+        AttrValue::U64(v) => *v,
+        AttrValue::I32(v) => *v as u64,
+        other => panic!("unexpected: {other:?}"),
+    };
+    assert_eq!(empty, 1);
+    std::fs::remove_file(path).unwrap();
+}

--- a/tests/serde_with_options.rs
+++ b/tests/serde_with_options.rs
@@ -1,0 +1,151 @@
+//! Tests for the new `to_bytes_with_options` / `to_file_with_options` API.
+
+use hdf5_pure::mat::{
+    self, Compression, EmptyMarkerEncoding, InvalidNamePolicy, Options, StringClass,
+};
+use hdf5_pure::{AttrValue, File};
+use serde::{Deserialize, Serialize};
+
+fn temp_path(name: &str) -> std::path::PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!("hdf5pure-mat-opts-{name}-{nanos}.mat"))
+}
+
+fn read_class(file: &File, ds_path: &str) -> String {
+    let ds = file.dataset(ds_path).unwrap();
+    let attrs = ds.attrs().unwrap();
+    match &attrs["MATLAB_class"] {
+        AttrValue::AsciiString(s) | AttrValue::String(s) => s.clone(),
+        other => panic!("unexpected class: {other:?}"),
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct Doc {
+    name: String,
+    score: f64,
+}
+
+#[test]
+fn default_options_produce_char_strings() {
+    let doc = Doc {
+        name: "alice".into(),
+        score: 9.5,
+    };
+    let bytes = mat::to_bytes_with_options(&doc, &Options::default()).unwrap();
+    let path = temp_path("default-char");
+    std::fs::write(&path, &bytes).unwrap();
+    let f = File::open(&path).unwrap();
+    assert_eq!(read_class(&f, "name"), "char");
+    assert_eq!(read_class(&f, "score"), "double");
+    std::fs::remove_file(path).unwrap();
+}
+
+#[test]
+fn string_class_option_produces_string_objects() {
+    let doc = Doc {
+        name: "alice".into(),
+        score: 9.5,
+    };
+    let mut opts = Options::default();
+    opts.string_class = StringClass::String;
+    let bytes = mat::to_bytes_with_options(&doc, &opts).unwrap();
+    let path = temp_path("string-class");
+    std::fs::write(&path, &bytes).unwrap();
+    let f = File::open(&path).unwrap();
+    assert_eq!(read_class(&f, "name"), "string");
+    let sub = f.dataset("#subsystem#/MCOS").unwrap();
+    let sub_attrs = sub.attrs().unwrap();
+    let sub_class = match &sub_attrs["MATLAB_class"] {
+        AttrValue::AsciiString(s) | AttrValue::String(s) => s.clone(),
+        _ => panic!(),
+    };
+    assert_eq!(sub_class, "FileWrapper__");
+    std::fs::remove_file(path).unwrap();
+}
+
+#[derive(Serialize)]
+struct WithKeyword {
+    end: u32,
+}
+
+#[test]
+fn sanitize_policy_rewrites_keywords() {
+    let doc = WithKeyword { end: 5 };
+    let mut opts = Options::default();
+    opts.invalid_name_policy = InvalidNamePolicy::Sanitize;
+    let bytes = mat::to_bytes_with_options(&doc, &opts).unwrap();
+    let path = temp_path("sanitize");
+    std::fs::write(&path, &bytes).unwrap();
+    let f = File::open(&path).unwrap();
+    assert_eq!(read_class(&f, "end_"), "uint32");
+    std::fs::remove_file(path).unwrap();
+}
+
+#[test]
+fn error_policy_rejects_keywords() {
+    let doc = WithKeyword { end: 5 };
+    let mut opts = Options::default();
+    opts.invalid_name_policy = InvalidNamePolicy::Error;
+    let err = mat::to_bytes_with_options(&doc, &opts).unwrap_err();
+    assert!(err.to_string().contains("invalid MATLAB name"));
+}
+
+#[derive(Serialize)]
+struct Big {
+    payload: Vec<f64>,
+}
+
+#[test]
+fn deflate_compression_shrinks_repetitive_data() {
+    // 1 MB of zeros should compress dramatically.
+    let doc = Big {
+        payload: vec![0.0; 128 * 1024],
+    };
+    let plain = mat::to_bytes_with_options(&doc, &Options::default()).unwrap();
+    let mut opts = Options::default();
+    opts.compression = Compression::Deflate {
+        level: 6,
+        shuffle: true,
+    };
+    let compressed = mat::to_bytes_with_options(&doc, &opts).unwrap();
+    assert!(
+        compressed.len() < plain.len() / 2,
+        "compressed {} not less than half of plain {}",
+        compressed.len(),
+        plain.len()
+    );
+}
+
+#[test]
+fn data_as_dims_empty_marker_encoding() {
+    #[derive(Serialize)]
+    struct OnlyEmpty {
+        v: Vec<f64>,
+    }
+    let doc = OnlyEmpty { v: Vec::new() };
+    let mut opts = Options::default();
+    opts.empty_marker_encoding = EmptyMarkerEncoding::DataAsDims;
+    let bytes = mat::to_bytes_with_options(&doc, &opts).unwrap();
+    let path = temp_path("data-as-dims");
+    std::fs::write(&path, &bytes).unwrap();
+    let f = File::open(&path).unwrap();
+    let ds = f.dataset("v").unwrap();
+    let attrs = ds.attrs().unwrap();
+    let empty = match &attrs["MATLAB_empty"] {
+        AttrValue::U32(v) => *v as u64,
+        AttrValue::U64(v) => *v,
+        AttrValue::I32(v) => *v as u64,
+        other => panic!("unexpected: {other:?}"),
+    };
+    assert_eq!(empty, 1);
+    // data-as-dims encoding stores the dimension vector as the data. Under
+    // the default ColumnVector mode an empty `Vec<f64>` has MATLAB shape
+    // `[0, 1]`, so the data-as-dims payload is `[0, 1]`.
+    let data = ds.read_u64().unwrap();
+    assert_eq!(data, vec![0, 1]);
+    std::fs::remove_file(path).unwrap();
+}


### PR DESCRIPTION
## Summary
- New mid-level `MatBuilder` writer API for MAT v7.3 (HDF5 with MATLAB conventions): streams output, applies `MATLAB_class` / `MATLAB_empty` / `#refs#` / `#subsystem#/MCOS` internally, no intermediate value tree.
- Reorganizes `src/mat` into `builder` / `options` / `identifier` / `dims` / `string_object` modules; convention helpers and the builder are now available without the `serde` feature.
- Serde writer preserved; new `to_bytes_with_options` and `to_file_with_options` route through `MatBuilder` so callers can pick `StringClass`, `OneDimensionalMode`, `Compression`, `EmptyMarkerEncoding`, `InvalidNamePolicy`, etc.
- Hot path: stack-buffered HDF5 dim conversion, `[usize; 2]` from `vector_dims`, `HashSet` for name dedup, single-pass UTF-16 string saveobj encoding, 32x32 cache-tiled transpose.
- Bumps to 0.4.0.

## Test plan
- [x] `cargo test --features serde` (537 tests pass, including new `tests/mat_builder.rs` and `tests/serde_with_options.rs`)
- [x] `cargo build --features serde --release` clean
- [x] Existing `examples/matlab_fixtures.rs` still produces valid MAT files