### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: Test (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: default
+            flags: ""
+          - name: serde
+            flags: --features serde
+          - name: zfp
+            flags: --features zfp
+          # `matio-crosscheck` is intentionally excluded: it links against the
+          # system libmatio and is meant for maintainer-local crosscheck runs.
+          - name: full
+            flags: --features "serde zfp fast-deflate fast-checksum provenance mmap parallel"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.name }}
+      - run: cargo test --locked ${{ matrix.flags }}
+
+  no-std-check:
+    name: Check (no_std)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: no-std
+      - run: cargo check --locked --no-default-features
+
+  wasm:
+    name: Build (wasm32-unknown-unknown)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: wasm32
+      - name: Check (no default features)
+        run: cargo check --locked --target wasm32-unknown-unknown --no-default-features
+      - name: Check (default features)
+        run: cargo check --locked --target wasm32-unknown-unknown

--- a/tests/serde_with_options.rs
+++ b/tests/serde_with_options.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "serde")]
 //! Tests for the new `to_bytes_with_options` / `to_file_with_options` API.
 
 use hdf5_pure::mat::{


### PR DESCRIPTION
## Summary
Adds a `CI` workflow that runs on every push to `main` and every PR:

- **test** — feature matrix (default / `serde` / `zfp` / "everything except `matio-crosscheck`") via `cargo test --locked`. `matio-crosscheck` is intentionally skipped because it links against system libmatio and is meant for maintainer-local crosscheck runs.
- **no-std-check** — `cargo check --no-default-features` so non-std builds don't regress.
- **wasm** — `cargo check` for `wasm32-unknown-unknown` with both `--no-default-features` and default features. Verifies the WASM compatibility the crate advertises actually holds.

Linux only, cached via `Swatinem/rust-cache@v2`. The slow part is the `hdf5-metno` dev-dep static-building HDF5 from source for the test matrix; cache makes subsequent runs minutes-not-tens-of-minutes (per-matrix `key` keeps caches scoped).

## Deferred
Lint enforcement (`cargo fmt --check`, `cargo clippy -D warnings`) is **not** included. The codebase predates these tools and currently has ~50 fmt diffs and ~33 clippy lints. Worth a follow-up cleanup PR; once the codebase is on the rails, it's ~10 lines to add a `lint` job.

## Test plan
- [x] `cargo test --features serde` passes locally (537 tests)
- [x] `cargo check --no-default-features` passes locally
- [x] `cargo check --target wasm32-unknown-unknown --no-default-features` passes locally
- [x] `cargo check --target wasm32-unknown-unknown` passes locally
- [ ] First CI run validates all four matrix entries on Linux (HDF5 static build will be slow on cold cache, ~5-10 min)