### PR TITLE
Add fmt + clippy CI; bring codebase into compliance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,19 @@ jobs:
         run: cargo check --locked --target wasm32-unknown-unknown --no-default-features
       - name: Check (default features)
         run: cargo check --locked --target wasm32-unknown-unknown
+
+  lint:
+    name: Lint (fmt, clippy)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: lint
+      - name: Rustfmt
+        run: cargo fmt --all -- --check
+      - name: Clippy
+        run: cargo clippy --locked --features serde --all-targets -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,26 @@ ndarray = "0.16"
 [[example]]
 name = "matlab_fixtures"
 required-features = ["serde"]
+
+# Style-preference clippy lints muted crate-wide. The remaining clippy
+# surface is still on (`-D warnings` in CI), so genuinely problematic
+# patterns continue to fail the build.
+[lints.clippy]
+# Low-level binary format code naturally has many fields per call site
+# (file_data, dataspace, datatype, layout, cache, ...). Default 7 is too tight.
+too_many_arguments = "allow"
+# Incremental bytestream construction reads more naturally as
+# `let mut buf = Vec::new(); buf.push(...);` than the equivalent `vec![...]`.
+vec_init_then_push = "allow"
+same_item_push = "allow"
+# Index-based loops are sometimes the clearest way to express the access pattern.
+needless_range_loop = "allow"
+# We prefer the explicit forms.
+collapsible_if = "allow"
+collapsible_match = "allow"
+collapsible_else_if = "allow"
+manual_div_ceil = "allow"
+manual_is_multiple_of = "allow"
+unnecessary_map_or = "allow"
+# Approximate float constants in tests/fixtures are intentional.
+approx_constant = "allow"

--- a/examples/matlab_fixtures.rs
+++ b/examples/matlab_fixtures.rs
@@ -174,7 +174,9 @@ fn write_matrix(dir: &Path) {
     let a = Matrix::from_row_major(
         3,
         4,
-        vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0],
+        vec![
+            1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
+        ],
     );
     let id = Matrix::from_row_major(2, 2, vec![1.0, 0.0, 0.0, 1.0]);
     let v = Matrices { a, id };
@@ -259,7 +261,9 @@ fn write_nested_struct(dir: &Path) {
     };
     // Wrap in a struct so the file has one top-level variable named `e`.
     #[derive(Serialize)]
-    struct Wrap<'a> { e: &'a Experiment }
+    struct Wrap<'a> {
+        e: &'a Experiment,
+    }
     mat::to_file(&Wrap { e: &v }, dir.join("nested.mat")).unwrap();
     println!("wrote: nested.mat");
 }
@@ -350,7 +354,9 @@ fn write_unit_enum(dir: &Path) {
             "disp('enum.mat OK')",
         ],
     );
-    let v = UnitEnum { phase: Phase::Running };
+    let v = UnitEnum {
+        phase: Phase::Running,
+    };
     mat::to_file(&v, dir.join("enum.mat")).unwrap();
     println!("wrote: enum.mat");
 }
@@ -603,17 +609,31 @@ fn write_complex_edges(dir: &Path) {
 
 /// 4-level deep struct nesting.
 #[derive(Serialize, Deserialize)]
-struct Root { label: String, inner: Inner }
+struct Root {
+    label: String,
+    inner: Inner,
+}
 #[derive(Serialize, Deserialize)]
-struct Inner { depth: u32, sub: SubInner }
+struct Inner {
+    depth: u32,
+    sub: SubInner,
+}
 #[derive(Serialize, Deserialize)]
-struct SubInner { tag: String, leaf: Leaf }
+struct SubInner {
+    tag: String,
+    leaf: Leaf,
+}
 #[derive(Serialize, Deserialize)]
-struct Leaf { id: u64, values: Vec<f64> }
+struct Leaf {
+    id: u64,
+    values: Vec<f64>,
+}
 
 fn write_deep_nested(dir: &Path) {
     #[derive(Serialize)]
-    struct Wrap { root: Root }
+    struct Wrap {
+        root: Root,
+    }
     let v = Wrap {
         root: Root {
             label: "top".into(),
@@ -621,7 +641,10 @@ fn write_deep_nested(dir: &Path) {
                 depth: 2,
                 sub: SubInner {
                     tag: "middle".into(),
-                    leaf: Leaf { id: 12345, values: vec![1.5, 2.5, 3.5] },
+                    leaf: Leaf {
+                        id: 12345,
+                        values: vec![1.5, 2.5, 3.5],
+                    },
                 },
             },
         },
@@ -665,8 +688,12 @@ struct EmptyVariants {
 
 fn write_empty_variants(dir: &Path) {
     let v = EmptyVariants {
-        e_f64: vec![], e_f32: vec![], e_i32: vec![], e_u8: vec![],
-        e_bool: vec![], e_str: String::new(),
+        e_f64: vec![],
+        e_f32: vec![],
+        e_i32: vec![],
+        e_u8: vec![],
+        e_bool: vec![],
+        e_str: String::new(),
     };
     mat::to_file(&v, dir.join("empty_variants.mat")).unwrap();
     println!("wrote: empty_variants.mat");

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -4,7 +4,7 @@
 use alloc::{string::String, vec::Vec};
 
 use crate::attribute_info::AttributeInfoMessage;
-use crate::btree_v2::{collect_btree_v2_records, BTreeV2Header};
+use crate::btree_v2::{BTreeV2Header, collect_btree_v2_records};
 use crate::data_read;
 use crate::dataspace::Dataspace;
 use crate::datatype::Datatype;
@@ -246,7 +246,12 @@ impl AttributeMessage {
 }
 
 /// Compute raw data size based on dataspace and datatype, then extract from message bytes.
-fn compute_raw_data(data: &[u8], pos: usize, dataspace: &Dataspace, datatype: &Datatype) -> Vec<u8> {
+fn compute_raw_data(
+    data: &[u8],
+    pos: usize,
+    dataspace: &Dataspace,
+    datatype: &Datatype,
+) -> Vec<u8> {
     let num_elements = dataspace.num_elements() as usize;
     let elem_size = datatype.type_size() as usize;
     let expected_size = num_elements * elem_size;
@@ -332,12 +337,12 @@ pub fn extract_attributes_full(
 
     // Check for dense attributes via AttributeInfo message
     let attr_info = find_attribute_info(header, offset_size)?;
-    if let Some(info) = attr_info {
-        if let Some(fh_addr) = info.fractal_heap_address {
-            let dense_attrs =
-                extract_dense_attributes(file_data, &info, fh_addr, offset_size, length_size)?;
-            attrs.extend(dense_attrs);
-        }
+    if let Some(info) = attr_info
+        && let Some(fh_addr) = info.fractal_heap_address
+    {
+        let dense_attrs =
+            extract_dense_attributes(file_data, &info, fh_addr, offset_size, length_size)?;
+        attrs.extend(dense_attrs);
     }
 
     Ok(attrs)
@@ -369,14 +374,13 @@ fn extract_dense_attributes(
     let fh = FractalHeapHeader::parse(file_data, fh_addr as usize, offset_size, length_size)?;
 
     // Parse B-tree v2 for name index (type 8)
-    let btree_addr = attr_info.btree_name_index_address.ok_or(
-        FormatError::UnexpectedEof {
+    let btree_addr = attr_info
+        .btree_name_index_address
+        .ok_or(FormatError::UnexpectedEof {
             expected: 1,
             available: 0,
-        }
-    )?;
-    let btree_hdr =
-        BTreeV2Header::parse(file_data, btree_addr as usize, offset_size, length_size)?;
+        })?;
+    let btree_hdr = BTreeV2Header::parse(file_data, btree_addr as usize, offset_size, length_size)?;
     let records = collect_btree_v2_records(file_data, &btree_hdr, offset_size, length_size)?;
 
     let mut attrs = Vec::new();
@@ -467,14 +471,13 @@ mod tests {
 
         // Name padded to 8 bytes
         data.extend_from_slice(name);
-        while data.len() % 8 != 0 || data.len() == 8 {
+        if data.len() % 8 != 0 || data.len() == 8 {
             // Pad name to 8-byte boundary from start of name
             let name_start = 8;
             let name_padded = pad8(name_size);
             while data.len() < name_start + name_padded {
                 data.push(0);
             }
-            break;
         }
 
         // Datatype padded to 8 bytes

--- a/src/attribute_info.rs
+++ b/src/attribute_info.rs
@@ -30,8 +30,14 @@ fn read_offset(data: &[u8], pos: usize, size: u8) -> Result<u64, FormatError> {
         2 => u16::from_le_bytes([data[pos], data[pos + 1]]) as u64,
         4 => u32::from_le_bytes([data[pos], data[pos + 1], data[pos + 2], data[pos + 3]]) as u64,
         8 => u64::from_le_bytes([
-            data[pos], data[pos + 1], data[pos + 2], data[pos + 3],
-            data[pos + 4], data[pos + 5], data[pos + 6], data[pos + 7],
+            data[pos],
+            data[pos + 1],
+            data[pos + 2],
+            data[pos + 3],
+            data[pos + 4],
+            data[pos + 5],
+            data[pos + 6],
+            data[pos + 7],
         ]),
         _ => return Err(FormatError::InvalidOffsetSize(size)),
     })

--- a/src/btree_v1.rs
+++ b/src/btree_v1.rs
@@ -148,7 +148,12 @@ pub fn collect_symbol_table_nodes(
     length_size: u8,
     base_address: u64,
 ) -> Result<Vec<u64>, FormatError> {
-    let node = BTreeV1Node::parse(file_data, (btree_address + base_address) as usize, offset_size, length_size)?;
+    let node = BTreeV1Node::parse(
+        file_data,
+        (btree_address + base_address) as usize,
+        offset_size,
+        length_size,
+    )?;
 
     if node.node_type != 0 {
         return Err(FormatError::InvalidBTreeNodeType(node.node_type));
@@ -161,8 +166,13 @@ pub fn collect_symbol_table_nodes(
         // Internal: recurse into children (child addresses are relative to base_address)
         let mut result = Vec::new();
         for &child_addr in &node.children {
-            let child_snods =
-                collect_symbol_table_nodes(file_data, child_addr, offset_size, length_size, base_address)?;
+            let child_snods = collect_symbol_table_nodes(
+                file_data,
+                child_addr,
+                offset_size,
+                length_size,
+                base_address,
+            )?;
             result.extend(child_snods);
         }
         Ok(result)
@@ -197,7 +207,11 @@ mod tests {
         buf.push(node_type);
         buf.push(level);
         buf.extend_from_slice(&entries_used.to_le_bytes());
-        let undef: u64 = if offset_size == 4 { 0xFFFFFFFF } else { 0xFFFFFFFFFFFFFFFF };
+        let undef: u64 = if offset_size == 4 {
+            0xFFFFFFFF
+        } else {
+            0xFFFFFFFFFFFFFFFF
+        };
         write_offset(&mut buf, left.unwrap_or(undef), offset_size);
         write_offset(&mut buf, right.unwrap_or(undef), offset_size);
         for i in 0..children.len() {
@@ -240,10 +254,13 @@ mod tests {
         let leaf1 = build_btree_node(0, 0, &[0, 5], &[0xA00], None, None, os);
         let leaf2 = build_btree_node(0, 0, &[5, 10], &[0xB00], None, None, os);
         let internal = build_btree_node(
-            0, 1,
+            0,
+            1,
             &[0, 5, 10],
             &[leaf1_offset as u64, leaf2_offset as u64],
-            None, None, os,
+            None,
+            None,
+            os,
         );
 
         let mut file = vec![0u8; 1024];

--- a/src/btree_v2.rs
+++ b/src/btree_v2.rs
@@ -46,8 +46,14 @@ fn read_offset(data: &[u8], pos: usize, size: u8) -> Result<u64, FormatError> {
         2 => u16::from_le_bytes([data[pos], data[pos + 1]]) as u64,
         4 => u32::from_le_bytes([data[pos], data[pos + 1], data[pos + 2], data[pos + 3]]) as u64,
         8 => u64::from_le_bytes([
-            data[pos], data[pos + 1], data[pos + 2], data[pos + 3],
-            data[pos + 4], data[pos + 5], data[pos + 6], data[pos + 7],
+            data[pos],
+            data[pos + 1],
+            data[pos + 2],
+            data[pos + 3],
+            data[pos + 4],
+            data[pos + 5],
+            data[pos + 6],
+            data[pos + 7],
         ]),
         _ => return Err(FormatError::InvalidOffsetSize(size)),
     })
@@ -119,8 +125,7 @@ impl BTreeV2Header {
         pos += offset_size as usize;
 
         ensure_len(file_data, pos, 2)?;
-        let num_records_in_root =
-            u16::from_le_bytes([file_data[pos], file_data[pos + 1]]);
+        let num_records_in_root = u16::from_le_bytes([file_data[pos], file_data[pos + 1]]);
         pos += 2;
 
         let total_records = read_offset(file_data, pos, length_size)?;
@@ -321,12 +326,8 @@ fn collect_internal_records(
     // We collect child[0] records, then record[0], then child[1], etc.
     for (i, &(child_addr, child_nrec)) in children.iter().enumerate() {
         if child_depth == 0 {
-            let leaf_recs = parse_leaf_records(
-                file_data,
-                child_addr as usize,
-                child_nrec,
-                record_size,
-            )?;
+            let leaf_recs =
+                parse_leaf_records(file_data, child_addr as usize, child_nrec, record_size)?;
             out.extend(leaf_recs);
         } else {
             collect_internal_records(

--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -67,22 +67,41 @@ fn rot(x: u32, k: u32) -> u32 {
 }
 
 fn mix(a: &mut u32, b: &mut u32, c: &mut u32) {
-    *a = a.wrapping_sub(*c); *a ^= rot(*c, 4);  *c = c.wrapping_add(*b);
-    *b = b.wrapping_sub(*a); *b ^= rot(*a, 6);  *a = a.wrapping_add(*c);
-    *c = c.wrapping_sub(*b); *c ^= rot(*b, 8);  *b = b.wrapping_add(*a);
-    *a = a.wrapping_sub(*c); *a ^= rot(*c, 16); *c = c.wrapping_add(*b);
-    *b = b.wrapping_sub(*a); *b ^= rot(*a, 19); *a = a.wrapping_add(*c);
-    *c = c.wrapping_sub(*b); *c ^= rot(*b, 4);  *b = b.wrapping_add(*a);
+    *a = a.wrapping_sub(*c);
+    *a ^= rot(*c, 4);
+    *c = c.wrapping_add(*b);
+    *b = b.wrapping_sub(*a);
+    *b ^= rot(*a, 6);
+    *a = a.wrapping_add(*c);
+    *c = c.wrapping_sub(*b);
+    *c ^= rot(*b, 8);
+    *b = b.wrapping_add(*a);
+    *a = a.wrapping_sub(*c);
+    *a ^= rot(*c, 16);
+    *c = c.wrapping_add(*b);
+    *b = b.wrapping_sub(*a);
+    *b ^= rot(*a, 19);
+    *a = a.wrapping_add(*c);
+    *c = c.wrapping_sub(*b);
+    *c ^= rot(*b, 4);
+    *b = b.wrapping_add(*a);
 }
 
 fn final_mix(a: &mut u32, b: &mut u32, c: &mut u32) {
-    *c ^= *b; *c = c.wrapping_sub(rot(*b, 14));
-    *a ^= *c; *a = a.wrapping_sub(rot(*c, 11));
-    *b ^= *a; *b = b.wrapping_sub(rot(*a, 25));
-    *c ^= *b; *c = c.wrapping_sub(rot(*b, 16));
-    *a ^= *c; *a = a.wrapping_sub(rot(*c, 4));
-    *b ^= *a; *b = b.wrapping_sub(rot(*a, 14));
-    *c ^= *b; *c = c.wrapping_sub(rot(*b, 24));
+    *c ^= *b;
+    *c = c.wrapping_sub(rot(*b, 14));
+    *a ^= *c;
+    *a = a.wrapping_sub(rot(*c, 11));
+    *b ^= *a;
+    *b = b.wrapping_sub(rot(*a, 25));
+    *c ^= *b;
+    *c = c.wrapping_sub(rot(*b, 16));
+    *a ^= *c;
+    *a = a.wrapping_sub(rot(*c, 4));
+    *b ^= *a;
+    *b = b.wrapping_sub(rot(*a, 14));
+    *c ^= *b;
+    *c = c.wrapping_sub(rot(*b, 24));
 }
 
 fn read_u32_le(data: &[u8], offset: usize) -> u32 {
@@ -96,7 +115,9 @@ fn read_u32_le(data: &[u8], offset: usize) -> u32 {
 
 fn hashlittle(data: &[u8], initval: u32) -> u32 {
     let length = data.len();
-    let mut a: u32 = 0xdeadbeefu32.wrapping_add(length as u32).wrapping_add(initval);
+    let mut a: u32 = 0xdeadbeefu32
+        .wrapping_add(length as u32)
+        .wrapping_add(initval);
     let mut b: u32 = a;
     let mut c: u32 = a;
 
@@ -235,11 +256,13 @@ mod tests {
         // Verify against a real HDF5 file checksum
         let file_data: &[u8] = include_bytes!("../tests/fixtures/v2_groups.h5");
         // Superblock v3: checksum at offset 44, covers bytes 0..44
-        let stored = u32::from_le_bytes([
-            file_data[44], file_data[45], file_data[46], file_data[47],
-        ]);
+        let stored =
+            u32::from_le_bytes([file_data[44], file_data[45], file_data[46], file_data[47]]);
         let computed = jenkins_lookup3(&file_data[0..44]);
-        assert_eq!(computed, stored, "Jenkins lookup3 should match HDF5 superblock checksum");
+        assert_eq!(
+            computed, stored,
+            "Jenkins lookup3 should match HDF5 superblock checksum"
+        );
     }
 
     // --- CRC32 tests ---

--- a/src/chunk_cache.rs
+++ b/src/chunk_cache.rs
@@ -11,22 +11,22 @@ extern crate alloc;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
-#[cfg(feature = "std")]
-use std::alloc::{alloc_zeroed, dealloc, handle_alloc_error};
 #[cfg(not(feature = "std"))]
 use alloc::alloc::{alloc_zeroed, dealloc, handle_alloc_error};
-
 #[cfg(feature = "std")]
-use std::sync::Mutex;
+use std::alloc::{alloc_zeroed, dealloc, handle_alloc_error};
+
 #[cfg(not(feature = "std"))]
 use crate::nosync::Mutex;
+#[cfg(feature = "std")]
+use std::sync::Mutex;
 
 use core::ops::{Deref, DerefMut};
 
-#[cfg(feature = "std")]
-use std::collections::HashMap;
 #[cfg(not(feature = "std"))]
 use alloc::collections::BTreeMap;
+#[cfg(feature = "std")]
+use std::collections::HashMap;
 
 use crate::chunked_read::ChunkInfo;
 
@@ -160,7 +160,7 @@ impl CacheAlignedBuffer {
     /// Returns `true` if the data pointer is aligned to `CACHE_LINE_SIZE`.
     #[inline]
     pub fn is_aligned(&self) -> bool {
-        self.len == 0 || (self.ptr as usize) % CACHE_LINE_SIZE == 0
+        self.len == 0 || (self.ptr as usize).is_multiple_of(CACHE_LINE_SIZE)
     }
 }
 
@@ -362,9 +362,11 @@ impl ChunkCache {
         let tick = inner.tick;
 
         // Track sequential vs random access
-        let is_sequential = inner.last_coord.as_ref().map_or(false, |prev| {
+        let is_sequential = inner.last_coord.as_ref().is_some_and(|prev| {
             // Sequential if exactly one dimension changed
-            let changes: usize = prev.iter().zip(coord.iter())
+            let changes: usize = prev
+                .iter()
+                .zip(coord.iter())
                 .filter(|(a, b)| a != b)
                 .count();
             changes <= 1
@@ -480,7 +482,9 @@ impl ChunkCache {
         // We touch the stats to record that prefetch hints were issued.
         let mut inner = self.inner.lock().unwrap();
         for coord in next_coords {
-            let exists = inner.index.as_ref()
+            let exists = inner
+                .index
+                .as_ref()
                 .map(|idx| idx.contains_key(coord))
                 .unwrap_or(false);
             if exists {
@@ -698,6 +702,9 @@ mod tests {
         assert_eq!(align_to_cache_line(0), 0);
         assert_eq!(align_to_cache_line(1), CACHE_LINE_SIZE);
         assert_eq!(align_to_cache_line(CACHE_LINE_SIZE), CACHE_LINE_SIZE);
-        assert_eq!(align_to_cache_line(CACHE_LINE_SIZE + 1), CACHE_LINE_SIZE * 2);
+        assert_eq!(
+            align_to_cache_line(CACHE_LINE_SIZE + 1),
+            CACHE_LINE_SIZE * 2
+        );
     }
 }

--- a/src/chunked_read.rs
+++ b/src/chunked_read.rs
@@ -6,14 +6,14 @@ extern crate alloc;
 #[cfg(not(feature = "std"))]
 use alloc::{format, vec, vec::Vec};
 
-use crate::chunk_cache::{ChunkCache, CacheAlignedBuffer};
+use crate::chunk_cache::{CacheAlignedBuffer, ChunkCache};
 use crate::data_layout::DataLayout;
 use crate::dataspace::Dataspace;
 use crate::datatype::Datatype;
 use crate::error::FormatError;
-use crate::filter_pipeline::FilterPipeline;
-use crate::filters::{decompress_chunk, ChunkContext};
 use crate::extensible_array::{ExtensibleArrayHeader, read_extensible_array_chunks};
+use crate::filter_pipeline::FilterPipeline;
+use crate::filters::{ChunkContext, decompress_chunk};
 use crate::fixed_array::{FixedArrayHeader, read_fixed_array_chunks};
 
 #[cfg(feature = "parallel")]
@@ -36,17 +36,9 @@ fn decompress_all_chunks(
         if let Some(pl) = pipeline {
             if parallel_read::should_use_parallel(chunks.len()) {
                 // Seed from the first chunk's address and count for determinism.
-                let seed = chunks.first()
-                    .map(|c| c.address)
-                    .unwrap_or(0)
-                    ^ (chunks.len() as u64);
+                let seed = chunks.first().map(|c| c.address).unwrap_or(0) ^ (chunks.len() as u64);
                 let (data, _stats) = parallel_read::decompress_chunks_lane_partitioned(
-                    file_data,
-                    chunks,
-                    pl,
-                    ctx,
-                    seed,
-                    None, // auto-detect lane count
+                    file_data, chunks, pl, ctx, seed, None, // auto-detect lane count
                 )?;
                 return Ok(data.into_iter().map(CacheAlignedBuffer::from_vec).collect());
             }
@@ -164,8 +156,7 @@ pub fn collect_chunk_info(
     }
 
     let node_level = file_data[offset + 5];
-    let entries_used =
-        u16::from_le_bytes([file_data[offset + 6], file_data[offset + 7]]) as usize;
+    let entries_used = u16::from_le_bytes([file_data[offset + 6], file_data[offset + 7]]) as usize;
 
     let mut pos = offset + 8 + os * 2; // skip left/right sibling
 
@@ -258,8 +249,8 @@ pub fn generate_implicit_chunks(
     element_size: u32,
 ) -> Vec<ChunkInfo> {
     let rank = chunk_dimensions.len();
-    let chunk_byte_size: u64 = chunk_dimensions.iter().map(|&d| d as u64).product::<u64>()
-        * element_size as u64;
+    let chunk_byte_size: u64 =
+        chunk_dimensions.iter().map(|&d| d as u64).product::<u64>() * element_size as u64;
 
     let mut num_chunks_per_dim = Vec::with_capacity(rank);
     for d in 0..rank {
@@ -301,8 +292,14 @@ pub fn read_chunked_data(
     offset_size: u8,
     length_size: u8,
 ) -> Result<Vec<u8>, FormatError> {
-    let (chunk_dimensions, version, chunk_index_type, addr_opt,
-         single_filtered_size, single_filter_mask) = match layout {
+    let (
+        chunk_dimensions,
+        version,
+        chunk_index_type,
+        addr_opt,
+        single_filtered_size,
+        single_filter_mask,
+    ) = match layout {
         DataLayout::Chunked {
             chunk_dimensions,
             btree_address,
@@ -310,18 +307,23 @@ pub fn read_chunked_data(
             chunk_index_type,
             single_chunk_filtered_size,
             single_chunk_filter_mask,
-        } => (chunk_dimensions, *version, *chunk_index_type, *btree_address,
-              *single_chunk_filtered_size, *single_chunk_filter_mask),
+        } => (
+            chunk_dimensions,
+            *version,
+            *chunk_index_type,
+            *btree_address,
+            *single_chunk_filtered_size,
+            *single_chunk_filter_mask,
+        ),
         _ => {
             return Err(FormatError::ChunkedReadError(
                 "expected chunked layout".into(),
-            ))
+            ));
         }
     };
 
-    let addr = addr_opt.ok_or_else(|| {
-        FormatError::ChunkedReadError("no address for chunked layout".into())
-    })?;
+    let addr = addr_opt
+        .ok_or_else(|| FormatError::ChunkedReadError("no address for chunked layout".into()))?;
 
     let elem_size = datatype.type_size() as usize;
 
@@ -377,27 +379,37 @@ pub fn read_chunked_data(
         (4, Some(3)) => {
             // Fixed Array — use spatial chunk dims only
             let spatial_chunk_dims: Vec<u32> = chunk_dimensions[..rank].to_vec();
-            let header = FixedArrayHeader::parse(file_data, addr as usize, offset_size, length_size)?;
+            let header =
+                FixedArrayHeader::parse(file_data, addr as usize, offset_size, length_size)?;
             read_fixed_array_chunks(
-                file_data, &header, &dataspace.dimensions, &spatial_chunk_dims,
-                elem_size as u32, offset_size, length_size,
+                file_data,
+                &header,
+                &dataspace.dimensions,
+                &spatial_chunk_dims,
+                elem_size as u32,
+                offset_size,
+                length_size,
             )?
         }
         (4, Some(4)) => {
             // Extensible Array — use spatial chunk dims only
             let spatial_chunk_dims: Vec<u32> = chunk_dimensions[..rank].to_vec();
-            let header = ExtensibleArrayHeader::parse(
-                file_data, addr as usize, offset_size, length_size,
-            )?;
+            let header =
+                ExtensibleArrayHeader::parse(file_data, addr as usize, offset_size, length_size)?;
             read_extensible_array_chunks(
-                file_data, &header, &dataspace.dimensions, &spatial_chunk_dims,
-                elem_size as u32, offset_size, length_size,
+                file_data,
+                &header,
+                &dataspace.dimensions,
+                &spatial_chunk_dims,
+                elem_size as u32,
+                offset_size,
+                length_size,
             )?
         }
         (v, idx) => {
             return Err(FormatError::ChunkedReadError(format!(
                 "unsupported chunked layout version={v}, index_type={idx:?}"
-            )))
+            )));
         }
     };
 
@@ -419,16 +431,13 @@ pub fn read_chunked_data(
     // Decompress all chunks (parallel when beneficial, sequential otherwise)
     let chunk_dims_u64: Vec<u64> = chunk_dims.iter().map(|&d| d as u64).collect();
     let ctx = ChunkContext::from_datatype(&chunk_dims_u64, datatype);
-    let decompressed_chunks = decompress_all_chunks(
-        file_data,
-        &chunks,
-        pipeline,
-        ctx,
-    )?;
+    let decompressed_chunks = decompress_all_chunks(file_data, &chunks, pipeline, ctx)?;
 
     for (chunk_info, decompressed) in chunks.iter().zip(decompressed_chunks.iter()) {
         // B-tree v1 (v3) offsets have rank+1 dims; v4 index offsets have rank dims
-        let chunk_offsets: Vec<usize> = chunk_info.offsets.iter()
+        let chunk_offsets: Vec<usize> = chunk_info
+            .offsets
+            .iter()
             .take(rank)
             .map(|&o| o as usize)
             .collect();
@@ -469,8 +478,14 @@ pub fn read_chunked_data_cached(
     length_size: u8,
     cache: &ChunkCache,
 ) -> Result<Vec<u8>, FormatError> {
-    let (chunk_dimensions, version, chunk_index_type, addr_opt,
-         single_filtered_size, single_filter_mask) = match layout {
+    let (
+        chunk_dimensions,
+        version,
+        chunk_index_type,
+        addr_opt,
+        single_filtered_size,
+        single_filter_mask,
+    ) = match layout {
         DataLayout::Chunked {
             chunk_dimensions,
             btree_address,
@@ -478,18 +493,23 @@ pub fn read_chunked_data_cached(
             chunk_index_type,
             single_chunk_filtered_size,
             single_chunk_filter_mask,
-        } => (chunk_dimensions, *version, *chunk_index_type, *btree_address,
-              *single_chunk_filtered_size, *single_chunk_filter_mask),
+        } => (
+            chunk_dimensions,
+            *version,
+            *chunk_index_type,
+            *btree_address,
+            *single_chunk_filtered_size,
+            *single_chunk_filter_mask,
+        ),
         _ => {
             return Err(FormatError::ChunkedReadError(
                 "expected chunked layout".into(),
-            ))
+            ));
         }
     };
 
-    let addr = addr_opt.ok_or_else(|| {
-        FormatError::ChunkedReadError("no address for chunked layout".into())
-    })?;
+    let addr = addr_opt
+        .ok_or_else(|| FormatError::ChunkedReadError("no address for chunked layout".into()))?;
 
     let elem_size = datatype.type_size() as usize;
     let ndims = chunk_dimensions.len();
@@ -503,16 +523,16 @@ pub fn read_chunked_data_cached(
     if ds_dims.len() != rank {
         return Err(FormatError::ChunkedReadError(format!(
             "rank mismatch: dataspace has {} dims, layout has {} chunk dims (rank={})",
-            ds_dims.len(), chunk_dimensions.len(), rank
+            ds_dims.len(),
+            chunk_dimensions.len(),
+            rank
         )));
     }
 
     // Populate chunk index on first access
     if !cache.has_index() {
         let chunks = match (version, chunk_index_type) {
-            (3, _) => {
-                collect_chunk_info(file_data, addr, ndims, offset_size, length_size)?
-            }
+            (3, _) => collect_chunk_info(file_data, addr, ndims, offset_size, length_size)?,
             (4, Some(1)) => {
                 let chunk_byte_size: usize = chunk_dims.iter().product::<usize>() * elem_size;
                 let (csize, fmask) = if let Some(fs) = single_filtered_size {
@@ -529,28 +549,49 @@ pub fn read_chunked_data_cached(
             }
             (4, Some(2)) => {
                 let spatial_chunk_dims: Vec<u32> = chunk_dimensions[..rank].to_vec();
-                generate_implicit_chunks(addr, &dataspace.dimensions, &spatial_chunk_dims, elem_size as u32)
+                generate_implicit_chunks(
+                    addr,
+                    &dataspace.dimensions,
+                    &spatial_chunk_dims,
+                    elem_size as u32,
+                )
             }
             (4, Some(3)) => {
                 let spatial_chunk_dims: Vec<u32> = chunk_dimensions[..rank].to_vec();
-                let header = FixedArrayHeader::parse(file_data, addr as usize, offset_size, length_size)?;
+                let header =
+                    FixedArrayHeader::parse(file_data, addr as usize, offset_size, length_size)?;
                 read_fixed_array_chunks(
-                    file_data, &header, &dataspace.dimensions, &spatial_chunk_dims,
-                    elem_size as u32, offset_size, length_size,
+                    file_data,
+                    &header,
+                    &dataspace.dimensions,
+                    &spatial_chunk_dims,
+                    elem_size as u32,
+                    offset_size,
+                    length_size,
                 )?
             }
             (4, Some(4)) => {
                 let spatial_chunk_dims: Vec<u32> = chunk_dimensions[..rank].to_vec();
-                let header = ExtensibleArrayHeader::parse(file_data, addr as usize, offset_size, length_size)?;
+                let header = ExtensibleArrayHeader::parse(
+                    file_data,
+                    addr as usize,
+                    offset_size,
+                    length_size,
+                )?;
                 read_extensible_array_chunks(
-                    file_data, &header, &dataspace.dimensions, &spatial_chunk_dims,
-                    elem_size as u32, offset_size, length_size,
+                    file_data,
+                    &header,
+                    &dataspace.dimensions,
+                    &spatial_chunk_dims,
+                    elem_size as u32,
+                    offset_size,
+                    length_size,
                 )?
             }
             (v, idx) => {
                 return Err(FormatError::ChunkedReadError(format!(
                     "unsupported chunked layout version={v}, index_type={idx:?}"
-                )))
+                )));
             }
         };
         cache.populate_index(&chunks, rank);
@@ -606,7 +647,9 @@ pub fn read_chunked_data_cached(
             dec
         };
 
-        let chunk_offsets: Vec<usize> = chunk_info.offsets.iter()
+        let chunk_offsets: Vec<usize> = chunk_info
+            .offsets
+            .iter()
             .take(rank)
             .map(|&o| o as usize)
             .collect();
@@ -700,9 +743,8 @@ impl SweepContext {
             }
         }
 
-        let threshold = (num_deltas + 1) / 2;
-        let (max_dim, max_changes) = changing.iter().enumerate()
-            .max_by_key(|(_, c)| *c).unwrap();
+        let threshold = num_deltas.div_ceil(2);
+        let (max_dim, max_changes) = changing.iter().enumerate().max_by_key(|(_, c)| *c).unwrap();
 
         if *max_changes < threshold {
             self.direction = "random";
@@ -710,7 +752,9 @@ impl SweepContext {
             return;
         }
 
-        let others_max = changing.iter().enumerate()
+        let others_max = changing
+            .iter()
+            .enumerate()
             .filter(|(d, _)| *d != max_dim)
             .map(|(_, c)| *c)
             .max()
@@ -786,8 +830,14 @@ pub fn read_chunked_data_sweep(
     cache: &ChunkCache,
     sweep: &mut SweepContext,
 ) -> Result<Vec<u8>, FormatError> {
-    let (chunk_dimensions, version, chunk_index_type, addr_opt,
-         single_filtered_size, single_filter_mask) = match layout {
+    let (
+        chunk_dimensions,
+        version,
+        chunk_index_type,
+        addr_opt,
+        single_filtered_size,
+        single_filter_mask,
+    ) = match layout {
         DataLayout::Chunked {
             chunk_dimensions,
             btree_address,
@@ -795,18 +845,23 @@ pub fn read_chunked_data_sweep(
             chunk_index_type,
             single_chunk_filtered_size,
             single_chunk_filter_mask,
-        } => (chunk_dimensions, *version, *chunk_index_type, *btree_address,
-              *single_chunk_filtered_size, *single_chunk_filter_mask),
+        } => (
+            chunk_dimensions,
+            *version,
+            *chunk_index_type,
+            *btree_address,
+            *single_chunk_filtered_size,
+            *single_chunk_filter_mask,
+        ),
         _ => {
             return Err(FormatError::ChunkedReadError(
                 "expected chunked layout".into(),
-            ))
+            ));
         }
     };
 
-    let addr = addr_opt.ok_or_else(|| {
-        FormatError::ChunkedReadError("no address for chunked layout".into())
-    })?;
+    let addr = addr_opt
+        .ok_or_else(|| FormatError::ChunkedReadError("no address for chunked layout".into()))?;
 
     let elem_size = datatype.type_size() as usize;
     let ndims = chunk_dimensions.len();
@@ -820,16 +875,16 @@ pub fn read_chunked_data_sweep(
     if ds_dims.len() != rank {
         return Err(FormatError::ChunkedReadError(format!(
             "rank mismatch: dataspace has {} dims, layout has {} chunk dims (rank={})",
-            ds_dims.len(), chunk_dimensions.len(), rank
+            ds_dims.len(),
+            chunk_dimensions.len(),
+            rank
         )));
     }
 
     // Populate chunk index on first access
     if !cache.has_index() {
         let chunks = match (version, chunk_index_type) {
-            (3, _) => {
-                collect_chunk_info(file_data, addr, ndims, offset_size, length_size)?
-            }
+            (3, _) => collect_chunk_info(file_data, addr, ndims, offset_size, length_size)?,
             (4, Some(1)) => {
                 let chunk_byte_size: usize = chunk_dims.iter().product::<usize>() * elem_size;
                 let (csize, fmask) = if let Some(fs) = single_filtered_size {
@@ -846,28 +901,49 @@ pub fn read_chunked_data_sweep(
             }
             (4, Some(2)) => {
                 let spatial_chunk_dims: Vec<u32> = chunk_dimensions[..rank].to_vec();
-                generate_implicit_chunks(addr, &dataspace.dimensions, &spatial_chunk_dims, elem_size as u32)
+                generate_implicit_chunks(
+                    addr,
+                    &dataspace.dimensions,
+                    &spatial_chunk_dims,
+                    elem_size as u32,
+                )
             }
             (4, Some(3)) => {
                 let spatial_chunk_dims: Vec<u32> = chunk_dimensions[..rank].to_vec();
-                let header = FixedArrayHeader::parse(file_data, addr as usize, offset_size, length_size)?;
+                let header =
+                    FixedArrayHeader::parse(file_data, addr as usize, offset_size, length_size)?;
                 read_fixed_array_chunks(
-                    file_data, &header, &dataspace.dimensions, &spatial_chunk_dims,
-                    elem_size as u32, offset_size, length_size,
+                    file_data,
+                    &header,
+                    &dataspace.dimensions,
+                    &spatial_chunk_dims,
+                    elem_size as u32,
+                    offset_size,
+                    length_size,
                 )?
             }
             (4, Some(4)) => {
                 let spatial_chunk_dims: Vec<u32> = chunk_dimensions[..rank].to_vec();
-                let header = ExtensibleArrayHeader::parse(file_data, addr as usize, offset_size, length_size)?;
+                let header = ExtensibleArrayHeader::parse(
+                    file_data,
+                    addr as usize,
+                    offset_size,
+                    length_size,
+                )?;
                 read_extensible_array_chunks(
-                    file_data, &header, &dataspace.dimensions, &spatial_chunk_dims,
-                    elem_size as u32, offset_size, length_size,
+                    file_data,
+                    &header,
+                    &dataspace.dimensions,
+                    &spatial_chunk_dims,
+                    elem_size as u32,
+                    offset_size,
+                    length_size,
                 )?
             }
             (v, idx) => {
                 return Err(FormatError::ChunkedReadError(format!(
                     "unsupported chunked layout version={v}, index_type={idx:?}"
-                )))
+                )));
             }
         };
         cache.populate_index(&chunks, rank);
@@ -932,7 +1008,9 @@ pub fn read_chunked_data_sweep(
             dec
         };
 
-        let chunk_offsets: Vec<usize> = chunk_info.offsets.iter()
+        let chunk_offsets: Vec<usize> = chunk_info
+            .offsets
+            .iter()
             .take(rank)
             .map(|&o| o as usize)
             .collect();
@@ -1018,11 +1096,7 @@ mod tests {
     }
 
     /// Build a B-tree v1 type 1 leaf node with given chunk infos.
-    fn build_chunk_btree_leaf(
-        chunks: &[ChunkInfo],
-        ndims: usize,
-        offset_size: u8,
-    ) -> Vec<u8> {
+    fn build_chunk_btree_leaf(chunks: &[ChunkInfo], ndims: usize, offset_size: u8) -> Vec<u8> {
         let _os = offset_size as usize;
         let entries_used = chunks.len() as u16;
         let mut buf = Vec::new();
@@ -1209,8 +1283,7 @@ mod tests {
             // Write chunk data (full chunk size, padding with zeros)
             for i in start..end {
                 let byte_offset = data_offset + (i - start) * elem_size;
-                file_data[byte_offset..byte_offset + 8]
-                    .copy_from_slice(&values[i].to_le_bytes());
+                file_data[byte_offset..byte_offset + 8].copy_from_slice(&values[i].to_le_bytes());
             }
 
             chunk_infos.push(ChunkInfo {
@@ -1254,8 +1327,8 @@ mod tests {
         let (file_data, layout, dataspace) = build_1d_chunked_file(&values, 10);
         let datatype = make_f64_type();
 
-        let raw = read_chunked_data(&file_data, &layout, &dataspace, &datatype, None, 8, 8)
-            .unwrap();
+        let raw =
+            read_chunked_data(&file_data, &layout, &dataspace, &datatype, None, 8, 8).unwrap();
         assert_eq!(raw.len(), 20 * 8);
 
         // Verify values
@@ -1272,8 +1345,8 @@ mod tests {
         let (file_data, layout, dataspace) = build_1d_chunked_file(&values, 10);
         let datatype = make_f64_type();
 
-        let raw = read_chunked_data(&file_data, &layout, &dataspace, &datatype, None, 8, 8)
-            .unwrap();
+        let raw =
+            read_chunked_data(&file_data, &layout, &dataspace, &datatype, None, 8, 8).unwrap();
         assert_eq!(raw.len(), 25 * 8);
 
         for i in 0..25 {
@@ -1285,7 +1358,7 @@ mod tests {
     #[cfg(feature = "deflate")]
     #[test]
     fn read_1d_two_chunks_with_deflate() {
-        use crate::filter_pipeline::{FilterDescription, FilterPipeline, FILTER_DEFLATE};
+        use crate::filter_pipeline::{FILTER_DEFLATE, FilterDescription, FilterPipeline};
         use crate::filters::compress_chunk;
 
         let os: u8 = 8;
@@ -1316,14 +1389,10 @@ mod tests {
                 chunk_bytes.extend_from_slice(&values[i].to_le_bytes());
             }
             let dims_u64 = [chunk_elems as u64];
-            let ctx = crate::filters::ChunkContext::basic(
-                &dims_u64,
-                elem_size as u32,
-            );
+            let ctx = crate::filters::ChunkContext::basic(&dims_u64, elem_size as u32);
             let compressed = compress_chunk(&chunk_bytes, &pipeline, ctx).unwrap();
 
-            file_data[data_offset..data_offset + compressed.len()]
-                .copy_from_slice(&compressed);
+            file_data[data_offset..data_offset + compressed.len()].copy_from_slice(&compressed);
 
             chunk_infos.push(ChunkInfo {
                 chunk_size: compressed.len() as u32,
@@ -1404,8 +1473,7 @@ mod tests {
                 }
 
                 let chunk_size = chunk_bytes.len();
-                file_data[data_offset..data_offset + chunk_size]
-                    .copy_from_slice(&chunk_bytes);
+                file_data[data_offset..data_offset + chunk_size].copy_from_slice(&chunk_bytes);
 
                 chunk_infos.push(ChunkInfo {
                     chunk_size: chunk_size as u32,
@@ -1438,8 +1506,8 @@ mod tests {
         };
         let datatype = make_f32_type();
 
-        let raw = read_chunked_data(&file_data, &layout, &dataspace, &datatype, None, 8, 8)
-            .unwrap();
+        let raw =
+            read_chunked_data(&file_data, &layout, &dataspace, &datatype, None, 8, 8).unwrap();
         assert_eq!(raw.len(), 24 * 4);
 
         for i in 0..24 {
@@ -1552,8 +1620,8 @@ mod tests {
         };
         let datatype = make_f64_type();
 
-        let raw = read_chunked_data(&file_data, &layout, &dataspace, &datatype, None, 8, 8)
-            .unwrap();
+        let raw =
+            read_chunked_data(&file_data, &layout, &dataspace, &datatype, None, 8, 8).unwrap();
         assert_eq!(raw.len(), 24);
         for i in 0..3 {
             let val = f64::from_le_bytes(raw[i * 8..(i + 1) * 8].try_into().unwrap());
@@ -1575,7 +1643,8 @@ mod tests {
         assert!(!cache.has_index());
         let raw = read_chunked_data_cached(
             &file_data, &layout, &dataspace, &datatype, None, 8, 8, &cache,
-        ).unwrap();
+        )
+        .unwrap();
         assert!(cache.has_index());
         assert_eq!(raw.len(), 20 * 8);
         for i in 0..20 {
@@ -1594,14 +1663,16 @@ mod tests {
         // First read — populates index + decompressed cache
         let raw1 = read_chunked_data_cached(
             &file_data, &layout, &dataspace, &datatype, None, 8, 8, &cache,
-        ).unwrap();
+        )
+        .unwrap();
         assert!(cache.has_index());
         assert!(cache.cached_chunk_count() > 0);
 
         // Second read — should hit the decompressed cache
         let raw2 = read_chunked_data_cached(
             &file_data, &layout, &dataspace, &datatype, None, 8, 8, &cache,
-        ).unwrap();
+        )
+        .unwrap();
         assert_eq!(raw1, raw2);
     }
 
@@ -1614,7 +1685,8 @@ mod tests {
 
         let raw = read_chunked_data_cached(
             &file_data, &layout, &dataspace, &datatype, None, 8, 8, &cache,
-        ).unwrap();
+        )
+        .unwrap();
         assert_eq!(raw.len(), 25 * 8);
         for i in 0..25 {
             let val = f64::from_le_bytes(raw[i * 8..(i + 1) * 8].try_into().unwrap());
@@ -1634,7 +1706,8 @@ mod tests {
 
         let raw = read_chunked_data_sweep(
             &file_data, &layout, &dataspace, &datatype, None, 8, 8, &cache, &mut sweep,
-        ).unwrap();
+        )
+        .unwrap();
         assert_eq!(raw.len(), 20 * 8);
         for i in 0..20 {
             let val = f64::from_le_bytes(raw[i * 8..(i + 1) * 8].try_into().unwrap());
@@ -1652,7 +1725,8 @@ mod tests {
 
         read_chunked_data_sweep(
             &file_data, &layout, &dataspace, &datatype, None, 8, 8, &cache, &mut sweep,
-        ).unwrap();
+        )
+        .unwrap();
 
         // After reading 2 chunks (offsets [0] and [10]), history should be populated
         assert!(!sweep.history.is_empty());
@@ -1689,7 +1763,8 @@ mod tests {
 
         read_chunked_data_sweep(
             &file_data, &layout, &dataspace, &datatype, None, 8, 8, &cache, &mut sweep,
-        ).unwrap();
+        )
+        .unwrap();
 
         let stats = cache.access_stats();
         // We accessed 2 chunks; the second should be sequential to the first

--- a/src/chunked_write.rs
+++ b/src/chunked_write.rs
@@ -9,12 +9,12 @@ use alloc::{vec, vec::Vec};
 use crate::checksum::jenkins_lookup3;
 use crate::chunk_cache::{CACHE_LINE_SIZE, align_to_cache_line};
 use crate::error::FormatError;
-use crate::filter_pipeline::{
-    FilterDescription, FilterPipeline, FILTER_DEFLATE, FILTER_FLETCHER32, FILTER_SHUFFLE,
-};
 #[cfg(feature = "zfp")]
 use crate::filter_pipeline::FILTER_ZFP;
-use crate::filters::{compress_chunk, ChunkContext, ZfpElementTypeWhenEnabled};
+use crate::filter_pipeline::{
+    FILTER_DEFLATE, FILTER_FLETCHER32, FILTER_SHUFFLE, FilterDescription, FilterPipeline,
+};
+use crate::filters::{ChunkContext, ZfpElementTypeWhenEnabled, compress_chunk};
 
 /// Round a file offset up to the next cache-line boundary.
 ///
@@ -116,9 +116,7 @@ impl ChunkOptions {
             });
         }
 
-        if !zfp_active
-            && let Some(level) = self.deflate_level
-        {
+        if !zfp_active && let Some(level) = self.deflate_level {
             filters.push(FilterDescription {
                 filter_id: FILTER_DEFLATE,
                 name: None,
@@ -132,7 +130,7 @@ impl ChunkOptions {
                 filter_id: FILTER_FLETCHER32,
                 name: None,
                 flags: 0,
-                client_data: vec![],  
+                client_data: vec![],
             });
         }
 
@@ -285,7 +283,12 @@ pub fn serialize_v4_single_chunk_pub(
     element_size: u32,
 ) -> Vec<u8> {
     serialize_v4_single_chunk(
-        chunk_dims, chunk_address, filtered_size, filter_mask, offset_size, element_size,
+        chunk_dims,
+        chunk_address,
+        filtered_size,
+        filter_mask,
+        offset_size,
+        element_size,
     )
 }
 
@@ -445,7 +448,11 @@ pub fn build_fixed_array_at(
     // where chunk.size is the unfiltered chunk size in bytes (product of all chunk dims).
     let chunk_size_bytes: usize = if has_filters {
         let max_raw = chunks.iter().map(|c| c.raw_size).max().unwrap_or(1);
-        let log2_val = if max_raw <= 1 { 0 } else { 63 - max_raw.leading_zeros() };
+        let log2_val = if max_raw <= 1 {
+            0
+        } else {
+            63 - max_raw.leading_zeros()
+        };
         let len = 1 + ((log2_val + 8) / 8) as usize;
         len.min(8)
     } else {
@@ -641,8 +648,7 @@ pub fn build_extensible_array_at(
     let max_dblk_nelmts_bits: u8 = 10;
 
     // EAHD size: fixed(12) + 6 stats(6*length_size) + addr(offset_size) + checksum(4)
-    let aehd_size = 4 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
-        + 6 * length_size as usize + os + 4;
+    let aehd_size = 4 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 6 * length_size as usize + os + 4;
     let aeib_address = ea_base_address + aehd_size as u64;
 
     // Determine how many elements go inline vs data blocks
@@ -659,7 +665,11 @@ pub fn build_extensible_array_at(
     let sblk_min = super_blk_min_nelmts as usize; // sup_blk_min_data_ptrs
     // nsblks = log2(2^max_nelmts_bits / data_blk_min_elmts) + 1
     //        = max_nelmts_bits - log2(data_blk_min_elmts) + 1
-    let log2_dblk_min = if min_dblk_nelmts <= 1 { 0 } else { (min_dblk_nelmts as u32).trailing_zeros() as usize };
+    let log2_dblk_min = if min_dblk_nelmts <= 1 {
+        0
+    } else {
+        (min_dblk_nelmts as u32).trailing_zeros() as usize
+    };
     let nsblks = (max_nelmts_bits as usize).saturating_sub(log2_dblk_min) + 1;
 
     // Direct data block addresses (from super blocks 0..sblk_min-1)
@@ -746,17 +756,13 @@ pub fn build_extensible_array_at(
         idx_blk_elmts as u64
     };
 
-    let write_length = |buf: &mut Vec<u8>, val: u64| {
-        match length_size {
-            4 => buf.extend_from_slice(&(val as u32).to_le_bytes()),
-            _ => buf.extend_from_slice(&val.to_le_bytes()),
-        }
+    let write_length = |buf: &mut Vec<u8>, val: u64| match length_size {
+        4 => buf.extend_from_slice(&(val as u32).to_le_bytes()),
+        _ => buf.extend_from_slice(&val.to_le_bytes()),
     };
-    let write_addr = |buf: &mut Vec<u8>, val: u64| {
-        match offset_size {
-            4 => buf.extend_from_slice(&(val as u32).to_le_bytes()),
-            _ => buf.extend_from_slice(&val.to_le_bytes()),
-        }
+    let write_addr = |buf: &mut Vec<u8>, val: u64| match offset_size {
+        4 => buf.extend_from_slice(&(val as u32).to_le_bytes()),
+        _ => buf.extend_from_slice(&val.to_le_bytes()),
     };
 
     write_length(&mut aehd, 0); // stat[0]: reserved/unknown
@@ -789,7 +795,13 @@ pub fn build_extensible_array_at(
     #[allow(clippy::needless_range_loop)]
     for i in 0..idx_blk_elmts as usize {
         if i < n_inline {
-            write_chunk_element(&mut aeib, &chunks[i], offset_size, has_filters, chunk_size_bytes);
+            write_chunk_element(
+                &mut aeib,
+                &chunks[i],
+                offset_size,
+                has_filters,
+                chunk_size_bytes,
+            );
         } else {
             write_undefined_element(&mut aeib, offset_size, has_filters, chunk_size_bytes);
         }
@@ -1105,8 +1117,7 @@ mod tests {
         let raw = f64_to_bytes(values);
         let base_address = 0x1000u64;
         let ctx = ChunkContext::basic(chunk_dims, 8);
-        let result =
-            build_chunked_data_at(&raw, shape, ctx, options, base_address).unwrap();
+        let result = build_chunked_data_at(&raw, shape, ctx, options, base_address).unwrap();
 
         // Build a fake file buffer
         let file_size = base_address as usize + result.data_bytes.len();
@@ -1260,8 +1271,8 @@ mod tests {
 
     #[test]
     fn align_chunk_offset_values() {
-        use super::align_chunk_offset;
         use super::CACHE_LINE_SIZE;
+        use super::align_chunk_offset;
         let cl = CACHE_LINE_SIZE as u64;
         assert_eq!(align_chunk_offset(0), 0);
         assert_eq!(align_chunk_offset(1), cl);
@@ -1284,8 +1295,7 @@ mod tests {
         };
         let dims = [20u64];
         let ctx = ChunkContext::basic(&dims, 8);
-        let result =
-            build_chunked_data_at(&raw, &[100], ctx, &options, base_address).unwrap();
+        let result = build_chunked_data_at(&raw, &[100], ctx, &options, base_address).unwrap();
 
         // Parse layout to get chunk addresses (via roundtrip read)
         let file_size = base_address as usize + result.data_bytes.len();
@@ -1302,9 +1312,8 @@ mod tests {
         let datatype = make_f64_type();
 
         // Verify data roundtrips correctly
-        let output = read_chunked_data(
-            &file_data, &layout, &dataspace, &datatype, None, 8, 8,
-        ).unwrap();
+        let output =
+            read_chunked_data(&file_data, &layout, &dataspace, &datatype, None, 8, 8).unwrap();
         assert_eq!(bytes_to_f64(&output), values);
     }
 
@@ -1493,10 +1502,9 @@ mod tests {
             ..Default::default()
         };
         let ctx = ChunkContext::basic(chunk_dims, 8);
-        let result = build_chunked_data_at_ext(
-            &raw, shape, ctx, &options, base_address, Some(maxshape),
-        )
-        .unwrap();
+        let result =
+            build_chunked_data_at_ext(&raw, shape, ctx, &options, base_address, Some(maxshape))
+                .unwrap();
 
         let file_size = base_address as usize + result.data_bytes.len();
         let mut file_data = vec![0u8; file_size];
@@ -1505,7 +1513,9 @@ mod tests {
         let layout = DataLayout::parse(&result.layout_message, 8, 8).unwrap();
         // Verify it uses EA index
         match &layout {
-            DataLayout::Chunked { chunk_index_type, .. } => {
+            DataLayout::Chunked {
+                chunk_index_type, ..
+            } => {
                 assert_eq!(*chunk_index_type, Some(4), "expected EA index type");
             }
             _ => panic!("expected chunked layout"),
@@ -1519,8 +1529,8 @@ mod tests {
         };
         let datatype = make_f64_type();
 
-        let output = read_chunked_data(&file_data, &layout, &dataspace, &datatype, None, 8, 8)
-            .unwrap();
+        let output =
+            read_chunked_data(&file_data, &layout, &dataspace, &datatype, None, 8, 8).unwrap();
 
         bytes_to_f64(&output)
     }
@@ -1571,8 +1581,14 @@ mod tests {
         let mut fw = FileWriter::new();
         let data1: Vec<f64> = (0..50).map(|i| i as f64).collect();
         let data2: Vec<f64> = (0..30).map(|i| (i * 10) as f64).collect();
-        fw.create_dataset("a").with_f64_data(&data1).with_shape(&[50]).with_chunks(&[25]);
-        fw.create_dataset("b").with_f64_data(&data2).with_shape(&[30]).with_chunks(&[10]);
+        fw.create_dataset("a")
+            .with_f64_data(&data1)
+            .with_shape(&[50])
+            .with_chunks(&[25]);
+        fw.create_dataset("b")
+            .with_f64_data(&data2)
+            .with_shape(&[30])
+            .with_chunks(&[10]);
         let bytes = fw.finish().unwrap();
         let path = std::env::temp_dir().join("rustyhdf5_chunked_multi.h5");
         std::fs::write(&path, &bytes).unwrap();
@@ -1591,10 +1607,13 @@ mod tests {
     #[cfg(feature = "std")]
     #[test]
     fn h5py_reads_chunked_with_attrs() {
-        use crate::file_writer::{FileWriter, AttrValue};
+        use crate::file_writer::{AttrValue, FileWriter};
         let mut fw = FileWriter::new();
         let data: Vec<f64> = (0..50).map(|i| i as f64).collect();
-        fw.create_dataset("data").with_f64_data(&data).with_shape(&[50]).with_chunks(&[25])
+        fw.create_dataset("data")
+            .with_f64_data(&data)
+            .with_shape(&[50])
+            .with_chunks(&[25])
             .set_attr("units", AttrValue::String("meters".to_string()));
         let bytes = fw.finish().unwrap();
         let path = std::env::temp_dir().join("rustyhdf5_chunked_attrs.h5");

--- a/src/data_layout.rs
+++ b/src/data_layout.rs
@@ -205,20 +205,10 @@ impl DataLayout {
                     let val = match dim_size_encoded_length {
                         1 => data[p] as u32,
                         2 => u16::from_le_bytes([data[p], data[p + 1]]) as u32,
-                        4 => u32::from_le_bytes([
-                            data[p],
-                            data[p + 1],
-                            data[p + 2],
-                            data[p + 3],
-                        ]),
+                        4 => u32::from_le_bytes([data[p], data[p + 1], data[p + 2], data[p + 3]]),
                         8 => {
                             // Truncate to u32
-                            u32::from_le_bytes([
-                                data[p],
-                                data[p + 1],
-                                data[p + 2],
-                                data[p + 3],
-                            ])
+                            u32::from_le_bytes([data[p], data[p + 1], data[p + 2], data[p + 3]])
                         }
                         _ => {
                             return Err(FormatError::UnexpectedEof {
@@ -252,7 +242,10 @@ impl DataLayout {
                             single_chunk_filtered_size = Some(read_length(data, p, length_size)?);
                             p += ls;
                             single_chunk_filter_mask = Some(u32::from_le_bytes([
-                                data[p], data[p + 1], data[p + 2], data[p + 3],
+                                data[p],
+                                data[p + 1],
+                                data[p + 2],
+                                data[p + 3],
                             ]));
                             p += 4;
                             if is_undefined(data, p, offset_size) {
@@ -415,7 +408,12 @@ mod tests {
         buf.extend_from_slice(&3u16.to_le_bytes());
         buf.extend_from_slice(&[1, 2, 3]);
         let layout = DataLayout::parse(&buf, 8, 8).unwrap();
-        assert_eq!(layout, DataLayout::Compact { data: vec![1, 2, 3] });
+        assert_eq!(
+            layout,
+            DataLayout::Compact {
+                data: vec![1, 2, 3]
+            }
+        );
     }
 
     #[test]

--- a/src/data_read.rs
+++ b/src/data_read.rs
@@ -118,9 +118,15 @@ pub fn read_raw_data_full(
             }
             Ok(file_data[addr..addr + sz].to_vec())
         }
-        DataLayout::Chunked { .. } => {
-            read_chunked_data(file_data, layout, dataspace, datatype, pipeline, offset_size, length_size)
-        }
+        DataLayout::Chunked { .. } => read_chunked_data(
+            file_data,
+            layout,
+            dataspace,
+            datatype,
+            pipeline,
+            offset_size,
+            length_size,
+        ),
         DataLayout::Virtual { .. } => Err(FormatError::UnsupportedVersion(0)),
     }
 }
@@ -141,15 +147,24 @@ pub fn read_raw_data_cached(
     cache: &ChunkCache,
 ) -> Result<Vec<u8>, FormatError> {
     match layout {
-        DataLayout::Chunked { .. } => {
-            read_chunked_data_cached(
-                file_data, layout, dataspace, datatype, pipeline,
-                offset_size, length_size, cache,
-            )
-        }
+        DataLayout::Chunked { .. } => read_chunked_data_cached(
+            file_data,
+            layout,
+            dataspace,
+            datatype,
+            pipeline,
+            offset_size,
+            length_size,
+            cache,
+        ),
         _ => read_raw_data_full(
-            file_data, layout, dataspace, datatype, pipeline,
-            offset_size, length_size,
+            file_data,
+            layout,
+            dataspace,
+            datatype,
+            pipeline,
+            offset_size,
+            length_size,
         ),
     }
 }
@@ -206,15 +221,27 @@ pub fn read_as_f64(raw: &[u8], datatype: &Datatype) -> Result<Vec<f64>, FormatEr
 
     // Fast path: native-endian f64 can use bulk copy (zero conversion overhead)
     #[cfg(target_endian = "little")]
-    if matches!(datatype, Datatype::FloatingPoint { size: 8, byte_order: DatatypeByteOrder::LittleEndian, .. })
-    {
+    if matches!(
+        datatype,
+        Datatype::FloatingPoint {
+            size: 8,
+            byte_order: DatatypeByteOrder::LittleEndian,
+            ..
+        }
+    ) {
         let mut result = vec![0.0f64; count];
         // Safety equivalent via from_le_bytes — but we use safe transmute-free copy
         for (i, val) in result.iter_mut().enumerate() {
             let off = i * 8;
             *val = f64::from_le_bytes([
-                raw[off], raw[off+1], raw[off+2], raw[off+3],
-                raw[off+4], raw[off+5], raw[off+6], raw[off+7],
+                raw[off],
+                raw[off + 1],
+                raw[off + 2],
+                raw[off + 3],
+                raw[off + 4],
+                raw[off + 5],
+                raw[off + 6],
+                raw[off + 7],
             ]);
         }
         return Ok(result);
@@ -328,10 +355,16 @@ pub fn read_as_f32(raw: &[u8], datatype: &Datatype) -> Result<Vec<f32>, FormatEr
             Datatype::FloatingPoint { size: 8, .. } => {
                 result.push(read_f64_bytes(chunk, &order) as f32);
             }
-            Datatype::FixedPoint { signed: true, size, .. } => {
+            Datatype::FixedPoint {
+                signed: true, size, ..
+            } => {
                 result.push(read_signed_int(chunk, *size as usize, &order) as f32);
             }
-            Datatype::FixedPoint { signed: false, size, .. } => {
+            Datatype::FixedPoint {
+                signed: false,
+                size,
+                ..
+            } => {
                 result.push(read_unsigned_int(chunk, *size as usize, &order) as f32);
             }
             _ => {
@@ -394,10 +427,7 @@ pub fn read_as_strings(raw: &[u8], datatype: &Datatype) -> Result<Vec<String>, F
                         String::from_utf8_lossy(&chunk[..end]).into_owned()
                     }
                     crate::datatype::StringPadding::SpacePad => {
-                        let end = chunk
-                            .iter()
-                            .rposition(|&b| b != b' ')
-                            .map_or(0, |p| p + 1);
+                        let end = chunk.iter().rposition(|&b| b != b' ').map_or(0, |p| p + 1);
                         String::from_utf8_lossy(&chunk[..end]).into_owned()
                     }
                 };
@@ -430,7 +460,10 @@ pub struct CompoundFieldData {
 ///
 /// Each returned `CompoundFieldData` contains the raw bytes for that field
 /// across all elements, suitable for further typed conversion with `read_as_f64`, etc.
-pub fn read_compound_fields(raw: &[u8], datatype: &Datatype) -> Result<Vec<CompoundFieldData>, FormatError> {
+pub fn read_compound_fields(
+    raw: &[u8],
+    datatype: &Datatype,
+) -> Result<Vec<CompoundFieldData>, FormatError> {
     match datatype {
         Datatype::Compound { size, members } => {
             let elem_size = *size as usize;
@@ -469,9 +502,14 @@ pub fn read_compound_fields(raw: &[u8], datatype: &Datatype) -> Result<Vec<Compo
 }
 
 /// Extract a single field by name from compound raw data.
-pub fn read_compound_field(raw: &[u8], datatype: &Datatype, field_name: &str) -> Result<CompoundFieldData, FormatError> {
+pub fn read_compound_field(
+    raw: &[u8],
+    datatype: &Datatype,
+    field_name: &str,
+) -> Result<CompoundFieldData, FormatError> {
     let fields = read_compound_fields(raw, datatype)?;
-    fields.into_iter()
+    fields
+        .into_iter()
         .find(|f| f.name == field_name)
         .ok_or_else(|| FormatError::PathNotFound(field_name.into()))
 }
@@ -513,17 +551,25 @@ pub fn read_enum_values(raw: &[u8], datatype: &Datatype) -> Result<Vec<EnumValue
             for i in 0..count {
                 let val_bytes = raw[i * elem_size..(i + 1) * elem_size].to_vec();
                 let name = lookup.get(&val_bytes).cloned().unwrap_or_else(|| {
-                    let hex: Vec<String> = val_bytes.iter().map(|b| {
-                        let mut s = String::new();
-                        core::fmt::Write::write_fmt(&mut s, format_args!("{b:02x}")).ok();
-                        s
-                    }).collect();
+                    let hex: Vec<String> = val_bytes
+                        .iter()
+                        .map(|b| {
+                            let mut s = String::new();
+                            core::fmt::Write::write_fmt(&mut s, format_args!("{b:02x}")).ok();
+                            s
+                        })
+                        .collect();
                     let mut result = String::from("UNKNOWN(0x");
-                    for h in &hex { result.push_str(h); }
+                    for h in &hex {
+                        result.push_str(h);
+                    }
                     result.push(')');
                     result
                 });
-                result.push(EnumValue { name, raw_value: val_bytes });
+                result.push(EnumValue {
+                    name,
+                    raw_value: val_bytes,
+                });
             }
             Ok(result)
         }
@@ -685,11 +731,15 @@ fn read_ref_address(bytes: &[u8], size: usize) -> u64 {
 /// each dataset element contains D1*D2*... values of type T.
 /// This function returns the raw bytes as a flat buffer that can be
 /// converted with `read_as_f64`, `read_as_i32`, etc. using the base type.
-pub fn read_array_flat(raw: &[u8], datatype: &Datatype) -> Result<(Vec<u8>, Datatype, Vec<u32>), FormatError> {
+pub fn read_array_flat(
+    raw: &[u8],
+    datatype: &Datatype,
+) -> Result<(Vec<u8>, Datatype, Vec<u32>), FormatError> {
     match datatype {
-        Datatype::Array { base_type, dimensions } => {
-            Ok((raw.to_vec(), *base_type.clone(), dimensions.clone()))
-        }
+        Datatype::Array {
+            base_type,
+            dimensions,
+        } => Ok((raw.to_vec(), *base_type.clone(), dimensions.clone())),
         _ => Err(FormatError::TypeMismatch {
             expected: "Array",
             actual: datatype_name(datatype),
@@ -1087,9 +1137,18 @@ mod tests {
             size: 4,
             base_type: Box::new(make_i32_le_type()),
             members: vec![
-                EnumMember { name: "RED".to_string(), value: 0i32.to_le_bytes().to_vec() },
-                EnumMember { name: "GREEN".to_string(), value: 1i32.to_le_bytes().to_vec() },
-                EnumMember { name: "BLUE".to_string(), value: 2i32.to_le_bytes().to_vec() },
+                EnumMember {
+                    name: "RED".to_string(),
+                    value: 0i32.to_le_bytes().to_vec(),
+                },
+                EnumMember {
+                    name: "GREEN".to_string(),
+                    value: 1i32.to_le_bytes().to_vec(),
+                },
+                EnumMember {
+                    name: "BLUE".to_string(),
+                    value: 2i32.to_le_bytes().to_vec(),
+                },
             ],
         };
         let mut raw = Vec::new();

--- a/src/dataspace.rs
+++ b/src/dataspace.rs
@@ -135,7 +135,11 @@ impl Dataspace {
         let mut buf = Vec::new();
         buf.push(2); // version 2
         buf.push(self.rank);
-        let flags = if self.max_dimensions.is_some() { 0x01 } else { 0x00 };
+        let flags = if self.max_dimensions.is_some() {
+            0x01
+        } else {
+            0x00
+        };
         buf.push(flags);
         let type_byte = match self.space_type {
             DataspaceType::Scalar => 0,
@@ -267,12 +271,7 @@ mod tests {
 
     #[test]
     fn simple_3d_with_max_dims_unlimited() {
-        let data = build_v1_dataspace(
-            3,
-            0x01,
-            &[2, 3, 4],
-            Some(&[10, u64::MAX, 100]),
-        );
+        let data = build_v1_dataspace(3, 0x01, &[2, 3, 4], Some(&[10, u64::MAX, 100]));
         let ds = Dataspace::parse(&data, 8).unwrap();
         assert_eq!(ds.rank, 3);
         assert_eq!(ds.dimensions, vec![2, 3, 4]);

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -84,10 +84,7 @@ pub enum Datatype {
         exponent_bias: u32,
     },
     /// Class 2: Time type (rarely used).
-    Time {
-        size: u32,
-        bit_precision: u16,
-    },
+    Time { size: u32, bit_precision: u16 },
     /// Class 3: Fixed-length string.
     String {
         size: u32,
@@ -102,20 +99,14 @@ pub enum Datatype {
         bit_precision: u16,
     },
     /// Class 5: Opaque data.
-    Opaque {
-        size: u32,
-        tag: Vec<u8>,
-    },
+    Opaque { size: u32, tag: Vec<u8> },
     /// Class 6: Compound type.
     Compound {
         size: u32,
         members: Vec<CompoundMember>,
     },
     /// Class 7: Reference type.
-    Reference {
-        size: u32,
-        ref_type: ReferenceType,
-    },
+    Reference { size: u32, ref_type: ReferenceType },
     /// Class 8: Enumeration type.
     Enumeration {
         size: u32,
@@ -298,7 +289,13 @@ impl Datatype {
                 ensure_len(data, pos, 2)?;
                 let bit_precision = LittleEndian::read_u16(&data[pos..pos + 2]);
                 pos += 2;
-                Ok((Datatype::Time { size, bit_precision }, pos))
+                Ok((
+                    Datatype::Time {
+                        size,
+                        bit_precision,
+                    },
+                    pos,
+                ))
             }
             3 => {
                 // String
@@ -306,7 +303,14 @@ impl Datatype {
                 let charset_val = (bf0 >> 4) & 0x0F;
                 let padding = parse_string_padding(padding_val)?;
                 let charset = parse_charset(charset_val)?;
-                Ok((Datatype::String { size, padding, charset }, pos))
+                Ok((
+                    Datatype::String {
+                        size,
+                        padding,
+                        charset,
+                    },
+                    pos,
+                ))
             }
             4 => {
                 // Bit Field
@@ -553,21 +557,44 @@ impl Datatype {
     /// Serialize datatype to HDF5 message bytes.
     pub fn serialize(&self) -> Vec<u8> {
         match self {
-            Datatype::FixedPoint { size, byte_order, signed, bit_offset, bit_precision } => {
+            Datatype::FixedPoint {
+                size,
+                byte_order,
+                signed,
+                bit_offset,
+                bit_precision,
+            } => {
                 let mut bf0 = 0u8;
-                if matches!(byte_order, DatatypeByteOrder::BigEndian) { bf0 |= 0x01; }
-                if *signed { bf0 |= 0x08; }
+                if matches!(byte_order, DatatypeByteOrder::BigEndian) {
+                    bf0 |= 0x01;
+                }
+                if *signed {
+                    bf0 |= 0x08;
+                }
                 let mut buf = Self::build_header(0, 1, [bf0, 0, 0], *size);
                 buf.extend_from_slice(&bit_offset.to_le_bytes());
                 buf.extend_from_slice(&bit_precision.to_le_bytes());
                 buf
             }
-            Datatype::FloatingPoint { size, byte_order, bit_offset, bit_precision,
-                exponent_location, exponent_size, mantissa_location, mantissa_size, exponent_bias } => {
+            Datatype::FloatingPoint {
+                size,
+                byte_order,
+                bit_offset,
+                bit_precision,
+                exponent_location,
+                exponent_size,
+                mantissa_location,
+                mantissa_size,
+                exponent_bias,
+            } => {
                 let mut bf0 = 0x20u8; // bit 5: sign location bit (standard IEEE 754)
                 match byte_order {
-                    DatatypeByteOrder::BigEndian => { bf0 |= 0x01; }
-                    DatatypeByteOrder::Vax => { bf0 |= 0x40; }
+                    DatatypeByteOrder::BigEndian => {
+                        bf0 |= 0x01;
+                    }
+                    DatatypeByteOrder::Vax => {
+                        bf0 |= 0x40;
+                    }
                     _ => {}
                 }
                 // bf[1] = sign bit location (bit position of sign in the value)
@@ -582,7 +609,11 @@ impl Datatype {
                 buf.extend_from_slice(&exponent_bias.to_le_bytes());
                 buf
             }
-            Datatype::String { size, padding, charset } => {
+            Datatype::String {
+                size,
+                padding,
+                charset,
+            } => {
                 let pad_val = match padding {
                     StringPadding::NullTerminate => 0,
                     StringPadding::NullPad => 1,
@@ -595,24 +626,29 @@ impl Datatype {
                 let bf0 = pad_val | (cs_val << 4);
                 Self::build_header(3, 1, [bf0, 0, 0], *size)
             }
-            Datatype::VariableLength { is_string, padding, charset, base_type } => {
+            Datatype::VariableLength {
+                is_string,
+                padding,
+                charset,
+                base_type,
+            } => {
                 let mut bf0 = if *is_string { 0x01u8 } else { 0x00 };
-                if *is_string {
-                    if let Some(p) = padding {
-                        let pv = match p {
-                            StringPadding::NullTerminate => 0,
-                            StringPadding::NullPad => 1,
-                            StringPadding::SpacePad => 2,
-                        };
-                        bf0 |= pv << 4;
-                    }
+                if *is_string && let Some(p) = padding {
+                    let pv = match p {
+                        StringPadding::NullTerminate => 0,
+                        StringPadding::NullPad => 1,
+                        StringPadding::SpacePad => 2,
+                    };
+                    bf0 |= pv << 4;
                 }
                 let bf1 = if *is_string {
                     charset.as_ref().map_or(0, |c| match c {
                         CharacterSet::Ascii => 0,
                         CharacterSet::Utf8 => 1,
                     })
-                } else { 0 };
+                } else {
+                    0
+                };
                 let mut buf = Self::build_header(9, 1, [bf0, bf1, 0], 16);
                 buf.extend_from_slice(&base_type.serialize());
                 buf
@@ -638,7 +674,11 @@ impl Datatype {
                 }
                 buf
             }
-            Datatype::Enumeration { size, base_type, members } => {
+            Datatype::Enumeration {
+                size,
+                base_type,
+                members,
+            } => {
                 let num = members.len() as u16;
                 let bf0 = (num & 0xFF) as u8;
                 let bf1 = ((num >> 8) & 0xFF) as u8;
@@ -656,7 +696,10 @@ impl Datatype {
                 }
                 buf
             }
-            Datatype::Array { base_type, dimensions } => {
+            Datatype::Array {
+                base_type,
+                dimensions,
+            } => {
                 let mut buf = Self::build_header(10, 3, [0, 0, 0], self.type_size());
                 buf.push(dimensions.len() as u8);
                 for &d in dimensions {
@@ -672,9 +715,7 @@ impl Datatype {
                 };
                 Self::build_header(7, 1, [bf0, 0, 0], *size)
             }
-            _ => {
-                Vec::new()
-            }
+            _ => Vec::new(),
         }
     }
 
@@ -701,8 +742,13 @@ impl Datatype {
             Datatype::Reference { size, .. } => *size,
             Datatype::Enumeration { size, .. } => *size,
             Datatype::VariableLength { .. } => 16, // typically pointer + length
-            Datatype::Array { base_type, dimensions } => {
-                let elem_count: u32 = dimensions.iter().copied()
+            Datatype::Array {
+                base_type,
+                dimensions,
+            } => {
+                let elem_count: u32 = dimensions
+                    .iter()
+                    .copied()
                     .fold(1u32, |a, b| a.saturating_mul(b));
                 base_type.type_size().saturating_mul(elem_count)
             }
@@ -727,7 +773,13 @@ mod tests {
     use super::*;
 
     // Helper to build a fixed-point datatype message
-    fn build_fixed_point(size: u32, be: bool, signed: bool, bit_offset: u16, bit_precision: u16) -> Vec<u8> {
+    fn build_fixed_point(
+        size: u32,
+        be: bool,
+        signed: bool,
+        bit_offset: u16,
+        bit_precision: u16,
+    ) -> Vec<u8> {
         let bf0 = if be { 0x01 } else { 0x00 } | if signed { 0x08 } else { 0x00 };
         let mut buf = build_dt_header(0, 1, [bf0, 0, 0], size);
         let mut props = [0u8; 4];
@@ -738,7 +790,14 @@ mod tests {
     }
 
     // Helper to build a floating-point datatype message
-    fn build_float(size: u32, exp_loc: u8, exp_size: u8, mant_loc: u8, mant_size: u8, exp_bias: u32) -> Vec<u8> {
+    fn build_float(
+        size: u32,
+        exp_loc: u8,
+        exp_size: u8,
+        mant_loc: u8,
+        mant_size: u8,
+        exp_bias: u32,
+    ) -> Vec<u8> {
         // LE byte order: bo_low=0, bo_high=0
         let bf0 = 0x00u8;
         let bf1 = 0x00u8;
@@ -762,26 +821,32 @@ mod tests {
         let data = build_fixed_point(1, false, false, 0, 8);
         let (dt, consumed) = Datatype::parse(&data).unwrap();
         assert_eq!(consumed, 12);
-        assert_eq!(dt, Datatype::FixedPoint {
-            size: 1,
-            byte_order: DatatypeByteOrder::LittleEndian,
-            signed: false,
-            bit_offset: 0,
-            bit_precision: 8,
-        });
+        assert_eq!(
+            dt,
+            Datatype::FixedPoint {
+                size: 1,
+                byte_order: DatatypeByteOrder::LittleEndian,
+                signed: false,
+                bit_offset: 0,
+                bit_precision: 8,
+            }
+        );
     }
 
     #[test]
     fn test_fixed_point_i16_le() {
         let data = build_fixed_point(2, false, true, 0, 16);
         let (dt, _) = Datatype::parse(&data).unwrap();
-        assert_eq!(dt, Datatype::FixedPoint {
-            size: 2,
-            byte_order: DatatypeByteOrder::LittleEndian,
-            signed: true,
-            bit_offset: 0,
-            bit_precision: 16,
-        });
+        assert_eq!(
+            dt,
+            Datatype::FixedPoint {
+                size: 2,
+                byte_order: DatatypeByteOrder::LittleEndian,
+                signed: true,
+                bit_offset: 0,
+                bit_precision: 16,
+            }
+        );
     }
 
     #[test]
@@ -789,7 +854,12 @@ mod tests {
         let data = build_fixed_point(4, true, false, 0, 32);
         let (dt, _) = Datatype::parse(&data).unwrap();
         match &dt {
-            Datatype::FixedPoint { byte_order, signed, size, .. } => {
+            Datatype::FixedPoint {
+                byte_order,
+                signed,
+                size,
+                ..
+            } => {
                 assert_eq!(*byte_order, DatatypeByteOrder::BigEndian);
                 assert!(!signed);
                 assert_eq!(*size, 4);
@@ -802,13 +872,16 @@ mod tests {
     fn test_fixed_point_i64_le() {
         let data = build_fixed_point(8, false, true, 0, 64);
         let (dt, _) = Datatype::parse(&data).unwrap();
-        assert_eq!(dt, Datatype::FixedPoint {
-            size: 8,
-            byte_order: DatatypeByteOrder::LittleEndian,
-            signed: true,
-            bit_offset: 0,
-            bit_precision: 64,
-        });
+        assert_eq!(
+            dt,
+            Datatype::FixedPoint {
+                size: 8,
+                byte_order: DatatypeByteOrder::LittleEndian,
+                signed: true,
+                bit_offset: 0,
+                bit_precision: 64,
+            }
+        );
     }
 
     #[test]
@@ -817,34 +890,40 @@ mod tests {
         let data = build_float(4, 23, 8, 0, 23, 127);
         let (dt, consumed) = Datatype::parse(&data).unwrap();
         assert_eq!(consumed, 20);
-        assert_eq!(dt, Datatype::FloatingPoint {
-            size: 4,
-            byte_order: DatatypeByteOrder::LittleEndian,
-            bit_offset: 0,
-            bit_precision: 32,
-            exponent_location: 23,
-            exponent_size: 8,
-            mantissa_location: 0,
-            mantissa_size: 23,
-            exponent_bias: 127,
-        });
+        assert_eq!(
+            dt,
+            Datatype::FloatingPoint {
+                size: 4,
+                byte_order: DatatypeByteOrder::LittleEndian,
+                bit_offset: 0,
+                bit_precision: 32,
+                exponent_location: 23,
+                exponent_size: 8,
+                mantissa_location: 0,
+                mantissa_size: 23,
+                exponent_bias: 127,
+            }
+        );
     }
 
     #[test]
     fn test_float_f64_le() {
         let data = build_float(8, 52, 11, 0, 52, 1023);
         let (dt, _) = Datatype::parse(&data).unwrap();
-        assert_eq!(dt, Datatype::FloatingPoint {
-            size: 8,
-            byte_order: DatatypeByteOrder::LittleEndian,
-            bit_offset: 0,
-            bit_precision: 64,
-            exponent_location: 52,
-            exponent_size: 11,
-            mantissa_location: 0,
-            mantissa_size: 52,
-            exponent_bias: 1023,
-        });
+        assert_eq!(
+            dt,
+            Datatype::FloatingPoint {
+                size: 8,
+                byte_order: DatatypeByteOrder::LittleEndian,
+                bit_offset: 0,
+                bit_precision: 64,
+                exponent_location: 52,
+                exponent_size: 11,
+                mantissa_location: 0,
+                mantissa_size: 52,
+                exponent_bias: 1023,
+            }
+        );
     }
 
     #[test]
@@ -852,11 +931,14 @@ mod tests {
         let buf = build_dt_header(3, 1, [0x00, 0, 0], 10); // padding=0(nullterm), charset=0(ascii)
         let (dt, consumed) = Datatype::parse(&buf).unwrap();
         assert_eq!(consumed, 8);
-        assert_eq!(dt, Datatype::String {
-            size: 10,
-            padding: StringPadding::NullTerminate,
-            charset: CharacterSet::Ascii,
-        });
+        assert_eq!(
+            dt,
+            Datatype::String {
+                size: 10,
+                padding: StringPadding::NullTerminate,
+                charset: CharacterSet::Ascii,
+            }
+        );
     }
 
     #[test]
@@ -864,11 +946,14 @@ mod tests {
         // padding=2(space pad), charset=1(utf8) → bf0 = 0x12
         let buf = build_dt_header(3, 1, [0x12, 0, 0], 32);
         let (dt, _) = Datatype::parse(&buf).unwrap();
-        assert_eq!(dt, Datatype::String {
-            size: 32,
-            padding: StringPadding::SpacePad,
-            charset: CharacterSet::Utf8,
-        });
+        assert_eq!(
+            dt,
+            Datatype::String {
+                size: 32,
+                padding: StringPadding::SpacePad,
+                charset: CharacterSet::Utf8,
+            }
+        );
     }
 
     #[test]
@@ -880,10 +965,13 @@ mod tests {
         buf.extend_from_slice(&[0, 0, 0, 0]);
         let (dt, consumed) = Datatype::parse(&buf).unwrap();
         assert_eq!(consumed, 16); // 8 header + 8 padded tag
-        assert_eq!(dt, Datatype::Opaque {
-            size: 64,
-            tag: b"BLOB".to_vec(),
-        });
+        assert_eq!(
+            dt,
+            Datatype::Opaque {
+                size: 64,
+                tag: b"BLOB".to_vec(),
+            }
+        );
     }
 
     #[test]
@@ -910,7 +998,11 @@ mod tests {
                 assert_eq!(members[1].name, "y");
                 assert_eq!(members[1].byte_offset, 4);
                 match &members[0].datatype {
-                    Datatype::FixedPoint { size: 4, signed: false, .. } => {}
+                    Datatype::FixedPoint {
+                        size: 4,
+                        signed: false,
+                        ..
+                    } => {}
                     other => panic!("expected u32, got {other:?}"),
                 }
                 match &members[1].datatype {
@@ -926,20 +1018,26 @@ mod tests {
     fn test_reference_object() {
         let buf = build_dt_header(7, 1, [0, 0, 0], 8);
         let (dt, _) = Datatype::parse(&buf).unwrap();
-        assert_eq!(dt, Datatype::Reference {
-            size: 8,
-            ref_type: ReferenceType::Object,
-        });
+        assert_eq!(
+            dt,
+            Datatype::Reference {
+                size: 8,
+                ref_type: ReferenceType::Object,
+            }
+        );
     }
 
     #[test]
     fn test_reference_region() {
         let buf = build_dt_header(7, 1, [1, 0, 0], 12);
         let (dt, _) = Datatype::parse(&buf).unwrap();
-        assert_eq!(dt, Datatype::Reference {
-            size: 12,
-            ref_type: ReferenceType::DatasetRegion,
-        });
+        assert_eq!(
+            dt,
+            Datatype::Reference {
+                size: 12,
+                ref_type: ReferenceType::DatasetRegion,
+            }
+        );
     }
 
     #[test]
@@ -959,7 +1057,11 @@ mod tests {
 
         let (dt, _) = Datatype::parse(&buf).unwrap();
         match dt {
-            Datatype::Enumeration { size, base_type, members } => {
+            Datatype::Enumeration {
+                size,
+                base_type,
+                members,
+            } => {
                 assert_eq!(size, 4);
                 assert_eq!(members.len(), 3);
                 assert_eq!(members[0].name, "RED");
@@ -969,7 +1071,11 @@ mod tests {
                 assert_eq!(members[2].name, "BLUE");
                 assert_eq!(members[2].value, 2i32.to_le_bytes().to_vec());
                 match *base_type {
-                    Datatype::FixedPoint { signed: true, size: 4, .. } => {}
+                    Datatype::FixedPoint {
+                        signed: true,
+                        size: 4,
+                        ..
+                    } => {}
                     other => panic!("expected i32, got {other:?}"),
                 }
             }
@@ -988,7 +1094,12 @@ mod tests {
 
         let (dt, _) = Datatype::parse(&buf).unwrap();
         match dt {
-            Datatype::VariableLength { is_string, padding, charset, base_type } => {
+            Datatype::VariableLength {
+                is_string,
+                padding,
+                charset,
+                base_type,
+            } => {
                 assert!(is_string);
                 assert_eq!(padding, Some(StringPadding::NullTerminate));
                 assert_eq!(charset, Some(CharacterSet::Utf8));
@@ -1008,7 +1119,12 @@ mod tests {
 
         let (dt, _) = Datatype::parse(&buf).unwrap();
         match dt {
-            Datatype::VariableLength { is_string, padding, charset, base_type } => {
+            Datatype::VariableLength {
+                is_string,
+                padding,
+                charset,
+                base_type,
+            } => {
                 assert!(!is_string);
                 assert_eq!(padding, None);
                 assert_eq!(charset, None);
@@ -1030,10 +1146,17 @@ mod tests {
 
         let (dt, _) = Datatype::parse(&buf).unwrap();
         match dt {
-            Datatype::Array { base_type, dimensions } => {
+            Datatype::Array {
+                base_type,
+                dimensions,
+            } => {
                 assert_eq!(dimensions, vec![3, 4]);
                 match *base_type {
-                    Datatype::FixedPoint { size: 4, signed: true, .. } => {}
+                    Datatype::FixedPoint {
+                        size: 4,
+                        signed: true,
+                        ..
+                    } => {}
                     other => panic!("expected i32, got {other:?}"),
                 }
             }
@@ -1050,12 +1173,15 @@ mod tests {
         buf.extend_from_slice(&props);
 
         let (dt, _) = Datatype::parse(&buf).unwrap();
-        assert_eq!(dt, Datatype::BitField {
-            size: 2,
-            byte_order: DatatypeByteOrder::LittleEndian,
-            bit_offset: 0,
-            bit_precision: 16,
-        });
+        assert_eq!(
+            dt,
+            Datatype::BitField {
+                size: 2,
+                byte_order: DatatypeByteOrder::LittleEndian,
+                bit_offset: 0,
+                bit_precision: 16,
+            }
+        );
     }
 
     #[test]
@@ -1067,10 +1193,13 @@ mod tests {
 
         let (dt, consumed) = Datatype::parse(&buf).unwrap();
         assert_eq!(consumed, 10);
-        assert_eq!(dt, Datatype::Time {
-            size: 8,
-            bit_precision: 64,
-        });
+        assert_eq!(
+            dt,
+            Datatype::Time {
+                size: 8,
+                bit_precision: 64,
+            }
+        );
     }
 
     #[test]
@@ -1102,7 +1231,10 @@ mod tests {
                 assert_eq!(members.len(), 1);
                 assert_eq!(members[0].name, "data");
                 match &members[0].datatype {
-                    Datatype::Array { dimensions, base_type } => {
+                    Datatype::Array {
+                        dimensions,
+                        base_type,
+                    } => {
                         assert_eq!(dimensions, &[2]);
                         match base_type.as_ref() {
                             Datatype::Enumeration { members, .. } => {
@@ -1167,28 +1299,41 @@ mod tests {
                     name: "x".to_string(),
                     byte_offset: 0,
                     datatype: Datatype::FloatingPoint {
-                        size: 8, byte_order: DatatypeByteOrder::LittleEndian,
-                        bit_offset: 0, bit_precision: 64,
-                        exponent_location: 52, exponent_size: 11,
-                        mantissa_location: 0, mantissa_size: 52, exponent_bias: 1023,
+                        size: 8,
+                        byte_order: DatatypeByteOrder::LittleEndian,
+                        bit_offset: 0,
+                        bit_precision: 64,
+                        exponent_location: 52,
+                        exponent_size: 11,
+                        mantissa_location: 0,
+                        mantissa_size: 52,
+                        exponent_bias: 1023,
                     },
                 },
                 CompoundMember {
                     name: "y".to_string(),
                     byte_offset: 8,
                     datatype: Datatype::FloatingPoint {
-                        size: 8, byte_order: DatatypeByteOrder::LittleEndian,
-                        bit_offset: 0, bit_precision: 64,
-                        exponent_location: 52, exponent_size: 11,
-                        mantissa_location: 0, mantissa_size: 52, exponent_bias: 1023,
+                        size: 8,
+                        byte_order: DatatypeByteOrder::LittleEndian,
+                        bit_offset: 0,
+                        bit_precision: 64,
+                        exponent_location: 52,
+                        exponent_size: 11,
+                        mantissa_location: 0,
+                        mantissa_size: 52,
+                        exponent_bias: 1023,
                     },
                 },
                 CompoundMember {
                     name: "id".to_string(),
                     byte_offset: 16,
                     datatype: Datatype::FixedPoint {
-                        size: 4, byte_order: DatatypeByteOrder::LittleEndian,
-                        signed: true, bit_offset: 0, bit_precision: 32,
+                        size: 4,
+                        byte_order: DatatypeByteOrder::LittleEndian,
+                        signed: true,
+                        bit_offset: 0,
+                        bit_precision: 32,
                     },
                 },
             ],
@@ -1203,13 +1348,25 @@ mod tests {
         let dt = Datatype::Enumeration {
             size: 4,
             base_type: Box::new(Datatype::FixedPoint {
-                size: 4, byte_order: DatatypeByteOrder::LittleEndian,
-                signed: true, bit_offset: 0, bit_precision: 32,
+                size: 4,
+                byte_order: DatatypeByteOrder::LittleEndian,
+                signed: true,
+                bit_offset: 0,
+                bit_precision: 32,
             }),
             members: vec![
-                EnumMember { name: "RED".to_string(), value: 0i32.to_le_bytes().to_vec() },
-                EnumMember { name: "GREEN".to_string(), value: 1i32.to_le_bytes().to_vec() },
-                EnumMember { name: "BLUE".to_string(), value: 2i32.to_le_bytes().to_vec() },
+                EnumMember {
+                    name: "RED".to_string(),
+                    value: 0i32.to_le_bytes().to_vec(),
+                },
+                EnumMember {
+                    name: "GREEN".to_string(),
+                    value: 1i32.to_le_bytes().to_vec(),
+                },
+                EnumMember {
+                    name: "BLUE".to_string(),
+                    value: 2i32.to_le_bytes().to_vec(),
+                },
             ],
         };
         let bytes = dt.serialize();
@@ -1221,10 +1378,15 @@ mod tests {
     fn serialize_parse_array_roundtrip() {
         let dt = Datatype::Array {
             base_type: Box::new(Datatype::FloatingPoint {
-                size: 8, byte_order: DatatypeByteOrder::LittleEndian,
-                bit_offset: 0, bit_precision: 64,
-                exponent_location: 52, exponent_size: 11,
-                mantissa_location: 0, mantissa_size: 52, exponent_bias: 1023,
+                size: 8,
+                byte_order: DatatypeByteOrder::LittleEndian,
+                bit_offset: 0,
+                bit_precision: 64,
+                exponent_location: 52,
+                exponent_size: 11,
+                mantissa_location: 0,
+                mantissa_size: 52,
+                exponent_bias: 1023,
             }),
             dimensions: vec![3],
         };
@@ -1236,15 +1398,21 @@ mod tests {
     #[test]
     fn test_type_size() {
         let dt = Datatype::FixedPoint {
-            size: 4, byte_order: DatatypeByteOrder::LittleEndian,
-            signed: true, bit_offset: 0, bit_precision: 32,
+            size: 4,
+            byte_order: DatatypeByteOrder::LittleEndian,
+            signed: true,
+            bit_offset: 0,
+            bit_precision: 32,
         };
         assert_eq!(dt.type_size(), 4);
 
         let dt = Datatype::Array {
             base_type: Box::new(Datatype::FixedPoint {
-                size: 4, byte_order: DatatypeByteOrder::LittleEndian,
-                signed: true, bit_offset: 0, bit_precision: 32,
+                size: 4,
+                byte_order: DatatypeByteOrder::LittleEndian,
+                signed: true,
+                bit_offset: 0,
+                bit_precision: 32,
             }),
             dimensions: vec![3, 4],
         };

--- a/src/error.rs
+++ b/src/error.rs
@@ -212,10 +212,7 @@ impl fmt::Display for FormatError {
                 write!(f, "invalid datatype class: {c}")
             }
             FormatError::InvalidDatatypeVersion { class, version } => {
-                write!(
-                    f,
-                    "invalid datatype version {version} for class {class}"
-                )
+                write!(f, "invalid datatype version {version} for class {class}")
             }
             FormatError::InvalidStringPadding(p) => {
                 write!(f, "invalid string padding type: {p}")
@@ -325,8 +322,14 @@ impl fmt::Display for FormatError {
             FormatError::InvalidGlobalHeapVersion(v) => {
                 write!(f, "invalid global heap version: {v}")
             }
-            FormatError::GlobalHeapObjectNotFound { collection_address, index } => {
-                write!(f, "global heap object not found: collection {collection_address:#x}, index {index}")
+            FormatError::GlobalHeapObjectNotFound {
+                collection_address,
+                index,
+            } => {
+                write!(
+                    f,
+                    "global heap object not found: collection {collection_address:#x}, index {index}"
+                )
             }
             FormatError::VlDataError(msg) => {
                 write!(f, "variable-length data error: {msg}")

--- a/src/extensible_array.rs
+++ b/src/extensible_array.rs
@@ -96,8 +96,8 @@ impl ExtensibleArrayHeader {
         //   max_nelmts_bits(1) + idx_blk_elmts(1) + min_dblk_nelmts(1) +
         //   super_blk_min_nelmts(1) + max_dblk_nelmts_bits(1) +
         //   6 stats fields (each length_size) + index_block_address(offset_size) + checksum(4)
-        let min_size = 4 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
-            + 6 * length_size as usize + offset_size as usize + 4;
+        let min_size =
+            4 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 6 * length_size as usize + offset_size as usize + 4;
         if offset + min_size > file_data.len() {
             return Err(FormatError::UnexpectedEof {
                 expected: offset + min_size,
@@ -114,9 +114,9 @@ impl ExtensibleArrayHeader {
 
         let version = d[4];
         if version != 0 {
-            return Err(FormatError::ChunkedReadError(
-                format!("unsupported Extensible Array header version: {version}"),
-            ));
+            return Err(FormatError::ChunkedReadError(format!(
+                "unsupported Extensible Array header version: {version}"
+            )));
         }
 
         let client_id = d[5];
@@ -153,8 +153,7 @@ impl ExtensibleArrayHeader {
 
     /// Compute the size of this header in bytes (for write support).
     pub fn serialized_size(offset_size: u8, length_size: u8) -> usize {
-        4 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
-            + 6 * length_size as usize + offset_size as usize + 4
+        4 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 6 * length_size as usize + offset_size as usize + 4
     }
 }
 
@@ -337,7 +336,11 @@ fn read_data_block_elements(
 
             let elems_this_page = if page_idx == npages - 1 {
                 let remainder = nelmts % page_nelmts;
-                if remainder == 0 { page_nelmts } else { remainder }
+                if remainder == 0 {
+                    page_nelmts
+                } else {
+                    remainder
+                }
             } else {
                 page_nelmts
             };
@@ -396,8 +399,8 @@ pub fn read_extensible_array_chunks(
         num_chunks_per_dim.push(ds_dim.div_ceil(ch_dim));
     }
 
-    let chunk_byte_size: u64 = chunk_dimensions.iter().map(|&d| d as u64).product::<u64>()
-        * element_size as u64;
+    let chunk_byte_size: u64 =
+        chunk_dimensions.iter().map(|&d| d as u64).product::<u64>() * element_size as u64;
 
     // Parse index block (AEIB)
     let ib_offset = header.index_block_address as usize;
@@ -656,17 +659,32 @@ mod tests {
         let num_chunks = vec![5u64];
         let chunk_dims = vec![20u32];
         assert_eq!(index_to_chunk_offsets(0, &num_chunks, &chunk_dims), vec![0]);
-        assert_eq!(index_to_chunk_offsets(1, &num_chunks, &chunk_dims), vec![20]);
-        assert_eq!(index_to_chunk_offsets(4, &num_chunks, &chunk_dims), vec![80]);
+        assert_eq!(
+            index_to_chunk_offsets(1, &num_chunks, &chunk_dims),
+            vec![20]
+        );
+        assert_eq!(
+            index_to_chunk_offsets(4, &num_chunks, &chunk_dims),
+            vec![80]
+        );
     }
 
     #[test]
     fn index_to_offsets_2d() {
         let num_chunks = vec![3u64, 2];
         let chunk_dims = vec![4u32, 3];
-        assert_eq!(index_to_chunk_offsets(0, &num_chunks, &chunk_dims), vec![0, 0]);
-        assert_eq!(index_to_chunk_offsets(1, &num_chunks, &chunk_dims), vec![0, 3]);
-        assert_eq!(index_to_chunk_offsets(2, &num_chunks, &chunk_dims), vec![4, 0]);
+        assert_eq!(
+            index_to_chunk_offsets(0, &num_chunks, &chunk_dims),
+            vec![0, 0]
+        );
+        assert_eq!(
+            index_to_chunk_offsets(1, &num_chunks, &chunk_dims),
+            vec![0, 3]
+        );
+        assert_eq!(
+            index_to_chunk_offsets(2, &num_chunks, &chunk_dims),
+            vec![4, 0]
+        );
     }
 
     #[test]
@@ -770,16 +788,9 @@ mod tests {
         let header = ExtensibleArrayHeader::parse(&file_data, aehd_offset, os, ls).unwrap();
         let ds_dims = vec![40u64]; // 2 chunks × 20 elements
         let chunk_dims = vec![20u32];
-        let chunks = read_extensible_array_chunks(
-            &file_data,
-            &header,
-            &ds_dims,
-            &chunk_dims,
-            8,
-            os,
-            ls,
-        )
-        .unwrap();
+        let chunks =
+            read_extensible_array_chunks(&file_data, &header, &ds_dims, &chunk_dims, 8, os, ls)
+                .unwrap();
 
         assert_eq!(chunks.len(), 2);
         assert_eq!(chunks[0].address, base_addr);
@@ -880,10 +891,9 @@ mod tests {
         let header = ExtensibleArrayHeader::parse(&file_data, aehd_offset, os, ls).unwrap();
         let ds_dims = vec![40u64];
         let chunk_dims = vec![10u32];
-        let chunks = read_extensible_array_chunks(
-            &file_data, &header, &ds_dims, &chunk_dims, 8, os, ls,
-        )
-        .unwrap();
+        let chunks =
+            read_extensible_array_chunks(&file_data, &header, &ds_dims, &chunk_dims, 8, os, ls)
+                .unwrap();
 
         assert_eq!(chunks.len(), 4);
         for (i, c) in chunks.iter().enumerate() {
@@ -907,10 +917,8 @@ mod tests {
         let data = vec![0xFFu8; 16];
         let num_chunks = vec![5u64];
         let chunk_dims = vec![10u32];
-        let (info, consumed) = read_element(
-            &data, 0, 0, 8, 8, 80, 0, &num_chunks, &chunk_dims,
-        )
-        .unwrap();
+        let (info, consumed) =
+            read_element(&data, 0, 0, 8, 8, 80, 0, &num_chunks, &chunk_dims).unwrap();
         assert!(info.is_none());
         assert_eq!(consumed, 8);
     }
@@ -932,7 +940,15 @@ mod tests {
         let num_chunks = vec![5u64];
         let chunk_dims = vec![10u32];
         let (info, consumed) = read_element(
-            &data, 0, 1, elem_size as u8, os, 80, 2, &num_chunks, &chunk_dims,
+            &data,
+            0,
+            1,
+            elem_size as u8,
+            os,
+            80,
+            2,
+            &num_chunks,
+            &chunk_dims,
         )
         .unwrap();
         let ci = info.unwrap();

--- a/src/file_writer.rs
+++ b/src/file_writer.rs
@@ -9,10 +9,10 @@ use alloc::{string::String, string::ToString, vec, vec::Vec};
 #[cfg(not(feature = "std"))]
 use alloc::format;
 
-#[cfg(feature = "std")]
-use std::collections::HashMap;
 #[cfg(not(feature = "std"))]
 use alloc::collections::BTreeMap as HashMap;
+#[cfg(feature = "std")]
+use std::collections::HashMap;
 
 use crate::attribute::AttributeMessage;
 use crate::chunked_write::{ChunkOptions, build_chunked_data_at_ext};
@@ -24,14 +24,14 @@ use crate::metadata_index::{DatasetMetadata, MetadataBlock, MetadataIndex};
 use crate::object_header_writer::ObjectHeaderWriter;
 use crate::superblock::Superblock;
 use crate::type_builders::{
-    build_attr_message, build_global_heap_collection, patch_vl_refs,
-    DatasetBuilder, FinishedGroup, GroupBuilder,
+    DatasetBuilder, FinishedGroup, GroupBuilder, build_attr_message, build_global_heap_collection,
+    patch_vl_refs,
 };
 
 // Re-export public types that moved to type_builders for API compatibility.
-pub use crate::type_builders::{AttrValue, CompoundTypeBuilder, EnumTypeBuilder};
 #[cfg(feature = "provenance")]
 pub use crate::type_builders::ProvenanceConfig;
+pub use crate::type_builders::{AttrValue, CompoundTypeBuilder, EnumTypeBuilder};
 
 use crate::datatype::{CharacterSet, Datatype};
 
@@ -169,9 +169,32 @@ pub(crate) fn build_dense_attrs(attrs: &[AttributeMessage], base_address: u64) -
     let starting_block_size = dblock_content_size.next_power_of_two().max(512) as u64;
 
     // Fractal heap header size
-    let frhp_size = 4 + 1 + 2 + 2 + 1 + 4
-        + ls + os + ls + os + ls + ls + ls + ls + ls + ls + ls + ls
-        + 2 + ls + ls + 2 + 2 + os + 2 + 4;
+    let frhp_size = 4
+        + 1
+        + 2
+        + 2
+        + 1
+        + 4
+        + ls
+        + os
+        + ls
+        + os
+        + ls
+        + ls
+        + ls
+        + ls
+        + ls
+        + ls
+        + ls
+        + ls
+        + 2
+        + ls
+        + ls
+        + 2
+        + 2
+        + os
+        + 2
+        + 4;
 
     let frhp_addr = base_address;
     let dblock_addr = frhp_addr + frhp_size as u64;
@@ -436,7 +459,7 @@ impl FileWriter {
             let dt = db.datatype.ok_or(FormatError::DatasetMissingData)?;
             let shape = db.shape.ok_or(FormatError::DatasetMissingShape)?;
             // Allow empty data for zero-element datasets (e.g. shape [0, 0]).
-            let is_empty = shape.iter().any(|&d| d == 0);
+            let is_empty = shape.contains(&0);
             let raw = if is_empty {
                 db.data.unwrap_or_default()
             } else {
@@ -444,12 +467,20 @@ impl FileWriter {
             };
             let max_dimensions = db.maxshape.clone();
             let dspace = Dataspace {
-                space_type: if shape.is_empty() { DataspaceType::Scalar } else { DataspaceType::Simple },
-                rank: shape.len() as u8, dimensions: shape, max_dimensions,
+                space_type: if shape.is_empty() {
+                    DataspaceType::Scalar
+                } else {
+                    DataspaceType::Simple
+                },
+                rank: shape.len() as u8,
+                dimensions: shape,
+                max_dimensions,
             };
             let patches = collect_vl_patches(&db.attrs);
             let mut attrs = Vec::new();
-            for (n, v) in &db.attrs { attrs.push(build_attr_message(n, v)); }
+            for (n, v) in &db.attrs {
+                attrs.push(build_attr_message(n, v));
+            }
             #[cfg(feature = "provenance")]
             if let Some(ref prov) = db.provenance {
                 let p = crate::provenance::Provenance {
@@ -460,7 +491,16 @@ impl FileWriter {
                 attrs.extend(p.build_attrs(&raw));
             }
             let idx = all_ds.len();
-            all_ds.push(DsFlat { name: db.name, dt, ds: dspace, raw, attrs, chunk_options: db.chunk_options, maxshape: db.maxshape, reference_targets: db.reference_targets });
+            all_ds.push(DsFlat {
+                name: db.name,
+                dt,
+                ds: dspace,
+                raw,
+                attrs,
+                chunk_options: db.chunk_options,
+                maxshape: db.maxshape,
+                reference_targets: db.reference_targets,
+            });
             ds_vl.push(patches);
             Ok(idx)
         }
@@ -474,7 +514,9 @@ impl FileWriter {
         ) -> Result<usize, FormatError> {
             let patches = collect_vl_patches(&g.attrs);
             let mut gattrs = Vec::new();
-            for (n, v) in &g.attrs { gattrs.push(build_attr_message(n, v)); }
+            for (n, v) in &g.attrs {
+                gattrs.push(build_attr_message(n, v));
+            }
             let mut ds_idx = Vec::new();
             for db in g.datasets {
                 ds_idx.push(flatten_dataset(db, all_ds, ds_vl)?);
@@ -484,7 +526,12 @@ impl FileWriter {
                 sub_grp_idx.push(flatten_group(sg, all_ds, groups, grp_vl, ds_vl)?);
             }
             let gi = groups.len();
-            groups.push(GrpFlat { name: g.name, attrs: gattrs, ds_indices: ds_idx, sub_group_indices: sub_grp_idx });
+            groups.push(GrpFlat {
+                name: g.name,
+                attrs: gattrs,
+                ds_indices: ds_idx,
+                sub_group_indices: sub_grp_idx,
+            });
             grp_vl.push(patches);
             Ok(gi)
         }
@@ -497,7 +544,13 @@ impl FileWriter {
         }
 
         for g in self.groups.into_iter() {
-            root_group_indices.push(flatten_group(g, &mut all_ds, &mut groups, &mut grp_vl, &mut ds_vl)?);
+            root_group_indices.push(flatten_group(
+                g,
+                &mut all_ds,
+                &mut groups,
+                &mut grp_vl,
+                &mut ds_vl,
+            )?);
         }
 
         // Build global heap collections for VarLenAsciiArray attributes.
@@ -528,27 +581,50 @@ impl FileWriter {
             root_attrs.push(build_attr_message(n, v));
         }
 
-        let is_chunked: Vec<bool> = all_ds.iter().map(|d| d.chunk_options.is_chunked() || d.maxshape.is_some()).collect();
+        let is_chunked: Vec<bool> = all_ds
+            .iter()
+            .map(|d| d.chunk_options.is_chunked() || d.maxshape.is_some())
+            .collect();
         let root_dense = root_attrs.len() > DENSE_ATTR_THRESHOLD;
-        let group_dense: Vec<bool> = groups.iter().map(|g| g.attrs.len() > DENSE_ATTR_THRESHOLD).collect();
-        let ds_dense: Vec<bool> = all_ds.iter().map(|d| d.attrs.len() > DENSE_ATTR_THRESHOLD).collect();
+        let group_dense: Vec<bool> = groups
+            .iter()
+            .map(|g| g.attrs.len() > DENSE_ATTR_THRESHOLD)
+            .collect();
+        let ds_dense: Vec<bool> = all_ds
+            .iter()
+            .map(|d| d.attrs.len() > DENSE_ATTR_THRESHOLD)
+            .collect();
 
         // Pass 1: compute OH sizes with dummy addresses
-        let group_oh_sizes: Vec<usize> = groups.iter().enumerate().map(|(gi, g)| {
-            let mut dummy_links: Vec<LinkMessage> = g.ds_indices.iter().map(|&i| make_link(&all_ds[i].name, 0)).collect();
-            for &sgi in &g.sub_group_indices { dummy_links.push(make_link(&groups[sgi].name, 0)); }
-            if group_dense[gi] {
-                let dummy_blob = build_dense_attrs(&g.attrs, 0);
-                build_group_oh(&dummy_links, &g.attrs, Some(&dummy_blob)).len()
-            } else {
-                build_group_oh(&dummy_links, &g.attrs, None).len()
-            }
-        }).collect();
+        let group_oh_sizes: Vec<usize> = groups
+            .iter()
+            .enumerate()
+            .map(|(gi, g)| {
+                let mut dummy_links: Vec<LinkMessage> = g
+                    .ds_indices
+                    .iter()
+                    .map(|&i| make_link(&all_ds[i].name, 0))
+                    .collect();
+                for &sgi in &g.sub_group_indices {
+                    dummy_links.push(make_link(&groups[sgi].name, 0));
+                }
+                if group_dense[gi] {
+                    let dummy_blob = build_dense_attrs(&g.attrs, 0);
+                    build_group_oh(&dummy_links, &g.attrs, Some(&dummy_blob)).len()
+                } else {
+                    build_group_oh(&dummy_links, &g.attrs, None).len()
+                }
+            })
+            .collect();
 
         let root_dummy_links: Vec<LinkMessage> = {
             let mut links = Vec::new();
-            for &i in &root_ds_indices { links.push(make_link(&all_ds[i].name, 0)); }
-            for &gi in &root_group_indices { links.push(make_link(&groups[gi].name, 0)); }
+            for &i in &root_ds_indices {
+                links.push(make_link(&all_ds[i].name, 0));
+            }
+            for &gi in &root_group_indices {
+                links.push(make_link(&groups[gi].name, 0));
+            }
             links
         };
         let root_oh_size = if root_dense {
@@ -558,7 +634,10 @@ impl FileWriter {
             build_group_oh(&root_dummy_links, &root_attrs, None).len()
         };
 
-        struct DataBlob { data: Vec<u8>, oh_bytes: Vec<u8> }
+        struct DataBlob {
+            data: Vec<u8>,
+            oh_bytes: Vec<u8>,
+        }
 
         let mut dummy_blobs: Vec<DataBlob> = Vec::new();
         let mut dummy_cursor = 0u64;
@@ -566,15 +645,50 @@ impl FileWriter {
             if is_chunked[i] {
                 let chunk_dims = d.chunk_options.resolve_chunk_dims(&d.ds.dimensions);
                 let ctx = crate::filters::ChunkContext::from_datatype(&chunk_dims, &d.dt);
-                let result = build_chunked_data_at_ext(&d.raw, &d.ds.dimensions, ctx, &d.chunk_options, dummy_cursor, d.maxshape.as_deref())?;
+                let result = build_chunked_data_at_ext(
+                    &d.raw,
+                    &d.ds.dimensions,
+                    ctx,
+                    &d.chunk_options,
+                    dummy_cursor,
+                    d.maxshape.as_deref(),
+                )?;
                 dummy_cursor += result.data_bytes.len() as u64;
-                let dense_blob = if ds_dense[i] { Some(build_dense_attrs(&d.attrs, 0)) } else { None };
-                let oh = build_chunked_dataset_oh(&d.dt, &d.ds, &result.layout_message, result.pipeline_message.as_deref(), &d.attrs, dense_blob.as_ref());
-                dummy_blobs.push(DataBlob { data: result.data_bytes, oh_bytes: oh });
+                let dense_blob = if ds_dense[i] {
+                    Some(build_dense_attrs(&d.attrs, 0))
+                } else {
+                    None
+                };
+                let oh = build_chunked_dataset_oh(
+                    &d.dt,
+                    &d.ds,
+                    &result.layout_message,
+                    result.pipeline_message.as_deref(),
+                    &d.attrs,
+                    dense_blob.as_ref(),
+                );
+                dummy_blobs.push(DataBlob {
+                    data: result.data_bytes,
+                    oh_bytes: oh,
+                });
             } else {
-                let dense_blob = if ds_dense[i] { Some(build_dense_attrs(&d.attrs, 0)) } else { None };
-                let oh = build_dataset_oh(&d.dt, &d.ds, 0, d.raw.len() as u64, &d.attrs, dense_blob.as_ref());
-                dummy_blobs.push(DataBlob { data: d.raw.clone(), oh_bytes: oh });
+                let dense_blob = if ds_dense[i] {
+                    Some(build_dense_attrs(&d.attrs, 0))
+                } else {
+                    None
+                };
+                let oh = build_dataset_oh(
+                    &d.dt,
+                    &d.ds,
+                    0,
+                    d.raw.len() as u64,
+                    &d.attrs,
+                    dense_blob.as_ref(),
+                );
+                dummy_blobs.push(DataBlob {
+                    data: d.raw.clone(),
+                    oh_bytes: oh,
+                });
             }
         }
 
@@ -596,32 +710,40 @@ impl FileWriter {
         };
 
         let mut group_dense_blobs: Vec<Option<DenseAttrBlob>> = Vec::new();
-        let group_addrs2: Vec<u64> = group_oh_sizes.iter().enumerate().map(|(gi, &sz)| {
-            let addr = cursor2 as u64;
-            cursor2 += sz;
-            if group_dense[gi] {
-                let blob = build_dense_attrs(&groups[gi].attrs, cursor2 as u64);
-                cursor2 += blob.blob.len();
-                group_dense_blobs.push(Some(blob));
-            } else {
-                group_dense_blobs.push(None);
-            }
-            addr
-        }).collect();
+        let group_addrs2: Vec<u64> = group_oh_sizes
+            .iter()
+            .enumerate()
+            .map(|(gi, &sz)| {
+                let addr = cursor2 as u64;
+                cursor2 += sz;
+                if group_dense[gi] {
+                    let blob = build_dense_attrs(&groups[gi].attrs, cursor2 as u64);
+                    cursor2 += blob.blob.len();
+                    group_dense_blobs.push(Some(blob));
+                } else {
+                    group_dense_blobs.push(None);
+                }
+                addr
+            })
+            .collect();
 
         let mut ds_dense_blobs: Vec<Option<DenseAttrBlob>> = Vec::new();
-        let ds_oh_addrs2: Vec<u64> = actual_ds_oh_sizes.iter().enumerate().map(|(i, &sz)| {
-            let addr = cursor2 as u64;
-            cursor2 += sz;
-            if ds_dense[i] {
-                let blob = build_dense_attrs(&all_ds[i].attrs, cursor2 as u64);
-                cursor2 += blob.blob.len();
-                ds_dense_blobs.push(Some(blob));
-            } else {
-                ds_dense_blobs.push(None);
-            }
-            addr
-        }).collect();
+        let ds_oh_addrs2: Vec<u64> = actual_ds_oh_sizes
+            .iter()
+            .enumerate()
+            .map(|(i, &sz)| {
+                let addr = cursor2 as u64;
+                cursor2 += sz;
+                if ds_dense[i] {
+                    let blob = build_dense_attrs(&all_ds[i].attrs, cursor2 as u64);
+                    cursor2 += blob.blob.len();
+                    ds_dense_blobs.push(Some(blob));
+                } else {
+                    ds_dense_blobs.push(None);
+                }
+                addr
+            })
+            .collect();
 
         // Resolve path-based references now that all addresses are known.
         // Build a map of (group_name, child_name) -> address for resolution.
@@ -651,11 +773,24 @@ impl FileWriter {
                     for &sgi in &groups[gi].sub_group_indices {
                         register_group(
                             &format!("{}/{}", prefix, groups[sgi].name),
-                            sgi, groups, ds_addrs, grp_addrs, all_ds, map,
+                            sgi,
+                            groups,
+                            ds_addrs,
+                            grp_addrs,
+                            all_ds,
+                            map,
                         );
                     }
                 }
-                register_group(&groups[gi].name, gi, &groups, &ds_oh_addrs2, &group_addrs2, &all_ds, &mut path_map);
+                register_group(
+                    &groups[gi].name,
+                    gi,
+                    &groups,
+                    &ds_oh_addrs2,
+                    &group_addrs2,
+                    &all_ds,
+                    &mut path_map,
+                );
             }
 
             // Patch reference datasets
@@ -684,20 +819,34 @@ impl FileWriter {
                 let chunk_dims = d.chunk_options.resolve_chunk_dims(&d.ds.dimensions);
                 let base_address = cursor2 as u64;
                 let ctx = crate::filters::ChunkContext::from_datatype(&chunk_dims, &d.dt);
-                let result = build_chunked_data_at_ext(&d.raw, &d.ds.dimensions, ctx, &d.chunk_options, base_address, d.maxshape.as_deref())?;
+                let result = build_chunked_data_at_ext(
+                    &d.raw,
+                    &d.ds.dimensions,
+                    ctx,
+                    &d.chunk_options,
+                    base_address,
+                    d.maxshape.as_deref(),
+                )?;
                 cursor2 += result.data_bytes.len();
                 ds_layouts.push(DsLayout {
-                    data: result.data_bytes, data_addr: base_address,
+                    data: result.data_bytes,
+                    data_addr: base_address,
                     chunked_msgs: Some((result.layout_message, result.pipeline_message)),
                 });
             } else {
                 let data = d.raw.clone();
-                let addr = if data.is_empty() { u64::MAX } else {
+                let addr = if data.is_empty() {
+                    u64::MAX
+                } else {
                     let a = cursor2 as u64;
                     cursor2 += data.len();
                     a
                 };
-                ds_layouts.push(DsLayout { data, data_addr: addr, chunked_msgs: None });
+                ds_layouts.push(DsLayout {
+                    data,
+                    data_addr: addr,
+                    chunked_msgs: None,
+                });
             }
         }
 
@@ -715,13 +864,19 @@ impl FileWriter {
             }
             for (gi, patches) in grp_vl.iter().enumerate() {
                 for patch in patches {
-                    patch_vl_refs(&mut groups[gi].attrs[patch.attr_index].raw_data, gcol_cursor);
+                    patch_vl_refs(
+                        &mut groups[gi].attrs[patch.attr_index].raw_data,
+                        gcol_cursor,
+                    );
                     gcol_cursor += patch.collection_bytes.len() as u64;
                 }
             }
             for (di, patches) in ds_vl.iter().enumerate() {
                 for patch in patches {
-                    patch_vl_refs(&mut all_ds[di].attrs[patch.attr_index].raw_data, gcol_cursor);
+                    patch_vl_refs(
+                        &mut all_ds[di].attrs[patch.attr_index].raw_data,
+                        gcol_cursor,
+                    );
                     gcol_cursor += patch.collection_bytes.len() as u64;
                 }
             }
@@ -733,11 +888,28 @@ impl FileWriter {
         for (i, d) in all_ds.iter().enumerate() {
             let layout = &ds_layouts[i];
             let oh = if let Some((ref lm, ref pm)) = layout.chunked_msgs {
-                build_chunked_dataset_oh(&d.dt, &d.ds, lm, pm.as_deref(), &d.attrs, ds_dense_blobs[i].as_ref())
+                build_chunked_dataset_oh(
+                    &d.dt,
+                    &d.ds,
+                    lm,
+                    pm.as_deref(),
+                    &d.attrs,
+                    ds_dense_blobs[i].as_ref(),
+                )
             } else {
-                build_dataset_oh(&d.dt, &d.ds, layout.data_addr, layout.data.len() as u64, &d.attrs, ds_dense_blobs[i].as_ref())
+                build_dataset_oh(
+                    &d.dt,
+                    &d.ds,
+                    layout.data_addr,
+                    layout.data.len() as u64,
+                    &d.attrs,
+                    ds_dense_blobs[i].as_ref(),
+                )
             };
-            ds_blobs2.push(DataBlob { data: layout.data.clone(), oh_bytes: oh });
+            ds_blobs2.push(DataBlob {
+                data: layout.data.clone(),
+                oh_bytes: oh,
+            });
         }
 
         let actual_ds_oh_sizes2: Vec<usize> = ds_blobs2.iter().map(|b| b.oh_bytes.len()).collect();
@@ -753,45 +925,90 @@ impl FileWriter {
         }
 
         let sb = Superblock {
-            version: 3, offset_size: OFFSET_SIZE, length_size: LENGTH_SIZE,
-            base_address: ub as u64, eof_address: eof_addr2, root_group_address: root_group_addr,
-            group_leaf_node_k: None, group_internal_node_k: None, indexed_storage_internal_node_k: None,
-            free_space_address: None, driver_info_address: None,
-            consistency_flags: 0, superblock_extension_address: Some(u64::MAX), checksum: None,
+            version: 3,
+            offset_size: OFFSET_SIZE,
+            length_size: LENGTH_SIZE,
+            base_address: ub as u64,
+            eof_address: eof_addr2,
+            root_group_address: root_group_addr,
+            group_leaf_node_k: None,
+            group_internal_node_k: None,
+            indexed_storage_internal_node_k: None,
+            free_space_address: None,
+            driver_info_address: None,
+            consistency_flags: 0,
+            superblock_extension_address: Some(u64::MAX),
+            checksum: None,
         };
         buf.extend_from_slice(&sb.serialize());
 
         // Root group OH
         let root_links: Vec<LinkMessage> = {
             let mut v = Vec::new();
-            for &i in &root_ds_indices { v.push(make_link(&all_ds[i].name, ds_oh_addrs2[i])); }
-            for &gi in &root_group_indices { v.push(make_link(&groups[gi].name, group_addrs2[gi])); }
+            for &i in &root_ds_indices {
+                v.push(make_link(&all_ds[i].name, ds_oh_addrs2[i]));
+            }
+            for &gi in &root_group_indices {
+                v.push(make_link(&groups[gi].name, group_addrs2[gi]));
+            }
             v
         };
-        buf.extend_from_slice(&build_group_oh(&root_links, &root_attrs, root_dense_blob.as_ref()));
-        if let Some(ref blob) = root_dense_blob { buf.extend_from_slice(&blob.blob); }
+        buf.extend_from_slice(&build_group_oh(
+            &root_links,
+            &root_attrs,
+            root_dense_blob.as_ref(),
+        ));
+        if let Some(ref blob) = root_dense_blob {
+            buf.extend_from_slice(&blob.blob);
+        }
 
         // Group OHs + dense blobs
         for (gi, g) in groups.iter().enumerate() {
-            let mut links: Vec<LinkMessage> = g.ds_indices.iter().map(|&i| make_link(&all_ds[i].name, ds_oh_addrs2[i])).collect();
-            for &sgi in &g.sub_group_indices { links.push(make_link(&groups[sgi].name, group_addrs2[sgi])); }
-            buf.extend_from_slice(&build_group_oh(&links, &g.attrs, group_dense_blobs[gi].as_ref()));
-            if let Some(ref blob) = group_dense_blobs[gi] { buf.extend_from_slice(&blob.blob); }
+            let mut links: Vec<LinkMessage> = g
+                .ds_indices
+                .iter()
+                .map(|&i| make_link(&all_ds[i].name, ds_oh_addrs2[i]))
+                .collect();
+            for &sgi in &g.sub_group_indices {
+                links.push(make_link(&groups[sgi].name, group_addrs2[sgi]));
+            }
+            buf.extend_from_slice(&build_group_oh(
+                &links,
+                &g.attrs,
+                group_dense_blobs[gi].as_ref(),
+            ));
+            if let Some(ref blob) = group_dense_blobs[gi] {
+                buf.extend_from_slice(&blob.blob);
+            }
         }
 
         // Dataset OHs + dense blobs
         for (i, blob) in ds_blobs2.iter().enumerate() {
             buf.extend_from_slice(&blob.oh_bytes);
-            if let Some(ref dense) = ds_dense_blobs[i] { buf.extend_from_slice(&dense.blob); }
+            if let Some(ref dense) = ds_dense_blobs[i] {
+                buf.extend_from_slice(&dense.blob);
+            }
         }
 
         // Data
-        for blob in &ds_blobs2 { buf.extend_from_slice(&blob.data); }
+        for blob in &ds_blobs2 {
+            buf.extend_from_slice(&blob.data);
+        }
 
         // Global heap collections
-        for patch in &vl_root { buf.extend_from_slice(&patch.collection_bytes); }
-        for patches in &grp_vl { for patch in patches { buf.extend_from_slice(&patch.collection_bytes); } }
-        for patches in &ds_vl { for patch in patches { buf.extend_from_slice(&patch.collection_bytes); } }
+        for patch in &vl_root {
+            buf.extend_from_slice(&patch.collection_bytes);
+        }
+        for patches in &grp_vl {
+            for patch in patches {
+                buf.extend_from_slice(&patch.collection_bytes);
+            }
+        }
+        for patches in &ds_vl {
+            for patch in patches {
+                buf.extend_from_slice(&patch.collection_bytes);
+            }
+        }
 
         Ok(buf)
     }
@@ -869,7 +1086,13 @@ mod tests {
     fn parse_file(bytes: &[u8]) -> (Superblock, ObjectHeader) {
         let sig = signature::find_signature(bytes).unwrap();
         let sb = Superblock::parse(bytes, sig).unwrap();
-        let oh = ObjectHeader::parse(bytes, sb.root_group_address as usize, sb.offset_size, sb.length_size).unwrap();
+        let oh = ObjectHeader::parse(
+            bytes,
+            sb.root_group_address as usize,
+            sb.offset_size,
+            sb.length_size,
+        )
+        .unwrap();
         (sb, oh)
     }
 
@@ -877,13 +1100,30 @@ mod tests {
         let sig = signature::find_signature(bytes).unwrap();
         let sb = Superblock::parse(bytes, sig).unwrap();
         let addr = resolve_path_any(bytes, &sb, path).unwrap();
-        let hdr = ObjectHeader::parse(bytes, addr as usize, sb.offset_size, sb.length_size).unwrap();
-        let dt_data = &hdr.messages.iter().find(|m| m.msg_type == MessageType::Datatype).unwrap().data;
-        let ds_data = &hdr.messages.iter().find(|m| m.msg_type == MessageType::Dataspace).unwrap().data;
-        let dl_data = &hdr.messages.iter().find(|m| m.msg_type == MessageType::DataLayout).unwrap().data;
+        let hdr =
+            ObjectHeader::parse(bytes, addr as usize, sb.offset_size, sb.length_size).unwrap();
+        let dt_data = &hdr
+            .messages
+            .iter()
+            .find(|m| m.msg_type == MessageType::Datatype)
+            .unwrap()
+            .data;
+        let ds_data = &hdr
+            .messages
+            .iter()
+            .find(|m| m.msg_type == MessageType::Dataspace)
+            .unwrap()
+            .data;
+        let dl_data = &hdr
+            .messages
+            .iter()
+            .find(|m| m.msg_type == MessageType::DataLayout)
+            .unwrap()
+            .data;
         let (dt, _) = Datatype::parse(dt_data).unwrap();
         let ds = Dataspace::parse(ds_data, sb.length_size).unwrap();
-        let dl = crate::data_layout::DataLayout::parse(dl_data, sb.offset_size, sb.length_size).unwrap();
+        let dl =
+            crate::data_layout::DataLayout::parse(dl_data, sb.offset_size, sb.length_size).unwrap();
         let raw = crate::data_read::read_raw_data(bytes, &dl, &ds, &dt).unwrap();
         crate::data_read::read_as_f64(&raw, &dt).unwrap()
     }
@@ -908,13 +1148,16 @@ mod tests {
     #[test]
     fn file_with_dataset_attrs() {
         let mut fw = FileWriter::new();
-        fw.create_dataset("data").with_f64_data(&[1.0, 2.0]).set_attr("scale", AttrValue::F64(0.5));
+        fw.create_dataset("data")
+            .with_f64_data(&[1.0, 2.0])
+            .set_attr("scale", AttrValue::F64(0.5));
         let bytes = fw.finish().unwrap();
         assert_eq!(read_dataset_f64(&bytes, "data"), vec![1.0, 2.0]);
         let sig = signature::find_signature(&bytes).unwrap();
         let sb = Superblock::parse(&bytes, sig).unwrap();
         let addr = resolve_path_any(&bytes, &sb, "data").unwrap();
-        let hdr = ObjectHeader::parse(&bytes, addr as usize, sb.offset_size, sb.length_size).unwrap();
+        let hdr =
+            ObjectHeader::parse(&bytes, addr as usize, sb.offset_size, sb.length_size).unwrap();
         let attrs = crate::attribute::extract_attributes(&hdr, sb.length_size).unwrap();
         assert_eq!(attrs.len(), 1);
         assert_eq!(attrs[0].name, "scale");
@@ -952,11 +1195,17 @@ mod tests {
         let sig = signature::find_signature(&bytes).unwrap();
         let sb = Superblock::parse(&bytes, sig).unwrap();
         let addr = resolve_path_any(&bytes, &sb, "data").unwrap();
-        let hdr = ObjectHeader::parse(&bytes, addr as usize, sb.offset_size, sb.length_size).unwrap();
-        let attrs = crate::attribute::extract_attributes_full(&bytes, &hdr, sb.offset_size, sb.length_size).unwrap();
+        let hdr =
+            ObjectHeader::parse(&bytes, addr as usize, sb.offset_size, sb.length_size).unwrap();
+        let attrs =
+            crate::attribute::extract_attributes_full(&bytes, &hdr, sb.offset_size, sb.length_size)
+                .unwrap();
         assert_eq!(attrs.len(), 20);
         for i in 0..20 {
-            let attr = attrs.iter().find(|a| a.name == format!("attr_{i:03}")).unwrap();
+            let attr = attrs
+                .iter()
+                .find(|a| a.name == format!("attr_{i:03}"))
+                .unwrap();
             let v = attr.read_as_f64().unwrap();
             assert!((v[0] - i as f64 * 1.5).abs() < 1e-10);
         }
@@ -973,8 +1222,16 @@ mod tests {
         let bytes = fw.finish().unwrap();
         let sig = signature::find_signature(&bytes).unwrap();
         let sb = Superblock::parse(&bytes, sig).unwrap();
-        let oh = ObjectHeader::parse(&bytes, sb.root_group_address as usize, sb.offset_size, sb.length_size).unwrap();
-        let attrs = crate::attribute::extract_attributes_full(&bytes, &oh, sb.offset_size, sb.length_size).unwrap();
+        let oh = ObjectHeader::parse(
+            &bytes,
+            sb.root_group_address as usize,
+            sb.offset_size,
+            sb.length_size,
+        )
+        .unwrap();
+        let attrs =
+            crate::attribute::extract_attributes_full(&bytes, &oh, sb.offset_size, sb.length_size)
+                .unwrap();
         assert_eq!(attrs.len(), 15);
     }
 
@@ -983,13 +1240,20 @@ mod tests {
         let mut fw = FileWriter::new();
         let ds = fw.create_dataset("data");
         ds.with_f64_data(&[1.0]);
-        for i in 0..5 { ds.set_attr(&format!("a{i}"), AttrValue::F64(i as f64)); }
+        for i in 0..5 {
+            ds.set_attr(&format!("a{i}"), AttrValue::F64(i as f64));
+        }
         let bytes = fw.finish().unwrap();
         let sig = signature::find_signature(&bytes).unwrap();
         let sb = Superblock::parse(&bytes, sig).unwrap();
         let addr = resolve_path_any(&bytes, &sb, "data").unwrap();
-        let hdr = ObjectHeader::parse(&bytes, addr as usize, sb.offset_size, sb.length_size).unwrap();
-        assert!(!hdr.messages.iter().any(|m| m.msg_type == MessageType::AttributeInfo));
+        let hdr =
+            ObjectHeader::parse(&bytes, addr as usize, sb.offset_size, sb.length_size).unwrap();
+        assert!(
+            !hdr.messages
+                .iter()
+                .any(|m| m.msg_type == MessageType::AttributeInfo)
+        );
         let attrs = crate::attribute::extract_attributes(&hdr, sb.length_size).unwrap();
         assert_eq!(attrs.len(), 5);
     }
@@ -998,11 +1262,16 @@ mod tests {
     fn encode_decode_managed_id_roundtrip() {
         let id = encode_managed_id(100, 42, 40, 8);
         let fh = crate::fractal_heap::FractalHeapHeader {
-            heap_id_length: 8, io_filter_encoded_length: 0,
-            max_managed_object_size: 1024, table_width: 4,
-            starting_block_size: 4096, max_direct_block_size: 65536,
-            max_heap_size: 40, starting_row_of_indirect_blocks: 1,
-            root_block_address: 0, current_rows_in_root_indirect_block: 0,
+            heap_id_length: 8,
+            io_filter_encoded_length: 0,
+            max_managed_object_size: 1024,
+            table_width: 4,
+            starting_block_size: 4096,
+            max_direct_block_size: 65536,
+            max_heap_size: 40,
+            starting_row_of_indirect_blocks: 1,
+            root_block_address: 0,
+            current_rows_in_root_indirect_block: 0,
             managed_objects_count: 0,
         };
         let (off, len) = fh.decode_managed_id(&id).unwrap();
@@ -1012,22 +1281,38 @@ mod tests {
 
     #[test]
     fn finalize_parallel_basic() {
-        use crate::metadata_index::{MetadataBlock, build_dataset_metadata};
         use crate::chunked_write::ChunkOptions;
+        use crate::metadata_index::{MetadataBlock, build_dataset_metadata};
         use crate::type_builders::make_f64_type;
 
         let mut b0 = MetadataBlock::new(0);
-        let data_a: Vec<u8> = [1.0f64, 2.0, 3.0].iter().flat_map(|v| v.to_le_bytes()).collect();
+        let data_a: Vec<u8> = [1.0f64, 2.0, 3.0]
+            .iter()
+            .flat_map(|v| v.to_le_bytes())
+            .collect();
         b0.add_dataset(build_dataset_metadata(
-            "alpha", make_f64_type(), vec![3], data_a,
-            ChunkOptions::default(), None, vec![],
+            "alpha",
+            make_f64_type(),
+            vec![3],
+            data_a,
+            ChunkOptions::default(),
+            None,
+            vec![],
         ));
 
         let mut b1 = MetadataBlock::new(1);
-        let data_b: Vec<u8> = [10.0f64, 20.0].iter().flat_map(|v| v.to_le_bytes()).collect();
+        let data_b: Vec<u8> = [10.0f64, 20.0]
+            .iter()
+            .flat_map(|v| v.to_le_bytes())
+            .collect();
         b1.add_dataset(build_dataset_metadata(
-            "beta", make_f64_type(), vec![2], data_b,
-            ChunkOptions::default(), None, vec![],
+            "beta",
+            make_f64_type(),
+            vec![2],
+            data_b,
+            ChunkOptions::default(),
+            None,
+            vec![],
         ));
 
         let bytes = finalize_parallel(vec![b0, b1]).unwrap();
@@ -1037,19 +1322,29 @@ mod tests {
 
     #[test]
     fn finalize_parallel_duplicate_error() {
-        use crate::metadata_index::{MetadataBlock, build_dataset_metadata};
         use crate::chunked_write::ChunkOptions;
+        use crate::metadata_index::{MetadataBlock, build_dataset_metadata};
         use crate::type_builders::make_f64_type;
 
         let mut b0 = MetadataBlock::new(0);
         b0.add_dataset(build_dataset_metadata(
-            "dup", make_f64_type(), vec![1], vec![0u8; 8],
-            ChunkOptions::default(), None, vec![],
+            "dup",
+            make_f64_type(),
+            vec![1],
+            vec![0u8; 8],
+            ChunkOptions::default(),
+            None,
+            vec![],
         ));
         let mut b1 = MetadataBlock::new(1);
         b1.add_dataset(build_dataset_metadata(
-            "dup", make_f64_type(), vec![1], vec![0u8; 8],
-            ChunkOptions::default(), None, vec![],
+            "dup",
+            make_f64_type(),
+            vec![1],
+            vec![0u8; 8],
+            ChunkOptions::default(),
+            None,
+            vec![],
         ));
         let err = finalize_parallel(vec![b0, b1]).unwrap_err();
         assert!(matches!(err, FormatError::DuplicateDatasetName(_)));

--- a/src/filter_pipeline.rs
+++ b/src/filter_pipeline.rs
@@ -101,7 +101,8 @@ impl FilterPipeline {
             ensure_len(data, pos, num_client_data * 4)?;
             let mut client_data = Vec::with_capacity(num_client_data);
             for _ in 0..num_client_data {
-                let val = u32::from_le_bytes([data[pos], data[pos + 1], data[pos + 2], data[pos + 3]]);
+                let val =
+                    u32::from_le_bytes([data[pos], data[pos + 1], data[pos + 2], data[pos + 3]]);
                 client_data.push(val);
                 pos += 4;
             }
@@ -119,7 +120,10 @@ impl FilterPipeline {
             });
         }
 
-        Ok(FilterPipeline { version: 1, filters })
+        Ok(FilterPipeline {
+            version: 1,
+            filters,
+        })
     }
 
     fn parse_v2(data: &[u8], number_of_filters: usize) -> Result<FilterPipeline, FormatError> {
@@ -163,7 +167,8 @@ impl FilterPipeline {
             ensure_len(data, pos, num_client_data * 4)?;
             let mut client_data = Vec::with_capacity(num_client_data);
             for _ in 0..num_client_data {
-                let val = u32::from_le_bytes([data[pos], data[pos + 1], data[pos + 2], data[pos + 3]]);
+                let val =
+                    u32::from_le_bytes([data[pos], data[pos + 1], data[pos + 2], data[pos + 3]]);
                 client_data.push(val);
                 pos += 4;
             }
@@ -178,7 +183,10 @@ impl FilterPipeline {
             });
         }
 
-        Ok(FilterPipeline { version: 2, filters })
+        Ok(FilterPipeline {
+            version: 2,
+            filters,
+        })
     }
 
     /// Serialize the filter pipeline to bytes.

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -7,9 +7,9 @@ extern crate alloc;
 use alloc::{format, vec, vec::Vec};
 
 use crate::error::FormatError;
-use crate::filter_pipeline::{FilterPipeline, FILTER_DEFLATE, FILTER_FLETCHER32, FILTER_SHUFFLE};
 #[cfg(feature = "zfp")]
 use crate::filter_pipeline::FILTER_ZFP;
+use crate::filter_pipeline::{FILTER_DEFLATE, FILTER_FLETCHER32, FILTER_SHUFFLE, FilterPipeline};
 #[cfg(feature = "zfp")]
 use crate::zfp::ZfpElementType;
 
@@ -73,8 +73,16 @@ pub fn zfp_element_type_from_datatype(
     match dt {
         Datatype::FloatingPoint { size: 4, .. } => Some(ZfpElementType::F32),
         Datatype::FloatingPoint { size: 8, .. } => Some(ZfpElementType::F64),
-        Datatype::FixedPoint { size: 4, signed: true, .. } => Some(ZfpElementType::I32),
-        Datatype::FixedPoint { size: 8, signed: true, .. } => Some(ZfpElementType::I64),
+        Datatype::FixedPoint {
+            size: 4,
+            signed: true,
+            ..
+        } => Some(ZfpElementType::I32),
+        Datatype::FixedPoint {
+            size: 8,
+            signed: true,
+            ..
+        } => Some(ZfpElementType::I64),
         _ => None,
     }
 }
@@ -137,9 +145,8 @@ pub fn compress_chunk(
 
 #[cfg(feature = "zfp")]
 fn zfp_rate(filter: &crate::filter_pipeline::FilterDescription) -> Result<f64, FormatError> {
-    crate::zfp::zfp_rate_from_cd_values(&filter.client_data).ok_or_else(|| {
-        FormatError::FilterError("ZFP: invalid or non-rate cd_values".into())
-    })
+    crate::zfp::zfp_rate_from_cd_values(&filter.client_data)
+        .ok_or_else(|| FormatError::FilterError("ZFP: invalid or non-rate cd_values".into()))
 }
 
 #[cfg(feature = "zfp")]
@@ -213,10 +220,7 @@ fn deflate_decompress(_data: &[u8]) -> Result<Vec<u8>, FormatError> {
 #[cfg(feature = "deflate")]
 fn deflate_compress(data: &[u8], level: u32) -> Result<Vec<u8>, FormatError> {
     use std::io::Write;
-    let mut encoder = flate2::write::ZlibEncoder::new(
-        Vec::new(),
-        flate2::Compression::new(level),
-    );
+    let mut encoder = flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::new(level));
     encoder
         .write_all(data)
         .map_err(|e| FormatError::CompressionError(e.to_string()))?;
@@ -394,7 +398,7 @@ mod tests {
         // Compress data and verify it decompresses correctly
         let data = vec![0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9];
         let compressed = deflate_compress(&data, 6).unwrap();
-        assert!(compressed.len() > 0);
+        assert!(!compressed.is_empty());
         let decompressed = deflate_decompress(&compressed).unwrap();
         assert_eq!(decompressed, data);
     }
@@ -425,7 +429,10 @@ mod tests {
         // After shuffle: [A0 B0 A1 B1 A2 B2 A3 B3]
         let data = vec![0xA0, 0xA1, 0xA2, 0xA3, 0xB0, 0xB1, 0xB2, 0xB3];
         let shuffled = shuffle_compress(&data, 4).unwrap();
-        assert_eq!(shuffled, vec![0xA0, 0xB0, 0xA1, 0xB1, 0xA2, 0xB2, 0xA3, 0xB3]);
+        assert_eq!(
+            shuffled,
+            vec![0xA0, 0xB0, 0xA1, 0xB1, 0xA2, 0xB2, 0xA3, 0xB3]
+        );
     }
 
     // --- Fletcher32 tests ---
@@ -468,7 +475,10 @@ mod tests {
         let last = with_checksum.len() - 1;
         with_checksum[last] ^= 0xFF;
         let result = fletcher32_verify(&with_checksum);
-        assert!(matches!(result, Err(FormatError::Fletcher32Mismatch { .. })));
+        assert!(matches!(
+            result,
+            Err(FormatError::Fletcher32Mismatch { .. })
+        ));
     }
 
     // --- Pipeline tests ---

--- a/src/fixed_array.rs
+++ b/src/fixed_array.rs
@@ -82,9 +82,9 @@ impl FixedArrayHeader {
 
         let version = d[4];
         if version != 0 {
-            return Err(FormatError::ChunkedReadError(
-                format!("unsupported Fixed Array header version: {version}"),
-            ));
+            return Err(FormatError::ChunkedReadError(format!(
+                "unsupported Fixed Array header version: {version}"
+            )));
         }
 
         let client_id = d[5];
@@ -168,8 +168,8 @@ pub fn read_fixed_array_chunks(
         num_chunks_per_dim.push(ds_dim.div_ceil(ch_dim));
     }
 
-    let chunk_byte_size: u64 = chunk_dimensions.iter().map(|&d| d as u64).product::<u64>()
-        * element_size as u64;
+    let chunk_byte_size: u64 =
+        chunk_dimensions.iter().map(|&d| d as u64).product::<u64>() * element_size as u64;
 
     let mut chunks = Vec::new();
 
@@ -280,8 +280,14 @@ mod tests {
         let num_chunks = vec![5u64];
         let chunk_dims = vec![20u32];
         assert_eq!(index_to_chunk_offsets(0, &num_chunks, &chunk_dims), vec![0]);
-        assert_eq!(index_to_chunk_offsets(1, &num_chunks, &chunk_dims), vec![20]);
-        assert_eq!(index_to_chunk_offsets(4, &num_chunks, &chunk_dims), vec![80]);
+        assert_eq!(
+            index_to_chunk_offsets(1, &num_chunks, &chunk_dims),
+            vec![20]
+        );
+        assert_eq!(
+            index_to_chunk_offsets(4, &num_chunks, &chunk_dims),
+            vec![80]
+        );
     }
 
     #[test]
@@ -289,17 +295,35 @@ mod tests {
         // 10x6 dataset with 4x3 chunks => ceil(10/4)=3, ceil(6/3)=2 => 6 chunks
         let num_chunks = vec![3u64, 2];
         let chunk_dims = vec![4u32, 3];
-        assert_eq!(index_to_chunk_offsets(0, &num_chunks, &chunk_dims), vec![0, 0]);
-        assert_eq!(index_to_chunk_offsets(1, &num_chunks, &chunk_dims), vec![0, 3]);
-        assert_eq!(index_to_chunk_offsets(2, &num_chunks, &chunk_dims), vec![4, 0]);
-        assert_eq!(index_to_chunk_offsets(3, &num_chunks, &chunk_dims), vec![4, 3]);
-        assert_eq!(index_to_chunk_offsets(5, &num_chunks, &chunk_dims), vec![8, 3]);
+        assert_eq!(
+            index_to_chunk_offsets(0, &num_chunks, &chunk_dims),
+            vec![0, 0]
+        );
+        assert_eq!(
+            index_to_chunk_offsets(1, &num_chunks, &chunk_dims),
+            vec![0, 3]
+        );
+        assert_eq!(
+            index_to_chunk_offsets(2, &num_chunks, &chunk_dims),
+            vec![4, 0]
+        );
+        assert_eq!(
+            index_to_chunk_offsets(3, &num_chunks, &chunk_dims),
+            vec![4, 3]
+        );
+        assert_eq!(
+            index_to_chunk_offsets(5, &num_chunks, &chunk_dims),
+            vec![8, 3]
+        );
     }
 
     #[test]
     fn read_variable_length_values() {
         assert_eq!(read_variable_length(&[0x78, 0x56], 2).unwrap(), 0x5678);
-        assert_eq!(read_variable_length(&[0x01, 0x02, 0x03, 0x04], 4).unwrap(), 0x04030201);
+        assert_eq!(
+            read_variable_length(&[0x01, 0x02, 0x03, 0x04], 4).unwrap(),
+            0x04030201
+        );
         assert_eq!(read_variable_length(&[0xFF], 1).unwrap(), 0xFF);
     }
 
@@ -382,13 +406,20 @@ mod tests {
             file_data[pos..pos + os].copy_from_slice(&addr.to_le_bytes());
         }
 
-        let header = FixedArrayHeader::parse(&file_data, fahd_offset, offset_size, length_size)
-            .unwrap();
+        let header =
+            FixedArrayHeader::parse(&file_data, fahd_offset, offset_size, length_size).unwrap();
         let ds_dims = vec![100u64];
         let chunk_dims = vec![20u32];
         let chunks = read_fixed_array_chunks(
-            &file_data, &header, &ds_dims, &chunk_dims, 8, offset_size, length_size,
-        ).unwrap();
+            &file_data,
+            &header,
+            &ds_dims,
+            &chunk_dims,
+            8,
+            offset_size,
+            length_size,
+        )
+        .unwrap();
 
         assert_eq!(chunks.len(), 5);
         for (i, c) in chunks.iter().enumerate() {
@@ -445,13 +476,20 @@ mod tests {
             file_data[pos + os + 4..pos + os + 8].copy_from_slice(&fmask.to_le_bytes());
         }
 
-        let header = FixedArrayHeader::parse(&file_data, fahd_offset, offset_size, length_size)
-            .unwrap();
+        let header =
+            FixedArrayHeader::parse(&file_data, fahd_offset, offset_size, length_size).unwrap();
         let ds_dims = vec![60u64];
         let chunk_dims = vec![20u32];
         let chunks = read_fixed_array_chunks(
-            &file_data, &header, &ds_dims, &chunk_dims, 8, offset_size, length_size,
-        ).unwrap();
+            &file_data,
+            &header,
+            &ds_dims,
+            &chunk_dims,
+            8,
+            offset_size,
+            length_size,
+        )
+        .unwrap();
 
         assert_eq!(chunks.len(), 3);
         assert_eq!(chunks[0].address, 0x1000);

--- a/src/fractal_heap.rs
+++ b/src/fractal_heap.rs
@@ -47,8 +47,14 @@ fn read_offset(data: &[u8], pos: usize, size: u8) -> Result<u64, FormatError> {
         2 => u16::from_le_bytes([data[pos], data[pos + 1]]) as u64,
         4 => u32::from_le_bytes([data[pos], data[pos + 1], data[pos + 2], data[pos + 3]]) as u64,
         8 => u64::from_le_bytes([
-            data[pos], data[pos + 1], data[pos + 2], data[pos + 3],
-            data[pos + 4], data[pos + 5], data[pos + 6], data[pos + 7],
+            data[pos],
+            data[pos + 1],
+            data[pos + 2],
+            data[pos + 3],
+            data[pos + 4],
+            data[pos + 5],
+            data[pos + 6],
+            data[pos + 7],
         ]),
         _ => return Err(FormatError::InvalidOffsetSize(size)),
     })
@@ -109,7 +115,10 @@ impl FractalHeapHeader {
 
         ensure_len(file_data, pos, 4)?;
         let max_managed_object_size = u32::from_le_bytes([
-            file_data[pos], file_data[pos + 1], file_data[pos + 2], file_data[pos + 3],
+            file_data[pos],
+            file_data[pos + 1],
+            file_data[pos + 2],
+            file_data[pos + 3],
         ]);
         pos += 4;
 
@@ -353,7 +362,7 @@ impl FractalHeapHeader {
 
         // Compute block sizes for each row using the doubling table
         let tw = self.table_width as u64;
-        
+
         let nrows_usize = nrows as usize;
 
         // Build table of (block_size, heap_offset) for each child entry
@@ -496,12 +505,16 @@ mod tests {
         // next_huge_object_id (length_size)
         pos += ls;
         // btree_huge_objects_address (offset_size) - undefined
-        for i in 0..os { buf[pos + i] = 0xFF; }
+        for i in 0..os {
+            buf[pos + i] = 0xFF;
+        }
         pos += os;
         // free_space_managed_blocks (length_size)
         pos += ls;
         // managed_block_free_space_manager_address (offset_size) - undefined
-        for i in 0..os { buf[pos + i] = 0xFF; }
+        for i in 0..os {
+            buf[pos + i] = 0xFF;
+        }
         pos += os;
         // managed_space_in_heap (length_size)
         pos += ls;
@@ -627,7 +640,7 @@ mod tests {
         // Wait, max_heap_size=16, ceil(16/8)=2. Header = sig(4)+ver(1)+addr(8)+bo(2) = 15.
         // The data was placed at data_start = block_addr + 15.
         // Since offset is from block start, the object is at offset 15 within the block.
-        let dblock_header_size = 5 + 8 + ((hdr.max_heap_size as usize + 7) / 8); // 15
+        let dblock_header_size = 5 + 8 + (hdr.max_heap_size as usize).div_ceil(8); // 15
         let offset: u64 = dblock_header_size as u64;
         let length: u64 = 13;
         let payload = offset | (length << hdr.max_heap_size);

--- a/src/global_heap.rs
+++ b/src/global_heap.rs
@@ -97,8 +97,7 @@ impl GlobalHeapCollection {
             let obj_header_size = 8 + length_size as usize;
             ensure_len(file_data, pos, obj_header_size)?;
 
-            let reference_count =
-                u16::from_le_bytes([file_data[pos + 2], file_data[pos + 3]]);
+            let reference_count = u16::from_le_bytes([file_data[pos + 2], file_data[pos + 3]]);
             let object_size = read_length(file_data, pos + 8, length_size)? as usize;
 
             pos += obj_header_size;
@@ -187,13 +186,7 @@ mod tests {
 
     #[test]
     fn parse_collection_two_objects() {
-        let data = build_collection(
-            &[
-                (1, 1, b"hello"),
-                (2, 1, b"world!!!"),
-            ],
-            8,
-        );
+        let data = build_collection(&[(1, 1, b"hello"), (2, 1, b"world!!!")], 8);
         let coll = GlobalHeapCollection::parse(&data, 0, 8).unwrap();
         assert_eq!(coll.objects.len(), 2);
         assert_eq!(coll.objects[0].index, 1);
@@ -204,13 +197,7 @@ mod tests {
 
     #[test]
     fn get_object_by_index() {
-        let data = build_collection(
-            &[
-                (1, 1, b"aaa"),
-                (3, 2, b"bbb"),
-            ],
-            8,
-        );
+        let data = build_collection(&[(1, 1, b"aaa"), (3, 2, b"bbb")], 8);
         let coll = GlobalHeapCollection::parse(&data, 0, 8).unwrap();
         let obj = coll.get_object(3).unwrap();
         assert_eq!(obj.data, b"bbb");

--- a/src/group_v1.rs
+++ b/src/group_v1.rs
@@ -54,7 +54,8 @@ pub fn resolve_v1_group_entries(
     let mut entries = Vec::new();
     for snod_addr in snod_addrs {
         // SNOD addresses from B-tree children are also relative to base_address
-        let snod = SymbolTableNode::parse(file_data, (snod_addr + base_address) as usize, offset_size)?;
+        let snod =
+            SymbolTableNode::parse(file_data, (snod_addr + base_address) as usize, offset_size)?;
         for entry in &snod.entries {
             let name = heap.read_string(file_data, entry.link_name_offset)?;
             entries.push(GroupEntry {
@@ -174,7 +175,11 @@ mod tests {
         let btree_offset = (btree_offset + 7) & !7;
 
         // B-tree: entries_used = 1 child (the SNOD), keys = [0, last_name_end]
-        let last_key = if children.is_empty() { 0u64 } else { heap_data_size as u64 };
+        let last_key = if children.is_empty() {
+            0u64
+        } else {
+            heap_data_size as u64
+        };
         let btree_header_size = 8 + os * 2; // sig + type + level + entries + siblings
         let btree_keys_children = os + os + os; // key[0] + child[0] + key[1]
         let total_size = btree_offset + btree_header_size + btree_keys_children + 64;
@@ -204,10 +209,8 @@ mod tests {
             pos += ls;
             // data_segment_address
             match offset_size {
-                4 => file[pos..pos + 4]
-                    .copy_from_slice(&(heap_data_offset as u32).to_le_bytes()),
-                8 => file[pos..pos + 8]
-                    .copy_from_slice(&(heap_data_offset as u64).to_le_bytes()),
+                4 => file[pos..pos + 4].copy_from_slice(&(heap_data_offset as u32).to_le_bytes()),
+                8 => file[pos..pos + 8].copy_from_slice(&(heap_data_offset as u64).to_le_bytes()),
                 _ => {}
             }
         }
@@ -263,8 +266,7 @@ mod tests {
             for _ in 0..2 {
                 match offset_size {
                     4 => file[pos..pos + 4].copy_from_slice(&0xFFFFFFFFu32.to_le_bytes()),
-                    8 => file[pos..pos + 8]
-                        .copy_from_slice(&0xFFFFFFFFFFFFFFFFu64.to_le_bytes()),
+                    8 => file[pos..pos + 8].copy_from_slice(&0xFFFFFFFFFFFFFFFFu64.to_le_bytes()),
                     _ => {}
                 }
                 pos += os;
@@ -301,11 +303,7 @@ mod tests {
 
     #[test]
     fn resolve_entries_two_children() {
-        let (file, msg) = build_synthetic_group(
-            &[("alpha", 0x1000, 0), ("beta", 0x2000, 0)],
-            8,
-            8,
-        );
+        let (file, msg) = build_synthetic_group(&[("alpha", 0x1000, 0), ("beta", 0x2000, 0)], 8, 8);
         let entries = resolve_v1_group_entries(&file, &msg, 8, 8, 0).unwrap();
         assert_eq!(entries.len(), 2);
         assert_eq!(entries[0].name, "alpha");
@@ -316,11 +314,8 @@ mod tests {
 
     #[test]
     fn resolve_path_single_level() {
-        let (file, msg) = build_synthetic_group(
-            &[("child1", 0x3000, 0), ("child2", 0x4000, 0)],
-            8,
-            8,
-        );
+        let (file, msg) =
+            build_synthetic_group(&[("child1", 0x3000, 0), ("child2", 0x4000, 0)], 8, 8);
         let addr = resolve_path(&file, &msg, "child1", 8, 8).unwrap();
         assert_eq!(addr, 0x3000);
     }
@@ -343,9 +338,24 @@ mod tests {
         crate::dataspace::Dataspace,
         crate::data_layout::DataLayout,
     ) {
-        let dt_data = &hdr.messages.iter().find(|m| m.msg_type == MessageType::Datatype).unwrap().data;
-        let ds_data = &hdr.messages.iter().find(|m| m.msg_type == MessageType::Dataspace).unwrap().data;
-        let dl_data = &hdr.messages.iter().find(|m| m.msg_type == MessageType::DataLayout).unwrap().data;
+        let dt_data = &hdr
+            .messages
+            .iter()
+            .find(|m| m.msg_type == MessageType::Datatype)
+            .unwrap()
+            .data;
+        let ds_data = &hdr
+            .messages
+            .iter()
+            .find(|m| m.msg_type == MessageType::Dataspace)
+            .unwrap()
+            .data;
+        let dl_data = &hdr
+            .messages
+            .iter()
+            .find(|m| m.msg_type == MessageType::DataLayout)
+            .unwrap()
+            .data;
         let (dt, _) = crate::datatype::Datatype::parse(dt_data).unwrap();
         let ds = crate::dataspace::Dataspace::parse(ds_data, length_size).unwrap();
         let dl = crate::data_layout::DataLayout::parse(dl_data, offset_size, length_size).unwrap();
@@ -357,10 +367,17 @@ mod tests {
         sb: &crate::superblock::Superblock,
     ) -> SymbolTableMessage {
         let root_header = ObjectHeader::parse(
-            file_data, sb.root_group_address as usize, sb.offset_size, sb.length_size,
-        ).unwrap();
-        let sym_msg = root_header.messages.iter()
-            .find(|m| m.msg_type == MessageType::SymbolTable).unwrap();
+            file_data,
+            sb.root_group_address as usize,
+            sb.offset_size,
+            sb.length_size,
+        )
+        .unwrap();
+        let sym_msg = root_header
+            .messages
+            .iter()
+            .find(|m| m.msg_type == MessageType::SymbolTable)
+            .unwrap();
         SymbolTableMessage::parse(&sym_msg.data, sb.offset_size).unwrap()
     }
 
@@ -373,10 +390,21 @@ mod tests {
         let sb = crate::superblock::Superblock::parse(file_data, sig_offset).unwrap();
         let root_sym = get_root_sym_table(file_data, &sb);
 
-        let entries = resolve_v1_group_entries(file_data, &root_sym, sb.offset_size, sb.length_size, 0).unwrap();
-        let data_entry = entries.iter().find(|e| e.name == "data").expect("should have 'data'");
+        let entries =
+            resolve_v1_group_entries(file_data, &root_sym, sb.offset_size, sb.length_size, 0)
+                .unwrap();
+        let data_entry = entries
+            .iter()
+            .find(|e| e.name == "data")
+            .expect("should have 'data'");
 
-        let hdr = ObjectHeader::parse(file_data, data_entry.object_header_address as usize, sb.offset_size, sb.length_size).unwrap();
+        let hdr = ObjectHeader::parse(
+            file_data,
+            data_entry.object_header_address as usize,
+            sb.offset_size,
+            sb.length_size,
+        )
+        .unwrap();
         let (dt, ds, dl) = extract_dataset(file_data, &hdr, sb.offset_size, sb.length_size);
         let raw = crate::data_read::read_raw_data(file_data, &dl, &ds, &dt).unwrap();
         let values = crate::data_read::read_as_f64(&raw, &dt).unwrap();
@@ -390,8 +418,16 @@ mod tests {
         let sb = crate::superblock::Superblock::parse(file_data, sig_offset).unwrap();
         let root_sym = get_root_sym_table(file_data, &sb);
 
-        let addr = resolve_path(file_data, &root_sym, "group1/values", sb.offset_size, sb.length_size).unwrap();
-        let hdr = ObjectHeader::parse(file_data, addr as usize, sb.offset_size, sb.length_size).unwrap();
+        let addr = resolve_path(
+            file_data,
+            &root_sym,
+            "group1/values",
+            sb.offset_size,
+            sb.length_size,
+        )
+        .unwrap();
+        let hdr =
+            ObjectHeader::parse(file_data, addr as usize, sb.offset_size, sb.length_size).unwrap();
         let (dt, ds, dl) = extract_dataset(file_data, &hdr, sb.offset_size, sb.length_size);
         let raw = crate::data_read::read_raw_data(file_data, &dl, &ds, &dt).unwrap();
         let values = crate::data_read::read_as_i32(&raw, &dt).unwrap();
@@ -405,8 +441,16 @@ mod tests {
         let sb = crate::superblock::Superblock::parse(file_data, sig_offset).unwrap();
         let root_sym = get_root_sym_table(file_data, &sb);
 
-        let addr = resolve_path(file_data, &root_sym, "group2/temps", sb.offset_size, sb.length_size).unwrap();
-        let hdr = ObjectHeader::parse(file_data, addr as usize, sb.offset_size, sb.length_size).unwrap();
+        let addr = resolve_path(
+            file_data,
+            &root_sym,
+            "group2/temps",
+            sb.offset_size,
+            sb.length_size,
+        )
+        .unwrap();
+        let hdr =
+            ObjectHeader::parse(file_data, addr as usize, sb.offset_size, sb.length_size).unwrap();
         let (dt, ds, dl) = extract_dataset(file_data, &hdr, sb.offset_size, sb.length_size);
         let raw = crate::data_read::read_raw_data(file_data, &dl, &ds, &dt).unwrap();
         let values = crate::data_read::read_as_f32(&raw, &dt).unwrap();
@@ -421,8 +465,16 @@ mod tests {
         let sb = crate::superblock::Superblock::parse(file_data, sig_offset).unwrap();
         let root_sym = get_root_sym_table(file_data, &sb);
 
-        let addr = resolve_path(file_data, &root_sym, "a/b/c/deep", sb.offset_size, sb.length_size).unwrap();
-        let hdr = ObjectHeader::parse(file_data, addr as usize, sb.offset_size, sb.length_size).unwrap();
+        let addr = resolve_path(
+            file_data,
+            &root_sym,
+            "a/b/c/deep",
+            sb.offset_size,
+            sb.length_size,
+        )
+        .unwrap();
+        let hdr =
+            ObjectHeader::parse(file_data, addr as usize, sb.offset_size, sb.length_size).unwrap();
         let (dt, ds, dl) = extract_dataset(file_data, &hdr, sb.offset_size, sb.length_size);
         let raw = crate::data_read::read_raw_data(file_data, &dl, &ds, &dt).unwrap();
         let values = crate::data_read::read_as_f64(&raw, &dt).unwrap();

--- a/src/group_v2.rs
+++ b/src/group_v2.rs
@@ -6,7 +6,7 @@
 #[cfg(not(feature = "std"))]
 use alloc::{string::String, vec::Vec};
 
-use crate::btree_v2::{collect_btree_v2_records, BTreeV2Header};
+use crate::btree_v2::{BTreeV2Header, collect_btree_v2_records};
 use crate::error::FormatError;
 use crate::fractal_heap::FractalHeapHeader;
 use crate::group_v1::{self, GroupEntry};
@@ -78,8 +78,7 @@ fn resolve_dense_entries(
     let btree_addr = link_info
         .btree_name_index_address
         .ok_or_else(|| FormatError::PathNotFound(String::from("no B-tree v2 name index")))?;
-    let btree_hdr =
-        BTreeV2Header::parse(file_data, btree_addr as usize, offset_size, length_size)?;
+    let btree_hdr = BTreeV2Header::parse(file_data, btree_addr as usize, offset_size, length_size)?;
     let records = collect_btree_v2_records(file_data, &btree_hdr, offset_size, length_size)?;
 
     let mut entries = Vec::new();
@@ -169,8 +168,13 @@ pub fn resolve_path_any(
     let ls = superblock.length_size;
     let base = superblock.base_address;
 
-    let root_header =
-        ObjectHeader::parse_with_base(file_data, superblock.root_group_address as usize, os, ls, base)?;
+    let root_header = ObjectHeader::parse_with_base(
+        file_data,
+        superblock.root_group_address as usize,
+        os,
+        ls,
+        base,
+    )?;
 
     let mut current_addr = superblock.root_group_address;
     let mut current_header = root_header;
@@ -216,9 +220,7 @@ pub fn resolve_group_entries(
             .messages
             .iter()
             .find(|m| m.msg_type == MessageType::SymbolTable)
-            .ok_or_else(|| {
-                FormatError::PathNotFound(String::from("no symbol table message"))
-            })?;
+            .ok_or_else(|| FormatError::PathNotFound(String::from("no symbol table message")))?;
         let stm = SymbolTableMessage::parse(&sym_msg.data, offset_size)?;
         group_v1::resolve_v1_group_entries(file_data, &stm, offset_size, length_size, base_address)
     } else if is_v2_group(object_header) {
@@ -334,8 +336,8 @@ mod tests {
         assert!(sb.version >= 2); // v2/v3 superblock
 
         let addr = resolve_path_any(file_data, &sb, "sensors/temperature").unwrap();
-        let hdr = ObjectHeader::parse(file_data, addr as usize, sb.offset_size, sb.length_size)
-            .unwrap();
+        let hdr =
+            ObjectHeader::parse(file_data, addr as usize, sb.offset_size, sb.length_size).unwrap();
         let (dt, ds, dl) = extract_dataset(file_data, &hdr, sb.offset_size, sb.length_size);
         let raw = data_read::read_raw_data(file_data, &dl, &ds, &dt).unwrap();
         let values = data_read::read_as_f64(&raw, &dt).unwrap();
@@ -349,8 +351,8 @@ mod tests {
         let sb = Superblock::parse(file_data, sig_offset).unwrap();
 
         let addr = resolve_path_any(file_data, &sb, "sensors/humidity").unwrap();
-        let hdr = ObjectHeader::parse(file_data, addr as usize, sb.offset_size, sb.length_size)
-            .unwrap();
+        let hdr =
+            ObjectHeader::parse(file_data, addr as usize, sb.offset_size, sb.length_size).unwrap();
         let (dt, ds, dl) = extract_dataset(file_data, &hdr, sb.offset_size, sb.length_size);
         let raw = data_read::read_raw_data(file_data, &dl, &ds, &dt).unwrap();
         let values = data_read::read_as_i32(&raw, &dt).unwrap();
@@ -364,8 +366,8 @@ mod tests {
         let sb = Superblock::parse(file_data, sig_offset).unwrap();
 
         let addr = resolve_path_any(file_data, &sb, "dataset_015").unwrap();
-        let hdr = ObjectHeader::parse(file_data, addr as usize, sb.offset_size, sb.length_size)
-            .unwrap();
+        let hdr =
+            ObjectHeader::parse(file_data, addr as usize, sb.offset_size, sb.length_size).unwrap();
         let (dt, ds, dl) = extract_dataset(file_data, &hdr, sb.offset_size, sb.length_size);
         let raw = data_read::read_raw_data(file_data, &dl, &ds, &dt).unwrap();
         let values = data_read::read_as_f64(&raw, &dt).unwrap();
@@ -380,8 +382,8 @@ mod tests {
         let sb = Superblock::parse(file_data, sig_offset).unwrap();
 
         let addr = resolve_path_any(file_data, &sb, "group1/values").unwrap();
-        let hdr = ObjectHeader::parse(file_data, addr as usize, sb.offset_size, sb.length_size)
-            .unwrap();
+        let hdr =
+            ObjectHeader::parse(file_data, addr as usize, sb.offset_size, sb.length_size).unwrap();
         let (dt, ds, dl) = extract_dataset(file_data, &hdr, sb.offset_size, sb.length_size);
         let raw = data_read::read_raw_data(file_data, &dl, &ds, &dt).unwrap();
         let values = data_read::read_as_i32(&raw, &dt).unwrap();
@@ -395,8 +397,8 @@ mod tests {
         let sb = Superblock::parse(file_data, sig_offset).unwrap();
 
         let addr = resolve_path_any(file_data, &sb, "sensors/temperature").unwrap();
-        let hdr = ObjectHeader::parse(file_data, addr as usize, sb.offset_size, sb.length_size)
-            .unwrap();
+        let hdr =
+            ObjectHeader::parse(file_data, addr as usize, sb.offset_size, sb.length_size).unwrap();
         let (dt, ds, dl) = extract_dataset(file_data, &hdr, sb.offset_size, sb.length_size);
         let raw = data_read::read_raw_data(file_data, &dl, &ds, &dt).unwrap();
         let values = data_read::read_as_f64(&raw, &dt).unwrap();

--- a/src/lane_partition.rs
+++ b/src/lane_partition.rs
@@ -124,7 +124,11 @@ pub fn partition(
         lanes.clear();
         let mut start = 0;
         for i in 0..num_lanes {
-            let target = if i < extra { base_per_lane + 1 } else { base_per_lane };
+            let target = if i < extra {
+                base_per_lane + 1
+            } else {
+                base_per_lane
+            };
             lanes.push(all_items[start..start + target].to_vec());
             start += target;
         }
@@ -137,11 +141,7 @@ pub fn partition(
 ///
 /// `seed` should incorporate the dataset offset and chunk range so the
 /// assignment is deterministic per query.
-pub fn partition_chunks(
-    num_chunks: usize,
-    num_lanes: usize,
-    seed: u64,
-) -> Vec<Vec<usize>> {
+pub fn partition_chunks(num_chunks: usize, num_lanes: usize, seed: u64) -> Vec<Vec<usize>> {
     partition(num_chunks, num_lanes, seed, PartitionMode::WorkStealing)
 }
 
@@ -175,8 +175,18 @@ impl PartitionStats {
 
     /// Returns the max/min chunk count across lanes (imbalance metric).
     pub fn imbalance(&self) -> (usize, usize) {
-        let max = self.per_lane.iter().map(|s| s.chunks_processed).max().unwrap_or(0);
-        let min = self.per_lane.iter().map(|s| s.chunks_processed).min().unwrap_or(0);
+        let max = self
+            .per_lane
+            .iter()
+            .map(|s| s.chunks_processed)
+            .max()
+            .unwrap_or(0);
+        let min = self
+            .per_lane
+            .iter()
+            .map(|s| s.chunks_processed)
+            .min()
+            .unwrap_or(0);
         (max, min)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,43 +37,43 @@ extern crate alloc;
 
 pub mod attribute;
 pub mod attribute_info;
+pub mod btree_v1;
+pub mod btree_v2;
+pub mod checksum;
 pub mod chunk_cache;
 pub mod chunked_read;
 pub mod chunked_write;
-pub mod file_writer;
-pub mod metadata_index;
-pub mod object_header_writer;
-pub mod type_builders;
-pub mod btree_v1;
-pub mod checksum;
-pub mod btree_v2;
-pub mod fractal_heap;
-pub mod group_info;
-pub mod group_v2;
-pub mod link_info;
-pub mod link_message;
 pub mod data_layout;
 pub mod data_read;
-pub mod filter_pipeline;
-pub mod extensible_array;
-pub mod fixed_array;
-pub mod filters;
-#[cfg(feature = "parallel")]
-pub mod lane_partition;
-#[cfg(feature = "parallel")]
-pub mod parallel_read;
 pub mod dataspace;
 pub mod datatype;
 pub mod error;
+pub mod extensible_array;
+pub mod file_writer;
+pub mod filter_pipeline;
+pub mod filters;
+pub mod fixed_array;
+pub mod fractal_heap;
 pub mod global_heap;
+pub mod group_info;
 pub mod group_v1;
+pub mod group_v2;
+#[cfg(feature = "parallel")]
+pub mod lane_partition;
+pub mod link_info;
+pub mod link_message;
 pub mod local_heap;
 pub mod message_type;
+pub mod metadata_index;
 pub mod object_header;
+pub mod object_header_writer;
+#[cfg(feature = "parallel")]
+pub mod parallel_read;
 pub mod shared_message;
 pub mod signature;
 pub mod superblock;
 pub mod symbol_table;
+pub mod type_builders;
 pub mod vl_data;
 #[cfg(feature = "zfp")]
 pub mod zfp;
@@ -116,7 +116,7 @@ pub use types::{AttrValue, DType};
 pub use writer::FileBuilder;
 
 pub use type_builders::{
-    CompoundTypeBuilder, EnumTypeBuilder,
-    make_f32_type, make_f64_type, make_i8_type, make_i16_type, make_i32_type, make_i64_type,
-    make_u8_type, make_u16_type, make_u32_type, make_u64_type,
+    CompoundTypeBuilder, EnumTypeBuilder, make_f32_type, make_f64_type, make_i8_type,
+    make_i16_type, make_i32_type, make_i64_type, make_u8_type, make_u16_type, make_u32_type,
+    make_u64_type,
 };

--- a/src/link_message.rs
+++ b/src/link_message.rs
@@ -79,9 +79,13 @@ impl LinkMessage {
 
         let name_bytes = self.name.as_bytes();
         let name_len = name_bytes.len();
-        let name_size_width: u8 = if name_len <= 0xFF { 1 }
-            else if name_len <= 0xFFFF { 2 }
-            else { 4 };
+        let name_size_width: u8 = if name_len <= 0xFF {
+            1
+        } else if name_len <= 0xFFFF {
+            2
+        } else {
+            4
+        };
 
         let is_hard = matches!(self.link_target, LinkTarget::Hard { .. });
         let has_link_type = !is_hard;
@@ -90,14 +94,25 @@ impl LinkMessage {
 
         let mut flags: u8 = 0;
         // Bits 0-1: size of name length field
-        let size_bits = match name_size_width { 1 => 0u8, 2 => 1, 4 => 2, _ => 3 };
+        let size_bits = match name_size_width {
+            1 => 0u8,
+            2 => 1,
+            4 => 2,
+            _ => 3,
+        };
         flags |= size_bits;
         // Bit 2: creation order present
-        if has_creation_order { flags |= 0x04; }
+        if has_creation_order {
+            flags |= 0x04;
+        }
         // Bit 3: link type present
-        if has_link_type { flags |= 0x08; }
+        if has_link_type {
+            flags |= 0x08;
+        }
         // Bit 4: charset present
-        if has_charset { flags |= 0x10; }
+        if has_charset {
+            flags |= 0x10;
+        }
         buf.push(flags);
 
         if has_link_type {
@@ -128,20 +143,23 @@ impl LinkMessage {
         buf.extend_from_slice(name_bytes);
 
         match &self.link_target {
-            LinkTarget::Hard { object_header_address } => {
-                match offset_size {
-                    2 => buf.extend_from_slice(&(*object_header_address as u16).to_le_bytes()),
-                    4 => buf.extend_from_slice(&(*object_header_address as u32).to_le_bytes()),
-                    8 => buf.extend_from_slice(&object_header_address.to_le_bytes()),
-                    _ => {}
-                }
-            }
+            LinkTarget::Hard {
+                object_header_address,
+            } => match offset_size {
+                2 => buf.extend_from_slice(&(*object_header_address as u16).to_le_bytes()),
+                4 => buf.extend_from_slice(&(*object_header_address as u32).to_le_bytes()),
+                8 => buf.extend_from_slice(&object_header_address.to_le_bytes()),
+                _ => {}
+            },
             LinkTarget::Soft { target_path } => {
                 let path_bytes = target_path.as_bytes();
                 buf.extend_from_slice(&(path_bytes.len() as u16).to_le_bytes());
                 buf.extend_from_slice(path_bytes);
             }
-            LinkTarget::External { filename, object_path } => {
+            LinkTarget::External {
+                filename,
+                object_path,
+            } => {
                 let mut ext_data = Vec::new();
                 ext_data.push(0); // flags
                 ext_data.extend_from_slice(filename.as_bytes());
@@ -249,19 +267,16 @@ impl LinkMessage {
             1 => {
                 // Soft link
                 ensure_len(data, pos, 2)?;
-                let soft_len =
-                    u16::from_le_bytes([data[pos], data[pos + 1]]) as usize;
+                let soft_len = u16::from_le_bytes([data[pos], data[pos + 1]]) as usize;
                 pos += 2;
                 ensure_len(data, pos, soft_len)?;
-                let target_path =
-                    String::from_utf8_lossy(&data[pos..pos + soft_len]).into_owned();
+                let target_path = String::from_utf8_lossy(&data[pos..pos + soft_len]).into_owned();
                 LinkTarget::Soft { target_path }
             }
             64 => {
                 // External link
                 ensure_len(data, pos, 2)?;
-                let ext_len =
-                    u16::from_le_bytes([data[pos], data[pos + 1]]) as usize;
+                let ext_len = u16::from_le_bytes([data[pos], data[pos + 1]]) as usize;
                 pos += 2;
                 ensure_len(data, pos, ext_len)?;
                 let ext_data = &data[pos..pos + ext_len];
@@ -270,8 +285,7 @@ impl LinkMessage {
                 let start = if !ext_data.is_empty() { 1 } else { 0 };
                 let rest = &ext_data[start..];
                 let null1 = rest.iter().position(|&b| b == 0).unwrap_or(rest.len());
-                let filename =
-                    String::from_utf8_lossy(&rest[..null1]).into_owned();
+                let filename = String::from_utf8_lossy(&rest[..null1]).into_owned();
                 let after_null1 = if null1 + 1 < rest.len() {
                     null1 + 1
                 } else {
@@ -279,8 +293,7 @@ impl LinkMessage {
                 };
                 let rest2 = &rest[after_null1..];
                 let null2 = rest2.iter().position(|&b| b == 0).unwrap_or(rest2.len());
-                let object_path =
-                    String::from_utf8_lossy(&rest2[..null2]).into_owned();
+                let object_path = String::from_utf8_lossy(&rest2[..null2]).into_owned();
                 LinkTarget::External {
                     filename,
                     object_path,

--- a/src/mat/builder.rs
+++ b/src/mat/builder.rs
@@ -34,12 +34,10 @@ use std::collections::HashSet;
 
 use crate::file_writer::AttrValue;
 use crate::mat::class::MatClass;
-use crate::mat::dims::{matrix_dims, storage_dims_u64_into, vector_dims, STORAGE_DIMS_BUF_LEN};
+use crate::mat::dims::{STORAGE_DIMS_BUF_LEN, matrix_dims, storage_dims_u64_into, vector_dims};
 use crate::mat::error::MatError;
 use crate::mat::identifier::{dedupe_name, is_valid_name, sanitize_name};
-use crate::mat::options::{
-    Compression, EmptyMarkerEncoding, InvalidNamePolicy, Options,
-};
+use crate::mat::options::{Compression, EmptyMarkerEncoding, InvalidNamePolicy, Options};
 use crate::mat::string_object;
 use crate::mat::userblock::{self, USERBLOCK_SIZE};
 use crate::mat::utf16;
@@ -268,7 +266,10 @@ impl MatBuilder {
         let target = self.resolve_target(name)?;
         let ds = self.dataset_at_target(&target);
         apply(ds);
-        ds.set_attr("MATLAB_class", AttrValue::AsciiString(class.as_str().into()));
+        ds.set_attr(
+            "MATLAB_class",
+            AttrValue::AsciiString(class.as_str().into()),
+        );
         Ok(self)
     }
 
@@ -280,9 +281,15 @@ impl MatBuilder {
         matlab_dims: &[usize],
         data: &[f64],
     ) -> Result<&mut Self, MatError> {
-        self.write_array_inner(name, MatClass::Double, matlab_dims, data.len(), |ds, shape| {
-            ds.with_f64_data(data).with_shape(shape);
-        })
+        self.write_array_inner(
+            name,
+            MatClass::Double,
+            matlab_dims,
+            data.len(),
+            |ds, shape| {
+                ds.with_f64_data(data).with_shape(shape);
+            },
+        )
     }
     pub fn write_f32(
         &mut self,
@@ -290,9 +297,15 @@ impl MatBuilder {
         matlab_dims: &[usize],
         data: &[f32],
     ) -> Result<&mut Self, MatError> {
-        self.write_array_inner(name, MatClass::Single, matlab_dims, data.len(), |ds, shape| {
-            ds.with_f32_data(data).with_shape(shape);
-        })
+        self.write_array_inner(
+            name,
+            MatClass::Single,
+            matlab_dims,
+            data.len(),
+            |ds, shape| {
+                ds.with_f32_data(data).with_shape(shape);
+            },
+        )
     }
     pub fn write_i8(
         &mut self,
@@ -300,9 +313,15 @@ impl MatBuilder {
         matlab_dims: &[usize],
         data: &[i8],
     ) -> Result<&mut Self, MatError> {
-        self.write_array_inner(name, MatClass::Int8, matlab_dims, data.len(), |ds, shape| {
-            ds.with_i8_data(data).with_shape(shape);
-        })
+        self.write_array_inner(
+            name,
+            MatClass::Int8,
+            matlab_dims,
+            data.len(),
+            |ds, shape| {
+                ds.with_i8_data(data).with_shape(shape);
+            },
+        )
     }
     pub fn write_i16(
         &mut self,
@@ -310,9 +329,15 @@ impl MatBuilder {
         matlab_dims: &[usize],
         data: &[i16],
     ) -> Result<&mut Self, MatError> {
-        self.write_array_inner(name, MatClass::Int16, matlab_dims, data.len(), |ds, shape| {
-            ds.with_i16_data(data).with_shape(shape);
-        })
+        self.write_array_inner(
+            name,
+            MatClass::Int16,
+            matlab_dims,
+            data.len(),
+            |ds, shape| {
+                ds.with_i16_data(data).with_shape(shape);
+            },
+        )
     }
     pub fn write_i32(
         &mut self,
@@ -320,9 +345,15 @@ impl MatBuilder {
         matlab_dims: &[usize],
         data: &[i32],
     ) -> Result<&mut Self, MatError> {
-        self.write_array_inner(name, MatClass::Int32, matlab_dims, data.len(), |ds, shape| {
-            ds.with_i32_data(data).with_shape(shape);
-        })
+        self.write_array_inner(
+            name,
+            MatClass::Int32,
+            matlab_dims,
+            data.len(),
+            |ds, shape| {
+                ds.with_i32_data(data).with_shape(shape);
+            },
+        )
     }
     pub fn write_i64(
         &mut self,
@@ -330,9 +361,15 @@ impl MatBuilder {
         matlab_dims: &[usize],
         data: &[i64],
     ) -> Result<&mut Self, MatError> {
-        self.write_array_inner(name, MatClass::Int64, matlab_dims, data.len(), |ds, shape| {
-            ds.with_i64_data(data).with_shape(shape);
-        })
+        self.write_array_inner(
+            name,
+            MatClass::Int64,
+            matlab_dims,
+            data.len(),
+            |ds, shape| {
+                ds.with_i64_data(data).with_shape(shape);
+            },
+        )
     }
     pub fn write_u8(
         &mut self,
@@ -340,9 +377,15 @@ impl MatBuilder {
         matlab_dims: &[usize],
         data: &[u8],
     ) -> Result<&mut Self, MatError> {
-        self.write_array_inner(name, MatClass::UInt8, matlab_dims, data.len(), |ds, shape| {
-            ds.with_u8_data(data).with_shape(shape);
-        })
+        self.write_array_inner(
+            name,
+            MatClass::UInt8,
+            matlab_dims,
+            data.len(),
+            |ds, shape| {
+                ds.with_u8_data(data).with_shape(shape);
+            },
+        )
     }
     pub fn write_u16(
         &mut self,
@@ -350,9 +393,15 @@ impl MatBuilder {
         matlab_dims: &[usize],
         data: &[u16],
     ) -> Result<&mut Self, MatError> {
-        self.write_array_inner(name, MatClass::UInt16, matlab_dims, data.len(), |ds, shape| {
-            ds.with_u16_data(data).with_shape(shape);
-        })
+        self.write_array_inner(
+            name,
+            MatClass::UInt16,
+            matlab_dims,
+            data.len(),
+            |ds, shape| {
+                ds.with_u16_data(data).with_shape(shape);
+            },
+        )
     }
     pub fn write_u32(
         &mut self,
@@ -360,9 +409,15 @@ impl MatBuilder {
         matlab_dims: &[usize],
         data: &[u32],
     ) -> Result<&mut Self, MatError> {
-        self.write_array_inner(name, MatClass::UInt32, matlab_dims, data.len(), |ds, shape| {
-            ds.with_u32_data(data).with_shape(shape);
-        })
+        self.write_array_inner(
+            name,
+            MatClass::UInt32,
+            matlab_dims,
+            data.len(),
+            |ds, shape| {
+                ds.with_u32_data(data).with_shape(shape);
+            },
+        )
     }
     pub fn write_u64(
         &mut self,
@@ -370,9 +425,15 @@ impl MatBuilder {
         matlab_dims: &[usize],
         data: &[u64],
     ) -> Result<&mut Self, MatError> {
-        self.write_array_inner(name, MatClass::UInt64, matlab_dims, data.len(), |ds, shape| {
-            ds.with_u64_data(data).with_shape(shape);
-        })
+        self.write_array_inner(
+            name,
+            MatClass::UInt64,
+            matlab_dims,
+            data.len(),
+            |ds, shape| {
+                ds.with_u64_data(data).with_shape(shape);
+            },
+        )
     }
 
     /// Write a logical array (MATLAB `logical`, stored as `uint8`).
@@ -385,10 +446,16 @@ impl MatBuilder {
         if data.is_empty() {
             return self.write_empty_with_decode(name, MatClass::Logical, matlab_dims, Some(1));
         }
-        self.write_array_inner(name, MatClass::Logical, matlab_dims, data.len(), |ds, shape| {
-            ds.with_u8_data(data).with_shape(shape);
-            ds.set_attr("MATLAB_int_decode", AttrValue::I32(1));
-        })
+        self.write_array_inner(
+            name,
+            MatClass::Logical,
+            matlab_dims,
+            data.len(),
+            |ds, shape| {
+                ds.with_u8_data(data).with_shape(shape);
+                ds.set_attr("MATLAB_int_decode", AttrValue::I32(1));
+            },
+        )
     }
 
     /// Write a `char` UTF-16 string (MATLAB `char`). Uses `[N, 1]` MATLAB
@@ -493,7 +560,8 @@ impl MatBuilder {
         let metadata = string_object::create_string_object_metadata(object_id);
         let target = self.resolve_target(name)?;
         let ds = self.dataset_at_target(&target);
-        ds.with_u32_data(&metadata).with_shape(&[1, metadata.len() as u64]);
+        ds.with_u32_data(&metadata)
+            .with_shape(&[1, metadata.len() as u64]);
         ds.set_attr(
             "MATLAB_class",
             AttrValue::AsciiString(string_object::MATLAB_CLASS_STRING.into()),
@@ -648,17 +716,16 @@ impl MatBuilder {
     }
 
     fn close_struct(&mut self) -> Result<(), MatError> {
-        let mut s = self.open_structs.pop().ok_or_else(|| {
-            MatError::Custom("close_struct called with no open struct".into())
-        })?;
+        let mut s = self
+            .open_structs
+            .pop()
+            .ok_or_else(|| MatError::Custom("close_struct called with no open struct".into()))?;
         s.group.set_attr(
             "MATLAB_class",
             AttrValue::AsciiString(MatClass::Struct.as_str().into()),
         );
-        s.group.set_attr(
-            "MATLAB_fields",
-            AttrValue::VarLenAsciiArray(s.fields),
-        );
+        s.group
+            .set_attr("MATLAB_fields", AttrValue::VarLenAsciiArray(s.fields));
         let finished = s.group.finish();
         match s.parent {
             ParentKind::Root => self.file.add_group(finished),
@@ -709,8 +776,7 @@ impl MatBuilder {
                 }
                 EmptyMarkerEncoding::DataAsDims => {
                     if matlab_dims.len() > STORAGE_DIMS_BUF_LEN {
-                        let dim_data: Vec<u64> =
-                            matlab_dims.iter().map(|&d| d as u64).collect();
+                        let dim_data: Vec<u64> = matlab_dims.iter().map(|&d| d as u64).collect();
                         ds.with_u64_data(&dim_data)
                             .with_shape(&[dim_data.len() as u64]);
                     } else {
@@ -865,8 +931,7 @@ impl MatBuilder {
         );
 
         // 6. Build the MCOS reference array.
-        let mut paths: Vec<String> =
-            Vec::with_capacity(5 + self.string_object_payload_paths.len());
+        let mut paths: Vec<String> = Vec::with_capacity(5 + self.string_object_payload_paths.len());
         paths.push(metadata_path);
         paths.push(canonical_path);
         paths.extend(self.string_object_payload_paths.iter().cloned());
@@ -1062,57 +1127,112 @@ impl<'a> StructWriter<'a> {
         Ok(self)
     }
     #[inline]
-    pub fn write_f64(&mut self, name: &str, dims: &[usize], data: &[f64]) -> Result<&mut Self, MatError> {
+    pub fn write_f64(
+        &mut self,
+        name: &str,
+        dims: &[usize],
+        data: &[f64],
+    ) -> Result<&mut Self, MatError> {
         self.mb.write_f64(name, dims, data)?;
         Ok(self)
     }
     #[inline]
-    pub fn write_f32(&mut self, name: &str, dims: &[usize], data: &[f32]) -> Result<&mut Self, MatError> {
+    pub fn write_f32(
+        &mut self,
+        name: &str,
+        dims: &[usize],
+        data: &[f32],
+    ) -> Result<&mut Self, MatError> {
         self.mb.write_f32(name, dims, data)?;
         Ok(self)
     }
     #[inline]
-    pub fn write_i8(&mut self, name: &str, dims: &[usize], data: &[i8]) -> Result<&mut Self, MatError> {
+    pub fn write_i8(
+        &mut self,
+        name: &str,
+        dims: &[usize],
+        data: &[i8],
+    ) -> Result<&mut Self, MatError> {
         self.mb.write_i8(name, dims, data)?;
         Ok(self)
     }
     #[inline]
-    pub fn write_i16(&mut self, name: &str, dims: &[usize], data: &[i16]) -> Result<&mut Self, MatError> {
+    pub fn write_i16(
+        &mut self,
+        name: &str,
+        dims: &[usize],
+        data: &[i16],
+    ) -> Result<&mut Self, MatError> {
         self.mb.write_i16(name, dims, data)?;
         Ok(self)
     }
     #[inline]
-    pub fn write_i32(&mut self, name: &str, dims: &[usize], data: &[i32]) -> Result<&mut Self, MatError> {
+    pub fn write_i32(
+        &mut self,
+        name: &str,
+        dims: &[usize],
+        data: &[i32],
+    ) -> Result<&mut Self, MatError> {
         self.mb.write_i32(name, dims, data)?;
         Ok(self)
     }
     #[inline]
-    pub fn write_i64(&mut self, name: &str, dims: &[usize], data: &[i64]) -> Result<&mut Self, MatError> {
+    pub fn write_i64(
+        &mut self,
+        name: &str,
+        dims: &[usize],
+        data: &[i64],
+    ) -> Result<&mut Self, MatError> {
         self.mb.write_i64(name, dims, data)?;
         Ok(self)
     }
     #[inline]
-    pub fn write_u8(&mut self, name: &str, dims: &[usize], data: &[u8]) -> Result<&mut Self, MatError> {
+    pub fn write_u8(
+        &mut self,
+        name: &str,
+        dims: &[usize],
+        data: &[u8],
+    ) -> Result<&mut Self, MatError> {
         self.mb.write_u8(name, dims, data)?;
         Ok(self)
     }
     #[inline]
-    pub fn write_u16(&mut self, name: &str, dims: &[usize], data: &[u16]) -> Result<&mut Self, MatError> {
+    pub fn write_u16(
+        &mut self,
+        name: &str,
+        dims: &[usize],
+        data: &[u16],
+    ) -> Result<&mut Self, MatError> {
         self.mb.write_u16(name, dims, data)?;
         Ok(self)
     }
     #[inline]
-    pub fn write_u32(&mut self, name: &str, dims: &[usize], data: &[u32]) -> Result<&mut Self, MatError> {
+    pub fn write_u32(
+        &mut self,
+        name: &str,
+        dims: &[usize],
+        data: &[u32],
+    ) -> Result<&mut Self, MatError> {
         self.mb.write_u32(name, dims, data)?;
         Ok(self)
     }
     #[inline]
-    pub fn write_u64(&mut self, name: &str, dims: &[usize], data: &[u64]) -> Result<&mut Self, MatError> {
+    pub fn write_u64(
+        &mut self,
+        name: &str,
+        dims: &[usize],
+        data: &[u64],
+    ) -> Result<&mut Self, MatError> {
         self.mb.write_u64(name, dims, data)?;
         Ok(self)
     }
     #[inline]
-    pub fn write_logical(&mut self, name: &str, dims: &[usize], data: &[u8]) -> Result<&mut Self, MatError> {
+    pub fn write_logical(
+        &mut self,
+        name: &str,
+        dims: &[usize],
+        data: &[u8],
+    ) -> Result<&mut Self, MatError> {
         self.mb.write_logical(name, dims, data)?;
         Ok(self)
     }
@@ -1296,7 +1416,8 @@ impl<'a> CellWriter<'a> {
     pub fn push_string(&mut self, value: &str) -> Result<&mut Self, MatError> {
         // MATLAB string scalar: dims [1, 1].
         let r = self.arm();
-        self.mb.write_string_object(&r, &[value.to_owned()], &[1, 1])?;
+        self.mb
+            .write_string_object(&r, &[value.to_owned()], &[1, 1])?;
         self.record(r);
         Ok(self)
     }

--- a/src/mat/class.rs
+++ b/src/mat/class.rs
@@ -136,6 +136,9 @@ mod tests {
 
     #[test]
     fn unknown_class_is_error() {
-        assert!(matches!(MatClass::parse("datetime"), Err(MatError::UnknownClass(_))));
+        assert!(matches!(
+            MatClass::parse("datetime"),
+            Err(MatError::UnknownClass(_))
+        ));
     }
 }

--- a/src/mat/de/reader.rs
+++ b/src/mat/de/reader.rs
@@ -48,7 +48,7 @@ fn read_dataset(ds: &Dataset<'_>) -> Result<MatValue, MatError> {
     let class = matlab_class_from_attrs(&attrs)?;
     let shape = ds.shape().map_err(MatError::Hdf5)?;
     let dtype = ds.dtype().map_err(MatError::Hdf5)?;
-    let is_empty = is_empty_attr(&attrs) || shape.iter().any(|&d| d == 0);
+    let is_empty = is_empty_attr(&attrs) || shape.contains(&0);
 
     let class = class.unwrap_or_else(|| class_from_dtype(&dtype));
 
@@ -98,7 +98,7 @@ fn matlab_class_from_attrs(
         other => {
             return Err(MatError::Custom(format!(
                 "MATLAB_class attribute has unexpected type: {other:?}"
-            )))
+            )));
         }
     };
     match raw {
@@ -172,11 +172,7 @@ fn is_complex_dtype(dtype: &DType) -> bool {
 // Numeric reading
 // ---------------------------------------------------------------------------
 
-fn read_numeric(
-    ds: &Dataset<'_>,
-    shape: &[u64],
-    class: MatClass,
-) -> Result<MatValue, MatError> {
+fn read_numeric(ds: &Dataset<'_>, shape: &[u64], class: MatClass) -> Result<MatValue, MatError> {
     let (rows, cols, total) = shape_decomposition(shape);
 
     // For a single-element dataset we emit a Scalar of the appropriate class.
@@ -299,11 +295,7 @@ fn transpose_col_major_to_row_major(
 // Complex reading
 // ---------------------------------------------------------------------------
 
-fn read_complex(
-    ds: &Dataset<'_>,
-    shape: &[u64],
-    class: MatClass,
-) -> Result<MatValue, MatError> {
+fn read_complex(ds: &Dataset<'_>, shape: &[u64], class: MatClass) -> Result<MatValue, MatError> {
     let (rows, cols, total) = shape_decomposition(shape);
     let bytes = ds.read_u8().map_err(MatError::Hdf5)?;
 

--- a/src/mat/de/value_de.rs
+++ b/src/mat/de/value_de.rs
@@ -333,12 +333,8 @@ fn dispatch_any<'de, V: Visitor<'de>>(value: MatValue, visitor: V) -> Result<V::
         MatValue::Matrix { rows, cols, vec } => {
             visitor.visit_seq(MatrixRowsSeq::new(rows, cols, vec))
         }
-        MatValue::ComplexScalar64 { re, im } => {
-            visitor.visit_map(ComplexStructMap64::new(re, im))
-        }
-        MatValue::ComplexScalar32 { re, im } => {
-            visitor.visit_map(ComplexStructMap32::new(re, im))
-        }
+        MatValue::ComplexScalar64 { re, im } => visitor.visit_map(ComplexStructMap64::new(re, im)),
+        MatValue::ComplexScalar32 { re, im } => visitor.visit_map(ComplexStructMap32::new(re, im)),
         MatValue::ComplexVec64(pairs) => {
             visitor.visit_seq(ComplexPairsSeq::Vec64(pairs.into_iter().collect()))
         }
@@ -361,7 +357,7 @@ fn dispatch_any<'de, V: Visitor<'de>>(value: MatValue, visitor: V) -> Result<V::
 // Helper coercions
 // ---------------------------------------------------------------------------
 
-fn mismatch<'de, T>(expected: &'static str, got: MatValue) -> Result<T, MatError> {
+fn mismatch<T>(expected: &'static str, got: MatValue) -> Result<T, MatError> {
     Err(MatError::Custom(format!(
         "expected {expected}, got {}",
         got.kind()
@@ -748,10 +744,7 @@ impl<'de> MapAccess<'de> for StructMap {
             None => Ok(None),
         }
     }
-    fn next_value_seed<V: DeserializeSeed<'de>>(
-        &mut self,
-        seed: V,
-    ) -> Result<V::Value, MatError> {
+    fn next_value_seed<V: DeserializeSeed<'de>>(&mut self, seed: V) -> Result<V::Value, MatError> {
         let v = self
             .pending_value
             .take()
@@ -828,10 +821,7 @@ impl<'de> MapAccess<'de> for MatrixStructMap {
         seed.deserialize(StringRefDe(key.to_string())).map(Some)
     }
 
-    fn next_value_seed<V: DeserializeSeed<'de>>(
-        &mut self,
-        seed: V,
-    ) -> Result<V::Value, MatError> {
+    fn next_value_seed<V: DeserializeSeed<'de>>(&mut self, seed: V) -> Result<V::Value, MatError> {
         match self.state {
             MatrixState::NeedRowsValue => {
                 self.state = MatrixState::NeedColsKey;
@@ -952,16 +942,8 @@ macro_rules! impl_complex_map {
     };
 }
 
-impl_complex_map!(
-    ComplexStructMap64,
-    f64,
-    |x: f64| x.into_deserializer()
-);
-impl_complex_map!(
-    ComplexStructMap32,
-    f32,
-    |x: f32| x.into_deserializer()
-);
+impl_complex_map!(ComplexStructMap64, f64, |x: f64| x.into_deserializer());
+impl_complex_map!(ComplexStructMap32, f32, |x: f32| x.into_deserializer());
 
 // ---------------------------------------------------------------------------
 // Enum unit variant

--- a/src/mat/dims.rs
+++ b/src/mat/dims.rs
@@ -48,10 +48,7 @@ pub fn matrix_dims(extents: &[usize], mode: OneDimensionalMode) -> Vec<usize> {
 ///
 /// Panics if `buf.len()` is smaller than `matlab_dims.len().max(2)`.
 #[inline]
-pub fn storage_dims_u64_into<'a>(
-    matlab_dims: &[usize],
-    buf: &'a mut [u64],
-) -> &'a [u64] {
+pub fn storage_dims_u64_into<'a>(matlab_dims: &[usize], buf: &'a mut [u64]) -> &'a [u64] {
     let n = matlab_dims.len().max(2);
     assert!(
         n <= buf.len(),
@@ -104,7 +101,10 @@ mod tests {
 
     #[test]
     fn matrix_dims_handles_special_cases() {
-        assert_eq!(matrix_dims(&[], OneDimensionalMode::ColumnVector), vec![1, 1]);
+        assert_eq!(
+            matrix_dims(&[], OneDimensionalMode::ColumnVector),
+            vec![1, 1]
+        );
         assert_eq!(
             matrix_dims(&[7], OneDimensionalMode::ColumnVector),
             vec![7, 1]
@@ -121,10 +121,7 @@ mod tests {
         assert_eq!(storage_dims_u64_into(&[], &mut buf), &[1u64, 1]);
         assert_eq!(storage_dims_u64_into(&[5], &mut buf), &[1u64, 5]);
         assert_eq!(storage_dims_u64_into(&[3, 4], &mut buf), &[4u64, 3]);
-        assert_eq!(
-            storage_dims_u64_into(&[2, 3, 4], &mut buf),
-            &[4u64, 3, 2]
-        );
+        assert_eq!(storage_dims_u64_into(&[2, 3, 4], &mut buf), &[4u64, 3, 2]);
     }
 
     #[test]

--- a/src/mat/mod.rs
+++ b/src/mat/mod.rs
@@ -87,9 +87,9 @@ pub use complex::{Complex32, Complex64};
 pub use matrix::Matrix;
 
 #[cfg(feature = "serde")]
-use serde::de::DeserializeOwned;
-#[cfg(feature = "serde")]
 use serde::Serialize;
+#[cfg(feature = "serde")]
+use serde::de::DeserializeOwned;
 
 /// Serialize `value` to a MAT v7.3 byte vector.
 ///

--- a/src/mat/ser/emit.rs
+++ b/src/mat/ser/emit.rs
@@ -8,7 +8,7 @@ use crate::mat::error::MatError;
 use crate::mat::userblock::{self, USERBLOCK_SIZE};
 use crate::mat::utf16;
 use crate::type_builders::{
-    make_f32_type, make_f64_type, DatasetBuilder, FinishedGroup, GroupBuilder,
+    DatasetBuilder, FinishedGroup, GroupBuilder, make_f32_type, make_f64_type,
 };
 use crate::writer::FileBuilder;
 

--- a/src/mat/ser/emit_with_builder.rs
+++ b/src/mat/ser/emit_with_builder.rs
@@ -68,10 +68,7 @@ fn emit_at_struct(sw: &mut StructWriter, name: &str, value: MatValue) -> Result<
     }
 }
 
-fn emit_cell_elements(
-    cw: &mut CellWriter,
-    elements: Vec<MatValue>,
-) -> Result<(), MatError> {
+fn emit_cell_elements(cw: &mut CellWriter, elements: Vec<MatValue>) -> Result<(), MatError> {
     for value in elements {
         emit_cell_element(cw, value)?;
     }
@@ -252,11 +249,7 @@ fn emit_cell_matrix(
     Ok(())
 }
 
-fn emit_leaf_at_builder(
-    mb: &mut MatBuilder,
-    name: &str,
-    value: MatValue,
-) -> Result<(), MatError> {
+fn emit_leaf_at_builder(mb: &mut MatBuilder, name: &str, value: MatValue) -> Result<(), MatError> {
     match value {
         MatValue::Omit | MatValue::Struct(_) | MatValue::Cell(_) => {
             // Handled by the caller.
@@ -280,21 +273,19 @@ fn emit_leaf_at_builder(
             .map(|_| ()),
         MatValue::ComplexMatrix64 { rows, cols, pairs } => {
             let col_major = transpose_pairs(rows, cols, &pairs);
-            mb.write_complex_f64(name, &[rows, cols], &col_major).map(|_| ())
+            mb.write_complex_f64(name, &[rows, cols], &col_major)
+                .map(|_| ())
         }
         MatValue::ComplexMatrix32 { rows, cols, pairs } => {
             let col_major = transpose_pairs(rows, cols, &pairs);
-            mb.write_complex_f32(name, &[rows, cols], &col_major).map(|_| ())
+            mb.write_complex_f32(name, &[rows, cols], &col_major)
+                .map(|_| ())
         }
         MatValue::EmptyStructArray => mb.write_empty_struct_array(name).map(|_| ()),
     }
 }
 
-fn emit_leaf_at_struct(
-    sw: &mut StructWriter,
-    name: &str,
-    value: MatValue,
-) -> Result<(), MatError> {
+fn emit_leaf_at_struct(sw: &mut StructWriter, name: &str, value: MatValue) -> Result<(), MatError> {
     match value {
         MatValue::Omit | MatValue::Struct(_) | MatValue::Cell(_) => Ok(()),
         MatValue::Scalar(n) => emit_scalar_at_struct(sw, name, n),
@@ -315,11 +306,13 @@ fn emit_leaf_at_struct(
             .map(|_| ()),
         MatValue::ComplexMatrix64 { rows, cols, pairs } => {
             let col_major = transpose_pairs(rows, cols, &pairs);
-            sw.write_complex_f64(name, &[rows, cols], &col_major).map(|_| ())
+            sw.write_complex_f64(name, &[rows, cols], &col_major)
+                .map(|_| ())
         }
         MatValue::ComplexMatrix32 { rows, cols, pairs } => {
             let col_major = transpose_pairs(rows, cols, &pairs);
-            sw.write_complex_f32(name, &[rows, cols], &col_major).map(|_| ())
+            sw.write_complex_f32(name, &[rows, cols], &col_major)
+                .map(|_| ())
         }
         MatValue::EmptyStructArray => sw.write_empty_struct_array(name).map(|_| ()),
     }
@@ -370,7 +363,9 @@ fn emit_scalar_at_struct(
 fn emit_vec_at_builder(mb: &mut MatBuilder, name: &str, v: NumVec) -> Result<(), MatError> {
     let dims = mb.vector_dims(v.len());
     if v.len() == 0 {
-        return mb.write_empty(name, scalar_class(v.tag()), &dims).map(|_| ());
+        return mb
+            .write_empty(name, scalar_class(v.tag()), &dims)
+            .map(|_| ());
     }
     match v {
         NumVec::Bool(vec) => {
@@ -394,7 +389,9 @@ fn emit_vec_at_builder(mb: &mut MatBuilder, name: &str, v: NumVec) -> Result<(),
 fn emit_vec_at_struct(sw: &mut StructWriter, name: &str, v: NumVec) -> Result<(), MatError> {
     let dims = sw.vector_dims(v.len());
     if v.len() == 0 {
-        return sw.write_empty(name, scalar_class(v.tag()), &dims).map(|_| ());
+        return sw
+            .write_empty(name, scalar_class(v.tag()), &dims)
+            .map(|_| ());
     }
     match v {
         NumVec::Bool(vec) => {
@@ -471,22 +468,16 @@ fn emit_matrix_at_struct(
     .map(|_| ())
 }
 
-fn emit_string_at_builder(
-    mb: &mut MatBuilder,
-    name: &str,
-    s: &str,
-) -> Result<(), MatError> {
+fn emit_string_at_builder(mb: &mut MatBuilder, name: &str, s: &str) -> Result<(), MatError> {
     match mb.options().string_class {
         StringClass::Char => mb.write_char(name, s).map(|_| ()),
-        StringClass::String => mb.write_string_object(name, &[s.to_owned()], &[1, 1]).map(|_| ()),
+        StringClass::String => mb
+            .write_string_object(name, &[s.to_owned()], &[1, 1])
+            .map(|_| ()),
     }
 }
 
-fn emit_string_at_struct(
-    sw: &mut StructWriter,
-    name: &str,
-    s: &str,
-) -> Result<(), MatError> {
+fn emit_string_at_struct(sw: &mut StructWriter, name: &str, s: &str) -> Result<(), MatError> {
     match sw.string_class() {
         StringClass::Char => sw.write_char(name, s).map(|_| ()),
         StringClass::String => sw

--- a/src/mat/ser/root.rs
+++ b/src/mat/ser/root.rs
@@ -4,16 +4,14 @@
 //! file. A flat `HashMap<String, T>` is also accepted, matching
 //! `scipy.io.savemat`'s dict-at-root convention.
 
-use serde::ser::{
-    self, Impossible, Serialize, SerializeMap, SerializeStruct, Serializer,
-};
+use serde::ser::{self, Impossible, Serialize, SerializeMap, SerializeStruct, Serializer};
 
 use crate::mat::error::MatError;
 use crate::mat::options::Options;
 
 use super::emit::emit_file;
 use super::emit_with_builder::emit_file_with_options;
-use super::value_ser::{to_value, ValueSerializer};
+use super::value_ser::{ValueSerializer, to_value};
 use crate::mat::value::MatValue;
 
 /// Serialize `value` to MAT v7.3 file bytes (with 512-byte userblock).
@@ -50,21 +48,51 @@ impl Serializer for RootSerializer {
     fn serialize_bool(self, _: bool) -> Result<Self::Ok, MatError> {
         Err(MatError::RootMustBeStruct)
     }
-    fn serialize_i8(self, _: i8) -> Result<Self::Ok, MatError> { Err(MatError::RootMustBeStruct) }
-    fn serialize_i16(self, _: i16) -> Result<Self::Ok, MatError> { Err(MatError::RootMustBeStruct) }
-    fn serialize_i32(self, _: i32) -> Result<Self::Ok, MatError> { Err(MatError::RootMustBeStruct) }
-    fn serialize_i64(self, _: i64) -> Result<Self::Ok, MatError> { Err(MatError::RootMustBeStruct) }
-    fn serialize_i128(self, _: i128) -> Result<Self::Ok, MatError> { Err(MatError::RootMustBeStruct) }
-    fn serialize_u8(self, _: u8) -> Result<Self::Ok, MatError> { Err(MatError::RootMustBeStruct) }
-    fn serialize_u16(self, _: u16) -> Result<Self::Ok, MatError> { Err(MatError::RootMustBeStruct) }
-    fn serialize_u32(self, _: u32) -> Result<Self::Ok, MatError> { Err(MatError::RootMustBeStruct) }
-    fn serialize_u64(self, _: u64) -> Result<Self::Ok, MatError> { Err(MatError::RootMustBeStruct) }
-    fn serialize_u128(self, _: u128) -> Result<Self::Ok, MatError> { Err(MatError::RootMustBeStruct) }
-    fn serialize_f32(self, _: f32) -> Result<Self::Ok, MatError> { Err(MatError::RootMustBeStruct) }
-    fn serialize_f64(self, _: f64) -> Result<Self::Ok, MatError> { Err(MatError::RootMustBeStruct) }
-    fn serialize_char(self, _: char) -> Result<Self::Ok, MatError> { Err(MatError::RootMustBeStruct) }
-    fn serialize_str(self, _: &str) -> Result<Self::Ok, MatError> { Err(MatError::RootMustBeStruct) }
-    fn serialize_bytes(self, _: &[u8]) -> Result<Self::Ok, MatError> { Err(MatError::RootMustBeStruct) }
+    fn serialize_i8(self, _: i8) -> Result<Self::Ok, MatError> {
+        Err(MatError::RootMustBeStruct)
+    }
+    fn serialize_i16(self, _: i16) -> Result<Self::Ok, MatError> {
+        Err(MatError::RootMustBeStruct)
+    }
+    fn serialize_i32(self, _: i32) -> Result<Self::Ok, MatError> {
+        Err(MatError::RootMustBeStruct)
+    }
+    fn serialize_i64(self, _: i64) -> Result<Self::Ok, MatError> {
+        Err(MatError::RootMustBeStruct)
+    }
+    fn serialize_i128(self, _: i128) -> Result<Self::Ok, MatError> {
+        Err(MatError::RootMustBeStruct)
+    }
+    fn serialize_u8(self, _: u8) -> Result<Self::Ok, MatError> {
+        Err(MatError::RootMustBeStruct)
+    }
+    fn serialize_u16(self, _: u16) -> Result<Self::Ok, MatError> {
+        Err(MatError::RootMustBeStruct)
+    }
+    fn serialize_u32(self, _: u32) -> Result<Self::Ok, MatError> {
+        Err(MatError::RootMustBeStruct)
+    }
+    fn serialize_u64(self, _: u64) -> Result<Self::Ok, MatError> {
+        Err(MatError::RootMustBeStruct)
+    }
+    fn serialize_u128(self, _: u128) -> Result<Self::Ok, MatError> {
+        Err(MatError::RootMustBeStruct)
+    }
+    fn serialize_f32(self, _: f32) -> Result<Self::Ok, MatError> {
+        Err(MatError::RootMustBeStruct)
+    }
+    fn serialize_f64(self, _: f64) -> Result<Self::Ok, MatError> {
+        Err(MatError::RootMustBeStruct)
+    }
+    fn serialize_char(self, _: char) -> Result<Self::Ok, MatError> {
+        Err(MatError::RootMustBeStruct)
+    }
+    fn serialize_str(self, _: &str) -> Result<Self::Ok, MatError> {
+        Err(MatError::RootMustBeStruct)
+    }
+    fn serialize_bytes(self, _: &[u8]) -> Result<Self::Ok, MatError> {
+        Err(MatError::RootMustBeStruct)
+    }
 
     fn serialize_none(self) -> Result<Self::Ok, MatError> {
         // `None` at root: produce an empty file (no variables).
@@ -138,11 +166,7 @@ impl Serializer for RootSerializer {
         Ok(RootMapSer::default())
     }
 
-    fn serialize_struct(
-        self,
-        _name: &'static str,
-        _len: usize,
-    ) -> Result<RootStructSer, MatError> {
+    fn serialize_struct(self, _name: &'static str, _len: usize) -> Result<RootStructSer, MatError> {
         Ok(RootStructSer::default())
     }
 

--- a/src/mat/ser/value_ser.rs
+++ b/src/mat/ser/value_ser.rs
@@ -60,7 +60,9 @@ impl Serializer for ValueSerializer {
         Ok(MatValue::Scalar(ScalarNum::I64(v)))
     }
     fn serialize_i128(self, _v: i128) -> Result<MatValue, MatError> {
-        Err(MatError::UnsupportedType("i128 (MATLAB has no 128-bit integer)"))
+        Err(MatError::UnsupportedType(
+            "i128 (MATLAB has no 128-bit integer)",
+        ))
     }
     fn serialize_u8(self, v: u8) -> Result<MatValue, MatError> {
         Ok(MatValue::Scalar(ScalarNum::U8(v)))
@@ -151,11 +153,7 @@ impl Serializer for ValueSerializer {
     fn serialize_tuple(self, len: usize) -> Result<SeqSer, MatError> {
         Ok(SeqSer::new(Some(len)))
     }
-    fn serialize_tuple_struct(
-        self,
-        _name: &'static str,
-        len: usize,
-    ) -> Result<SeqSer, MatError> {
+    fn serialize_tuple_struct(self, _name: &'static str, len: usize) -> Result<SeqSer, MatError> {
         Ok(SeqSer::new(Some(len)))
     }
     fn serialize_tuple_variant(
@@ -172,11 +170,7 @@ impl Serializer for ValueSerializer {
         Ok(MapSer::new())
     }
 
-    fn serialize_struct(
-        self,
-        name: &'static str,
-        _len: usize,
-    ) -> Result<StructSer, MatError> {
+    fn serialize_struct(self, name: &'static str, _len: usize) -> Result<StructSer, MatError> {
         Ok(match name {
             MATRIX_SENTINEL => StructSer::Matrix(MatrixFields::default()),
             COMPLEX64_SENTINEL => StructSer::Complex64(ComplexFields::default()),
@@ -288,9 +282,7 @@ fn unify_sequence(elements: Vec<MatValue>) -> Result<MatValue, MatError> {
 /// ownership without re-cloning each element. (Cloning a `Vec1D` or
 /// `ComplexVec*` of the inner shape would double peak allocation on the
 /// matrix path for large `Vec<Vec<T>>` inputs.)
-fn try_unify_homogeneous(
-    elements: Vec<MatValue>,
-) -> Result<MatValue, Vec<MatValue>> {
+fn try_unify_homogeneous(elements: Vec<MatValue>) -> Result<MatValue, Vec<MatValue>> {
     debug_assert!(!elements.is_empty());
 
     // ----- all elements are numeric scalars of the same tag → Vec1D -----
@@ -302,7 +294,9 @@ fn try_unify_homogeneous(
         {
             let mut vec = NumVec::empty_with_tag(first_tag);
             for e in elements {
-                let MatValue::Scalar(s) = e else { unreachable!() };
+                let MatValue::Scalar(s) = e else {
+                    unreachable!()
+                };
                 vec.push(s).expect("tag check held");
             }
             return Ok(MatValue::Vec1D(vec));
@@ -313,13 +307,15 @@ fn try_unify_homogeneous(
     if let Some(MatValue::Vec1D(first)) = elements.first() {
         let first_tag = first.tag();
         let first_len = first.len();
-        if elements.iter().all(|e| {
-            matches!(e, MatValue::Vec1D(v) if v.tag() == first_tag && v.len() == first_len)
-        }) {
+        if elements.iter().all(
+            |e| matches!(e, MatValue::Vec1D(v) if v.tag() == first_tag && v.len() == first_len),
+        ) {
             let rows = elements.len();
             let mut flat = NumVec::empty_with_tag(first_tag);
             for e in elements {
-                let MatValue::Vec1D(v) = e else { unreachable!() };
+                let MatValue::Vec1D(v) = e else {
+                    unreachable!()
+                };
                 flat.extend(v).expect("tag check held");
             }
             return Ok(MatValue::Matrix {
@@ -369,7 +365,9 @@ fn try_unify_homogeneous(
             let rows = elements.len();
             let mut pairs: Vec<(f64, f64)> = Vec::with_capacity(rows * first_len);
             for e in elements {
-                let MatValue::ComplexVec64(v) = e else { unreachable!() };
+                let MatValue::ComplexVec64(v) = e else {
+                    unreachable!()
+                };
                 pairs.extend(v);
             }
             return Ok(MatValue::ComplexMatrix64 {
@@ -388,7 +386,9 @@ fn try_unify_homogeneous(
             let rows = elements.len();
             let mut pairs: Vec<(f32, f32)> = Vec::with_capacity(rows * first_len);
             for e in elements {
-                let MatValue::ComplexVec32(v) = e else { unreachable!() };
+                let MatValue::ComplexVec32(v) = e else {
+                    unreachable!()
+                };
                 pairs.extend(v);
             }
             return Ok(MatValue::ComplexMatrix32 {
@@ -432,7 +432,7 @@ impl SerializeMap for MapSer {
                 return Err(MatError::UnsupportedType(match other.kind() {
                     "struct" => "map with non-string keys (struct as key)",
                     _ => "map with non-string keys",
-                }))
+                }));
             }
         };
         self.pending_key = Some(key_str);
@@ -440,10 +440,9 @@ impl SerializeMap for MapSer {
     }
 
     fn serialize_value<T: Serialize + ?Sized>(&mut self, value: &T) -> Result<(), MatError> {
-        let key = self
-            .pending_key
-            .take()
-            .ok_or_else(|| MatError::Custom("serialize_value called before serialize_key".into()))?;
+        let key = self.pending_key.take().ok_or_else(|| {
+            MatError::Custom("serialize_value called before serialize_key".into())
+        })?;
         let val = value.serialize(ValueSerializer)?;
         if !matches!(val, MatValue::Omit) {
             self.fields.push((key, val));
@@ -512,7 +511,7 @@ impl SerializeStruct for StructSer {
                 other => {
                     return Err(MatError::Custom(format!(
                         "unexpected field {other:?} on Matrix sentinel"
-                    )))
+                    )));
                 }
             },
             StructSer::Complex64(fields) => match key {
@@ -521,7 +520,7 @@ impl SerializeStruct for StructSer {
                 other => {
                     return Err(MatError::Custom(format!(
                         "unexpected field {other:?} on Complex64 sentinel"
-                    )))
+                    )));
                 }
             },
             StructSer::Complex32(fields) => match key {
@@ -530,7 +529,7 @@ impl SerializeStruct for StructSer {
                 other => {
                     return Err(MatError::Custom(format!(
                         "unexpected field {other:?} on Complex32 sentinel"
-                    )))
+                    )));
                 }
             },
             StructSer::Plain(ps) => {
@@ -566,9 +565,15 @@ impl SerializeStruct for StructSer {
 }
 
 fn matrix_from_fields(fields: MatrixFields) -> Result<MatValue, MatError> {
-    let rows = fields.rows.ok_or_else(|| MatError::MissingField("rows".into()))?;
-    let cols = fields.cols.ok_or_else(|| MatError::MissingField("cols".into()))?;
-    let data = fields.data.ok_or_else(|| MatError::MissingField("data".into()))?;
+    let rows = fields
+        .rows
+        .ok_or_else(|| MatError::MissingField("rows".into()))?;
+    let cols = fields
+        .cols
+        .ok_or_else(|| MatError::MissingField("cols".into()))?;
+    let data = fields
+        .data
+        .ok_or_else(|| MatError::MissingField("data".into()))?;
     let vec = match data {
         MatValue::Vec1D(v) => v,
         // Serializing `Vec<T>` of length 0 with T unknown yields F64.
@@ -582,7 +587,7 @@ fn matrix_from_fields(fields: MatrixFields) -> Result<MatValue, MatError> {
             return Err(MatError::Custom(format!(
                 "Matrix::data must be a Vec<T>, got {}",
                 other.kind()
-            )))
+            )));
         }
     };
     if vec.len() != rows * cols {

--- a/src/mat/string_object.rs
+++ b/src/mat/string_object.rs
@@ -175,7 +175,9 @@ fn u32_bytes(values: &[u32]) -> Vec<u8> {
 }
 
 fn product(extents: &[usize]) -> Option<usize> {
-    extents.iter().try_fold(1usize, |acc, &dim| acc.checked_mul(dim))
+    extents
+        .iter()
+        .try_fold(1usize, |acc, &dim| acc.checked_mul(dim))
 }
 
 #[cfg(test)]
@@ -199,11 +201,8 @@ mod tests {
 
     #[test]
     fn saveobj_validates_dim_product() {
-        let err = encode_string_saveobj_payload(
-            &["a".to_owned(), "b".to_owned()],
-            &[3, 1],
-        )
-        .unwrap_err();
+        let err =
+            encode_string_saveobj_payload(&["a".to_owned(), "b".to_owned()], &[3, 1]).unwrap_err();
         assert!(matches!(err, MatError::Custom(_)));
     }
 }

--- a/src/mat/userblock.rs
+++ b/src/mat/userblock.rs
@@ -10,8 +10,7 @@
 pub const USERBLOCK_SIZE: u64 = 512;
 
 /// Default description text written in the first 124 bytes.
-pub const DEFAULT_DESCRIPTION: &str =
-    "MATLAB 7.3 MAT-file, Platform: hdf5-pure (Rust)";
+pub const DEFAULT_DESCRIPTION: &str = "MATLAB 7.3 MAT-file, Platform: hdf5-pure (Rust)";
 
 /// Write the MATLAB v7.3 userblock into the first 512 bytes of `file_bytes`.
 ///
@@ -32,7 +31,11 @@ pub fn write_header(file_bytes: &mut [u8], description: &str) {
     let n = bytes.len().min(124);
     for (dst, src) in file_bytes[..n].iter_mut().zip(bytes[..n].iter()) {
         // Replace non-ASCII with '?' to keep the header valid ASCII.
-        *dst = if src.is_ascii() && *src != 0 { *src } else { b'?' };
+        *dst = if src.is_ascii() && *src != 0 {
+            *src
+        } else {
+            b'?'
+        };
     }
 
     // 124..126: version = 0x0200 (little-endian → bytes 0x00, 0x02).

--- a/src/mat/value.rs
+++ b/src/mat/value.rs
@@ -218,13 +218,9 @@ impl MatValue {
             MatValue::Vec1D(_) => "1-D vector",
             MatValue::Matrix { .. } => "2-D matrix",
             MatValue::String(_) => "string",
-            MatValue::ComplexScalar64 { .. } | MatValue::ComplexScalar32 { .. } => {
-                "complex scalar"
-            }
+            MatValue::ComplexScalar64 { .. } | MatValue::ComplexScalar32 { .. } => "complex scalar",
             MatValue::ComplexVec64(_) | MatValue::ComplexVec32(_) => "complex vector",
-            MatValue::ComplexMatrix64 { .. } | MatValue::ComplexMatrix32 { .. } => {
-                "complex matrix"
-            }
+            MatValue::ComplexMatrix64 { .. } | MatValue::ComplexMatrix32 { .. } => "complex matrix",
             MatValue::Struct(_) => "struct",
             MatValue::Cell(_) => "cell array",
             MatValue::EmptyStructArray => "empty struct array",

--- a/src/object_header.rs
+++ b/src/object_header.rs
@@ -130,19 +130,24 @@ impl ObjectHeader {
 
         // Pad to 8-byte alignment: header prefix is 12 bytes, pad to 16
         let padding = 4; // pad 12-byte prefix to 16-byte alignment
-        let msg_start = offset.checked_add(12 + padding).ok_or(FormatError::UnexpectedEof {
-            expected: usize::MAX,
-            available: data.len(),
-        })?;
+        let msg_start = offset
+            .checked_add(12 + padding)
+            .ok_or(FormatError::UnexpectedEof {
+                expected: usize::MAX,
+                available: data.len(),
+            })?;
 
         ensure_len(data, msg_start, header_data_size)?;
 
         let mut messages = Vec::new();
         let mut pos = msg_start;
-        let msg_end = msg_start.checked_add(header_data_size).ok_or(FormatError::UnexpectedEof {
-            expected: usize::MAX,
-            available: data.len(),
-        })?;
+        let msg_end =
+            msg_start
+                .checked_add(header_data_size)
+                .ok_or(FormatError::UnexpectedEof {
+                    expected: usize::MAX,
+                    available: data.len(),
+                })?;
 
         for _ in 0..num_messages {
             if pos + 8 > msg_end {
@@ -158,10 +163,10 @@ impl ObjectHeader {
             let msg_type = MessageType::from_u16(msg_type_raw);
 
             // Check if unknown + must-understand (bit 3 of msg_flags)
-            if let MessageType::Unknown(id) = msg_type {
-                if msg_flags & 0x08 != 0 {
-                    return Err(FormatError::UnsupportedMessage(id));
-                }
+            if let MessageType::Unknown(id) = msg_type
+                && msg_flags & 0x08 != 0
+            {
+                return Err(FormatError::UnsupportedMessage(id));
             }
 
             if msg_type != MessageType::Nil {
@@ -178,15 +183,15 @@ impl ObjectHeader {
 
             // Follow continuations
             if msg_type == MessageType::ObjectHeaderContinuation {
-                let cont_msg_data = &messages.last()
-                    .ok_or(FormatError::InvalidObjectHeaderSignature)?.data;
+                let cont_msg_data = &messages
+                    .last()
+                    .ok_or(FormatError::InvalidObjectHeaderSignature)?
+                    .data;
                 if cont_msg_data.len() >= (offset_size as usize + length_size as usize) {
-                    let cont_offset_raw =
-                        read_offset(cont_msg_data, 0, offset_size)?;
+                    let cont_offset_raw = read_offset(cont_msg_data, 0, offset_size)?;
                     let cont_offset = (cont_offset_raw + base_address) as usize;
                     let cont_length =
-                        read_offset(cont_msg_data, offset_size as usize, length_size)?
-                            as usize;
+                        read_offset(cont_msg_data, offset_size as usize, length_size)? as usize;
                     // Parse continuation block (v1: just raw messages, no signature)
                     let cont_msgs = Self::parse_v1_continuation(
                         data,
@@ -243,10 +248,10 @@ impl ObjectHeader {
 
             let msg_type = MessageType::from_u16(msg_type_raw);
 
-            if let MessageType::Unknown(id) = msg_type {
-                if msg_flags & 0x08 != 0 {
-                    return Err(FormatError::UnsupportedMessage(id));
-                }
+            if let MessageType::Unknown(id) = msg_type
+                && msg_flags & 0x08 != 0
+            {
+                return Err(FormatError::UnsupportedMessage(id));
             }
 
             if msg_type != MessageType::Nil {
@@ -263,17 +268,21 @@ impl ObjectHeader {
 
             // Recursive continuations
             if msg_type == MessageType::ObjectHeaderContinuation {
-                let cont_msg_data = &messages.last()
-                    .ok_or(FormatError::InvalidObjectHeaderSignature)?.data;
+                let cont_msg_data = &messages
+                    .last()
+                    .ok_or(FormatError::InvalidObjectHeaderSignature)?
+                    .data;
                 if cont_msg_data.len() >= (offset_size as usize + length_size as usize) {
-                    let cont_offset_raw =
-                        read_offset(cont_msg_data, 0, offset_size)?;
+                    let cont_offset_raw = read_offset(cont_msg_data, 0, offset_size)?;
                     let cont_offset = (cont_offset_raw + base_address) as usize;
                     let cont_length =
-                        read_offset(cont_msg_data, offset_size as usize, length_size)?
-                            as usize;
+                        read_offset(cont_msg_data, offset_size as usize, length_size)? as usize;
                     let cont_msgs = Self::parse_v1_continuation(
-                        data, cont_offset, cont_length, offset_size, length_size,
+                        data,
+                        cont_offset,
+                        cont_length,
+                        offset_size,
+                        length_size,
                         base_address,
                         depth_remaining - 1,
                     )?;
@@ -335,10 +344,12 @@ impl ObjectHeader {
         pos += chunk_size_width as usize;
 
         let chunk0_msg_start = pos;
-        let chunk0_msg_end = pos.checked_add(chunk0_size).ok_or(FormatError::UnexpectedEof {
-            expected: usize::MAX,
-            available: data.len(),
-        })?;
+        let chunk0_msg_end = pos
+            .checked_add(chunk0_size)
+            .ok_or(FormatError::UnexpectedEof {
+                expected: usize::MAX,
+                available: data.len(),
+            })?;
 
         // Validate checksum: from OHDR signature through all messages (before checksum)
         ensure_len(data, chunk0_msg_end, 4)?;
@@ -434,10 +445,10 @@ impl ObjectHeader {
 
             let msg_type = MessageType::from_u16(msg_type_raw);
 
-            if let MessageType::Unknown(id) = msg_type {
-                if msg_flags & 0x08 != 0 {
-                    return Err(FormatError::UnsupportedMessage(id));
-                }
+            if let MessageType::Unknown(id) = msg_type
+                && msg_flags & 0x08 != 0
+            {
+                return Err(FormatError::UnsupportedMessage(id));
             }
 
             let msg_data = data[pos..pos + msg_data_size].to_vec();
@@ -565,13 +576,11 @@ mod tests {
         buf.push(2); // version
         buf.push(flags);
 
-        if has_timestamps {
-            if let Some((at, mt, ct, bt)) = timestamps {
-                buf.extend_from_slice(&at.to_le_bytes());
-                buf.extend_from_slice(&mt.to_le_bytes());
-                buf.extend_from_slice(&ct.to_le_bytes());
-                buf.extend_from_slice(&bt.to_le_bytes());
-            }
+        if has_timestamps && let Some((at, mt, ct, bt)) = timestamps {
+            buf.extend_from_slice(&at.to_le_bytes());
+            buf.extend_from_slice(&mt.to_le_bytes());
+            buf.extend_from_slice(&ct.to_le_bytes());
+            buf.extend_from_slice(&bt.to_le_bytes());
         }
 
         if flags & 0x10 != 0 {
@@ -623,7 +632,7 @@ mod tests {
     fn parse_v1_two_messages() {
         let messages = [
             (0x0001u16, &[1u8, 2, 3, 4][..], 0u8), // Dataspace
-            (0x0008, &[5u8, 6][..], 0),              // DataLayout
+            (0x0008, &[5u8, 6][..], 0),            // DataLayout
         ];
         let data = build_v1_header(&messages, 8, 8);
         let hdr = ObjectHeader::parse(&data, 0, 8, 8).unwrap();
@@ -666,11 +675,7 @@ mod tests {
 
     #[test]
     fn parse_v2_with_timestamps() {
-        let data = build_v2_header(
-            0x20,
-            &[(0x01, &[1], 0)],
-            Some((100, 200, 300, 400)),
-        );
+        let data = build_v2_header(0x20, &[(0x01, &[1], 0)], Some((100, 200, 300, 400)));
         let hdr = ObjectHeader::parse(&data, 0, 8, 8).unwrap();
         assert_eq!(hdr.access_time, Some(100));
         assert_eq!(hdr.modification_time, Some(200));
@@ -722,7 +727,7 @@ mod tests {
             0x00,
             &[
                 (0x00, &[0, 0, 0, 0], 0), // NIL
-                (0x01, &[42], 0),           // Dataspace
+                (0x01, &[42], 0),         // Dataspace
             ],
             None,
         );
@@ -781,8 +786,8 @@ mod tests {
         let header = build_v2_header(
             0x00,
             &[
-                (0x01, &[42], 0),       // Dataspace
-                (0x10, &cont_data, 0),   // Continuation
+                (0x01, &[42], 0),      // Dataspace
+                (0x10, &cont_data, 0), // Continuation
             ],
             None,
         );

--- a/src/object_header_writer.rs
+++ b/src/object_header_writer.rs
@@ -8,7 +8,7 @@ use crate::message_type::MessageType;
 
 /// Writer for v2 object headers with proper checksums.
 pub struct ObjectHeaderWriter {
-    messages: Vec<(MessageType, Vec<u8>, u8)>,  // (type, data, msg_flags)
+    messages: Vec<(MessageType, Vec<u8>, u8)>, // (type, data, msg_flags)
 }
 
 impl ObjectHeaderWriter {
@@ -32,7 +32,9 @@ impl ObjectHeaderWriter {
     /// Serialize the complete v2 object header (OHDR + messages + checksum).
     pub fn serialize(&self) -> Vec<u8> {
         // Calculate total message bytes: each message has type(1) + size(2) + flags(1) + data
-        let msg_bytes_total: usize = self.messages.iter()
+        let msg_bytes_total: usize = self
+            .messages
+            .iter()
             .map(|(_, data, _)| 4 + data.len())
             .sum();
 

--- a/src/parallel_read.rs
+++ b/src/parallel_read.rs
@@ -10,7 +10,7 @@
 use crate::chunked_read::ChunkInfo;
 use crate::error::FormatError;
 use crate::filter_pipeline::FilterPipeline;
-use crate::filters::{decompress_chunk, ChunkContext};
+use crate::filters::{ChunkContext, decompress_chunk};
 use crate::lane_partition::{self, LaneStats, PartitionStats};
 
 /// Threshold: only use parallel decompression when chunk count exceeds this.
@@ -90,7 +90,10 @@ pub fn decompress_chunks_lane_partitioned(
                 stats.compressed_bytes += size as u64;
                 stats.decompressed_bytes += decompressed.len() as u64;
 
-                results.push(DecompressedChunk { index, data: decompressed });
+                results.push(DecompressedChunk {
+                    index,
+                    data: decompressed,
+                });
             }
 
             Ok((results, stats))
@@ -153,7 +156,10 @@ pub fn decompress_chunks_parallel(
                 raw_chunk.to_vec()
             };
 
-            Ok(DecompressedChunk { index, data: decompressed })
+            Ok(DecompressedChunk {
+                index,
+                data: decompressed,
+            })
         })
         .collect();
 

--- a/src/provenance.rs
+++ b/src/provenance.rs
@@ -15,7 +15,7 @@ use crate::dataspace::Dataspace;
 use crate::datatype::Datatype;
 use crate::error::FormatError;
 use crate::object_header::ObjectHeader;
-use crate::type_builders::{build_attr_message, AttrValue};
+use crate::type_builders::{AttrValue, build_attr_message};
 
 // ---- Attribute name constants ----
 
@@ -99,12 +99,8 @@ pub fn verify_dataset(
     length_size: u8,
 ) -> Result<VerifyResult, FormatError> {
     // 1. Extract all attributes (compact + dense).
-    let attrs = crate::attribute::extract_attributes_full(
-        file_data,
-        header,
-        offset_size,
-        length_size,
-    )?;
+    let attrs =
+        crate::attribute::extract_attributes_full(file_data, header, offset_size, length_size)?;
 
     // 2. Find the stored hash.
     let stored_hash = attrs
@@ -229,21 +225,14 @@ mod tests {
         use crate::signature;
         use crate::superblock::Superblock;
 
-        let raw_data: Vec<u8> = (0..24u64)
-            .flat_map(|v| (v as f64).to_le_bytes())
-            .collect();
+        let raw_data: Vec<u8> = (0..24u64).flat_map(|v| (v as f64).to_le_bytes()).collect();
         let expected_hash = sha256_hex(&raw_data);
 
         let mut fw = FileWriter::new();
         let ds = fw.create_dataset("sensor");
-        ds.with_f64_data(
-            &(0..24).map(|v| v as f64).collect::<Vec<_>>(),
-        );
+        ds.with_f64_data(&(0..24).map(|v| v as f64).collect::<Vec<_>>());
         ds.set_attr(ATTR_SHA256, AttrValue::String(expected_hash.clone()));
-        ds.set_attr(
-            ATTR_CREATOR,
-            AttrValue::String("test-suite".into()),
-        );
+        ds.set_attr(ATTR_CREATOR, AttrValue::String("test-suite".into()));
         ds.set_attr(
             ATTR_TIMESTAMP,
             AttrValue::String("2026-02-19T12:00:00Z".into()),

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -17,7 +17,7 @@ use crate::object_header::ObjectHeader;
 use crate::signature;
 use crate::superblock::Superblock;
 
-use crate::types::{attrs_to_map, classify_datatype, AttrValue, DType};
+use crate::types::{AttrValue, DType, attrs_to_map, classify_datatype};
 
 // ---------------------------------------------------------------------------
 // File
@@ -384,12 +384,13 @@ impl<'f> Dataset<'f> {
         let ds = self.dataspace()?;
         let mut dl = self.data_layout()?;
         // Adjust contiguous data address by base_address offset
-        if self.file.addr_offset != 0 {
-            if let DataLayout::Contiguous { ref mut address, .. } = dl {
-                if let Some(addr) = address {
-                    *addr += self.file.addr_offset;
-                }
-            }
+        if self.file.addr_offset != 0
+            && let DataLayout::Contiguous {
+                ref mut address, ..
+            } = dl
+            && let Some(addr) = address
+        {
+            *addr += self.file.addr_offset;
         }
         let pipeline = self.filter_pipeline();
         Ok(data_read::read_raw_data_cached(
@@ -425,11 +426,9 @@ fn has_message(header: &ObjectHeader, msg_type: MessageType) -> bool {
 }
 
 fn is_group(header: &ObjectHeader) -> bool {
-    header
-        .messages
-        .iter()
-        .any(|m| m.msg_type == MessageType::LinkInfo
+    header.messages.iter().any(|m| {
+        m.msg_type == MessageType::LinkInfo
             || m.msg_type == MessageType::Link
-            || m.msg_type == MessageType::SymbolTable)
+            || m.msg_type == MessageType::SymbolTable
+    })
 }
-

--- a/src/shared_message.rs
+++ b/src/shared_message.rs
@@ -109,8 +109,14 @@ fn read_offset(data: &[u8], pos: usize, size: u8) -> Result<u64, FormatError> {
         2 => u16::from_le_bytes([data[pos], data[pos + 1]]) as u64,
         4 => u32::from_le_bytes([data[pos], data[pos + 1], data[pos + 2], data[pos + 3]]) as u64,
         8 => u64::from_le_bytes([
-            data[pos], data[pos + 1], data[pos + 2], data[pos + 3],
-            data[pos + 4], data[pos + 5], data[pos + 6], data[pos + 7],
+            data[pos],
+            data[pos + 1],
+            data[pos + 2],
+            data[pos + 3],
+            data[pos + 4],
+            data[pos + 5],
+            data[pos + 6],
+            data[pos + 7],
         ]),
         _ => return Err(FormatError::InvalidOffsetSize(size)),
     })
@@ -135,10 +141,7 @@ pub fn is_shared(msg_flags: u8) -> bool {
 ///
 /// When the shared flag is set on a message, the data contains a reference
 /// instead of the actual message content.
-pub fn parse_shared_ref(
-    data: &[u8],
-    offset_size: u8,
-) -> Result<SharedMessageRef, FormatError> {
+pub fn parse_shared_ref(data: &[u8], offset_size: u8) -> Result<SharedMessageRef, FormatError> {
     ensure_len(data, 0, 2)?;
     let version = data[0];
     let ref_type = data[1];
@@ -243,7 +246,10 @@ pub fn parse_sohm_table(
         let mesg_types = u16::from_le_bytes([file_data[pos], file_data[pos + 1]]);
         pos += 2;
         let min_mesg_size = u32::from_le_bytes([
-            file_data[pos], file_data[pos + 1], file_data[pos + 2], file_data[pos + 3],
+            file_data[pos],
+            file_data[pos + 1],
+            file_data[pos + 2],
+            file_data[pos + 3],
         ]);
         pos += 4;
         let list_max = u16::from_le_bytes([file_data[pos], file_data[pos + 1]]);
@@ -373,7 +379,10 @@ pub fn parse_sohm_btree_entries(
 /// Find the SOHM index that handles the given message type.
 fn find_index_for_msg_type(table: &SohmTable, msg_type: MessageType) -> Option<&SohmIndex> {
     let type_bit = 1u16 << msg_type.to_u16();
-    table.indexes.iter().find(|idx| idx.mesg_types & type_bit != 0)
+    table
+        .indexes
+        .iter()
+        .find(|idx| idx.mesg_types & type_bit != 0)
 }
 
 fn is_undefined(val: u64, offset_size: u8) -> bool {
@@ -397,16 +406,18 @@ pub fn resolve_sohm_message(
     offset_size: u8,
     length_size: u8,
 ) -> Result<Vec<u8>, FormatError> {
-    let index = find_index_for_msg_type(sohm_table, target_msg_type).ok_or(
-        FormatError::InvalidSharedMessageVersion(2),
-    )?;
+    let index = find_index_for_msg_type(sohm_table, target_msg_type)
+        .ok_or(FormatError::InvalidSharedMessageVersion(2))?;
 
     if is_undefined(index.heap_addr, offset_size) {
         return Err(FormatError::InvalidSharedMessageVersion(2));
     }
 
     let fh_header = FractalHeapHeader::parse(
-        file_data, index.heap_addr as usize, offset_size, length_size,
+        file_data,
+        index.heap_addr as usize,
+        offset_size,
+        length_size,
     )?;
     fh_header.read_managed_object(file_data, heap_id, offset_size)
 }
@@ -424,7 +435,12 @@ pub fn resolve_shared_message(
     length_size: u8,
 ) -> Result<Vec<u8>, FormatError> {
     resolve_shared_message_with_sohm(
-        file_data, shared_ref, target_msg_type, offset_size, length_size, None,
+        file_data,
+        shared_ref,
+        target_msg_type,
+        offset_size,
+        length_size,
+        None,
     )
 }
 
@@ -439,12 +455,12 @@ pub fn resolve_shared_message_with_sohm(
 ) -> Result<Vec<u8>, FormatError> {
     match shared_ref.ref_type {
         1 | 3 => {
-            let addr = shared_ref.object_header_address.ok_or(
-                FormatError::UnexpectedEof {
+            let addr = shared_ref
+                .object_header_address
+                .ok_or(FormatError::UnexpectedEof {
                     expected: 1,
                     available: 0,
-                }
-            )?;
+                })?;
             let target_header =
                 ObjectHeader::parse(file_data, addr as usize, offset_size, length_size)?;
             for msg in &target_header.messages {
@@ -472,19 +488,23 @@ pub fn resolve_shared_message_with_sohm(
             })
         }
         2 => {
-            let heap_id = shared_ref.heap_id.as_ref().ok_or(
-                FormatError::InvalidSharedMessageVersion(2),
-            )?;
-            let table = sohm_table.ok_or(
-                FormatError::InvalidSharedMessageVersion(2),
-            )?;
+            let heap_id = shared_ref
+                .heap_id
+                .as_ref()
+                .ok_or(FormatError::InvalidSharedMessageVersion(2))?;
+            let table = sohm_table.ok_or(FormatError::InvalidSharedMessageVersion(2))?;
             resolve_sohm_message(
-                file_data, heap_id, table, target_msg_type, offset_size, length_size,
+                file_data,
+                heap_id,
+                table,
+                target_msg_type,
+                offset_size,
+                length_size,
             )
         }
-        _ => {
-            Err(FormatError::InvalidSharedMessageVersion(shared_ref.ref_type))
-        }
+        _ => Err(FormatError::InvalidSharedMessageVersion(
+            shared_ref.ref_type,
+        )),
     }
 }
 
@@ -697,14 +717,24 @@ mod tests {
     fn parse_smtb_two_indexes_4byte() {
         let indexes = vec![
             SohmIndex {
-                index_type: 0, mesg_types: 0x0008, min_mesg_size: 50,
-                list_max: 50, btree_min: 40, num_messages: 1,
-                index_addr: 0x1000, heap_addr: 0x2000,
+                index_type: 0,
+                mesg_types: 0x0008,
+                min_mesg_size: 50,
+                list_max: 50,
+                btree_min: 40,
+                num_messages: 1,
+                index_addr: 0x1000,
+                heap_addr: 0x2000,
             },
             SohmIndex {
-                index_type: 1, mesg_types: 0x0002, min_mesg_size: 100,
-                list_max: 25, btree_min: 15, num_messages: 5,
-                index_addr: 0x5000, heap_addr: 0x6000,
+                index_type: 1,
+                mesg_types: 0x0002,
+                min_mesg_size: 100,
+                list_max: 25,
+                btree_min: 15,
+                num_messages: 5,
+                index_addr: 0x5000,
+                heap_addr: 0x6000,
             },
         ];
         let data = build_smtb(&indexes, 4);
@@ -798,14 +828,20 @@ mod tests {
     fn parse_smli_two_entries() {
         let entries = vec![
             SohmEntry {
-                location: 0, hash: 0x1111,
+                location: 0,
+                hash: 0x1111,
                 heap_id: Some([10, 20, 30, 40, 50, 60, 70, 80]),
-                ref_count: Some(1), mesg_index: None, oh_addr: None,
+                ref_count: Some(1),
+                mesg_index: None,
+                oh_addr: None,
             },
             SohmEntry {
-                location: 0, hash: 0x2222,
+                location: 0,
+                hash: 0x2222,
                 heap_id: Some([11, 21, 31, 41, 51, 61, 71, 81]),
-                ref_count: Some(2), mesg_index: None, oh_addr: None,
+                ref_count: Some(2),
+                mesg_index: None,
+                oh_addr: None,
             },
         ];
         let data = build_smli(&entries, 8);
@@ -829,14 +865,16 @@ mod tests {
     #[test]
     fn find_index_for_datatype() {
         let table = SohmTable {
-            indexes: vec![
-                SohmIndex {
-                    index_type: 0,
-                    mesg_types: 0x0008, // bit 3 = Datatype (0x0003)
-                    min_mesg_size: 50, list_max: 50, btree_min: 40,
-                    num_messages: 1, index_addr: 0x1000, heap_addr: 0x2000,
-                },
-            ],
+            indexes: vec![SohmIndex {
+                index_type: 0,
+                mesg_types: 0x0008, // bit 3 = Datatype (0x0003)
+                min_mesg_size: 50,
+                list_max: 50,
+                btree_min: 40,
+                num_messages: 1,
+                index_addr: 0x1000,
+                heap_addr: 0x2000,
+            }],
         };
         let idx = find_index_for_msg_type(&table, MessageType::Datatype);
         assert!(idx.is_some());
@@ -846,14 +884,16 @@ mod tests {
     #[test]
     fn find_index_no_match() {
         let table = SohmTable {
-            indexes: vec![
-                SohmIndex {
-                    index_type: 0,
-                    mesg_types: 0x0002, // bit 1 = Dataspace
-                    min_mesg_size: 50, list_max: 50, btree_min: 40,
-                    num_messages: 1, index_addr: 0x1000, heap_addr: 0x2000,
-                },
-            ],
+            indexes: vec![SohmIndex {
+                index_type: 0,
+                mesg_types: 0x0002, // bit 1 = Dataspace
+                min_mesg_size: 50,
+                list_max: 50,
+                btree_min: 40,
+                num_messages: 1,
+                index_addr: 0x1000,
+                heap_addr: 0x2000,
+            }],
         };
         let idx = find_index_for_msg_type(&table, MessageType::Datatype);
         assert!(idx.is_none());

--- a/src/type_builders.rs
+++ b/src/type_builders.rs
@@ -486,8 +486,7 @@ pub(crate) fn patch_vl_refs(raw_data: &mut [u8], collection_address: u64) {
     let count = raw_data.len() / vl_ref_size;
     for i in 0..count {
         let addr_offset = i * vl_ref_size + 4; // skip sequence_length
-        raw_data[addr_offset..addr_offset + 8]
-            .copy_from_slice(&collection_address.to_le_bytes());
+        raw_data[addr_offset..addr_offset + 8].copy_from_slice(&collection_address.to_le_bytes());
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -135,7 +135,10 @@ pub(crate) fn classify_datatype(dt: &crate::datatype::Datatype) -> DType {
             base_type,
             dimensions,
         } => DType::Array(Box::new(classify_datatype(base_type)), dimensions.clone()),
-        Datatype::Reference { ref_type: crate::datatype::ReferenceType::Object, .. } => DType::ObjectReference,
+        Datatype::Reference {
+            ref_type: crate::datatype::ReferenceType::Object,
+            ..
+        } => DType::ObjectReference,
         _ => DType::Other(format!("{dt:?}")),
     }
 }
@@ -155,7 +158,9 @@ pub(crate) fn attrs_to_map(
 ) -> HashMap<std::string::String, AttrValue> {
     let mut map = HashMap::new();
     for attr in attrs {
-        if let Some(val) = decode_attr_value(attr, file_data, offset_size, length_size, base_address) {
+        if let Some(val) =
+            decode_attr_value(attr, file_data, offset_size, length_size, base_address)
+        {
             map.insert(attr.name.clone(), val);
         }
     }
@@ -206,9 +211,11 @@ fn decode_attr_value(
                 Some(AttrValue::StringArray(strings))
             }
         }
-        Datatype::VariableLength { is_string, base_type, .. }
-            if *is_string || is_ascii_char_vlen_base(base_type) =>
-        {
+        Datatype::VariableLength {
+            is_string,
+            base_type,
+            ..
+        } if *is_string || is_ascii_char_vlen_base(base_type) => {
             // Two MATLAB-relevant encodings share the same on-disk byte
             // layout (length + heap ref + object index per element; heap
             // object holds raw bytes without terminator):
@@ -274,8 +281,14 @@ fn rebase_vl_refs(raw_data: &[u8], offset_size: u8, base_address: u64) -> Vec<u8
                 out[addr_start + 3],
             ]) as u64,
             8 => u64::from_le_bytes([
-                out[addr_start], out[addr_start + 1], out[addr_start + 2], out[addr_start + 3],
-                out[addr_start + 4], out[addr_start + 5], out[addr_start + 6], out[addr_start + 7],
+                out[addr_start],
+                out[addr_start + 1],
+                out[addr_start + 2],
+                out[addr_start + 3],
+                out[addr_start + 4],
+                out[addr_start + 5],
+                out[addr_start + 6],
+                out[addr_start + 7],
             ]),
             _ => return raw_data.to_vec(),
         };

--- a/src/vl_data.rs
+++ b/src/vl_data.rs
@@ -124,17 +124,14 @@ pub fn read_vl_strings(
             continue;
         }
 
-        let coll = GlobalHeapCollection::parse(
-            file_data,
-            vl.collection_address as usize,
-            length_size,
-        )?;
-        let obj = coll
-            .get_object(vl.object_index as u16)
-            .ok_or(FormatError::GlobalHeapObjectNotFound {
+        let coll =
+            GlobalHeapCollection::parse(file_data, vl.collection_address as usize, length_size)?;
+        let obj = coll.get_object(vl.object_index as u16).ok_or(
+            FormatError::GlobalHeapObjectNotFound {
                 collection_address: vl.collection_address,
                 index: vl.object_index as u16,
-            })?;
+            },
+        )?;
 
         // The object data is the raw string bytes
         let len = (vl.length as usize).min(obj.data.len());
@@ -157,22 +154,22 @@ pub fn read_vl_bytes(
     let mut result = Vec::with_capacity(refs.len());
 
     for vl in &refs {
-        if vl.length == 0 && (is_undefined_address(vl.collection_address, offset_size) || vl.collection_address == 0) {
+        if vl.length == 0
+            && (is_undefined_address(vl.collection_address, offset_size)
+                || vl.collection_address == 0)
+        {
             result.push(Vec::new());
             continue;
         }
 
-        let coll = GlobalHeapCollection::parse(
-            file_data,
-            vl.collection_address as usize,
-            length_size,
-        )?;
-        let obj = coll
-            .get_object(vl.object_index as u16)
-            .ok_or(FormatError::GlobalHeapObjectNotFound {
+        let coll =
+            GlobalHeapCollection::parse(file_data, vl.collection_address as usize, length_size)?;
+        let obj = coll.get_object(vl.object_index as u16).ok_or(
+            FormatError::GlobalHeapObjectNotFound {
                 collection_address: vl.collection_address,
                 index: vl.object_index as u16,
-            })?;
+            },
+        )?;
 
         let len = (vl.length as usize).min(obj.data.len());
         result.push(obj.data[..len].to_vec());
@@ -267,10 +264,7 @@ mod tests {
     fn read_vl_strings_from_heap() {
         let gcol_offset = 256usize;
         let mut file_data = vec![0u8; 512];
-        build_gcol_at(&mut file_data, gcol_offset, &[
-            (1, b"Alice"),
-            (2, b"Bob"),
-        ]);
+        build_gcol_at(&mut file_data, gcol_offset, &[(1, b"Alice"), (2, b"Bob")]);
 
         let raw = build_vl_refs(&["Alice", "Bob"], gcol_offset as u64, 1, 8);
         let strings = read_vl_strings(&file_data, &raw, 2, 8, 8).unwrap();
@@ -306,10 +300,11 @@ mod tests {
     fn read_vl_bytes_from_heap() {
         let gcol_offset = 128usize;
         let mut file_data = vec![0u8; 512];
-        build_gcol_at(&mut file_data, gcol_offset, &[
-            (1, &[0xDE, 0xAD]),
-            (2, &[0xBE, 0xEF, 0xCA]),
-        ]);
+        build_gcol_at(
+            &mut file_data,
+            gcol_offset,
+            &[(1, &[0xDE, 0xAD]), (2, &[0xBE, 0xEF, 0xCA])],
+        );
 
         let _raw = build_vl_refs(&["ab", "abc"], gcol_offset as u64, 1, 8);
         // Fix lengths to match actual byte lengths

--- a/src/zfp.rs
+++ b/src/zfp.rs
@@ -524,13 +524,24 @@ macro_rules! impl_lift {
             let mut y = p[1];
             let mut z = p[2];
             let mut w = p[3];
-            x = x.wrapping_add(w); x >>= 1; w = w.wrapping_sub(x);
-            z = z.wrapping_add(y); z >>= 1; y = y.wrapping_sub(z);
-            x = x.wrapping_add(z); x >>= 1; z = z.wrapping_sub(x);
-            w = w.wrapping_add(y); w >>= 1; y = y.wrapping_sub(w);
+            x = x.wrapping_add(w);
+            x >>= 1;
+            w = w.wrapping_sub(x);
+            z = z.wrapping_add(y);
+            z >>= 1;
+            y = y.wrapping_sub(z);
+            x = x.wrapping_add(z);
+            x >>= 1;
+            z = z.wrapping_sub(x);
+            w = w.wrapping_add(y);
+            w >>= 1;
+            y = y.wrapping_sub(w);
             w = w.wrapping_add(y >> 1);
             y = y.wrapping_sub(w >> 1);
-            p[0] = x; p[1] = y; p[2] = z; p[3] = w;
+            p[0] = x;
+            p[1] = y;
+            p[2] = z;
+            p[3] = w;
         }
         #[allow(clippy::many_single_char_names)]
         fn $inv(p: &mut [$int; BLOCK_SIZE]) {
@@ -540,11 +551,22 @@ macro_rules! impl_lift {
             let mut w = p[3];
             y = y.wrapping_add(w >> 1);
             w = w.wrapping_sub(y >> 1);
-            y = y.wrapping_add(w); w <<= 1; w = w.wrapping_sub(y);
-            z = z.wrapping_add(x); x <<= 1; x = x.wrapping_sub(z);
-            y = y.wrapping_add(z); z <<= 1; z = z.wrapping_sub(y);
-            w = w.wrapping_add(x); x <<= 1; x = x.wrapping_sub(w);
-            p[0] = x; p[1] = y; p[2] = z; p[3] = w;
+            y = y.wrapping_add(w);
+            w <<= 1;
+            w = w.wrapping_sub(y);
+            z = z.wrapping_add(x);
+            x <<= 1;
+            x = x.wrapping_sub(z);
+            y = y.wrapping_add(z);
+            z <<= 1;
+            z = z.wrapping_sub(y);
+            w = w.wrapping_add(x);
+            x <<= 1;
+            x = x.wrapping_sub(w);
+            p[0] = x;
+            p[1] = y;
+            p[2] = z;
+            p[3] = w;
         }
     };
 }
@@ -619,67 +641,141 @@ macro_rules! impl_nd_xform {
     ($fwd2:ident, $inv2:ident, $fwd3:ident, $inv3:ident, $fwd4:ident, $inv4:ident,
      $fwd_axis:ident, $inv_axis:ident, $int:ty) => {
         fn $fwd2(block: &mut [$int; 16]) {
-            for y in 0..4 { $fwd_axis(block.as_mut_slice(), 4 * y, 1); }
-            for x in 0..4 { $fwd_axis(block.as_mut_slice(), x, 4); }
+            for y in 0..4 {
+                $fwd_axis(block.as_mut_slice(), 4 * y, 1);
+            }
+            for x in 0..4 {
+                $fwd_axis(block.as_mut_slice(), x, 4);
+            }
         }
         fn $inv2(block: &mut [$int; 16]) {
-            for x in 0..4 { $inv_axis(block.as_mut_slice(), x, 4); }
-            for y in 0..4 { $inv_axis(block.as_mut_slice(), 4 * y, 1); }
+            for x in 0..4 {
+                $inv_axis(block.as_mut_slice(), x, 4);
+            }
+            for y in 0..4 {
+                $inv_axis(block.as_mut_slice(), 4 * y, 1);
+            }
         }
 
         fn $fwd3(block: &mut [$int; 64]) {
-            for z in 0..4 { for y in 0..4 { $fwd_axis(block.as_mut_slice(), 16 * z + 4 * y, 1); } }
-            for z in 0..4 { for x in 0..4 { $fwd_axis(block.as_mut_slice(), 16 * z + x, 4); } }
-            for y in 0..4 { for x in 0..4 { $fwd_axis(block.as_mut_slice(), 4 * y + x, 16); } }
+            for z in 0..4 {
+                for y in 0..4 {
+                    $fwd_axis(block.as_mut_slice(), 16 * z + 4 * y, 1);
+                }
+            }
+            for z in 0..4 {
+                for x in 0..4 {
+                    $fwd_axis(block.as_mut_slice(), 16 * z + x, 4);
+                }
+            }
+            for y in 0..4 {
+                for x in 0..4 {
+                    $fwd_axis(block.as_mut_slice(), 4 * y + x, 16);
+                }
+            }
         }
         fn $inv3(block: &mut [$int; 64]) {
-            for y in 0..4 { for x in 0..4 { $inv_axis(block.as_mut_slice(), 4 * y + x, 16); } }
-            for z in 0..4 { for x in 0..4 { $inv_axis(block.as_mut_slice(), 16 * z + x, 4); } }
-            for z in 0..4 { for y in 0..4 { $inv_axis(block.as_mut_slice(), 16 * z + 4 * y, 1); } }
+            for y in 0..4 {
+                for x in 0..4 {
+                    $inv_axis(block.as_mut_slice(), 4 * y + x, 16);
+                }
+            }
+            for z in 0..4 {
+                for x in 0..4 {
+                    $inv_axis(block.as_mut_slice(), 16 * z + x, 4);
+                }
+            }
+            for z in 0..4 {
+                for y in 0..4 {
+                    $inv_axis(block.as_mut_slice(), 16 * z + 4 * y, 1);
+                }
+            }
         }
 
         fn $fwd4(block: &mut [$int; 256]) {
-            for w in 0..4 { for z in 0..4 { for y in 0..4 {
-                $fwd_axis(block.as_mut_slice(), 64 * w + 16 * z + 4 * y, 1);
-            } } }
-            for w in 0..4 { for z in 0..4 { for x in 0..4 {
-                $fwd_axis(block.as_mut_slice(), 64 * w + 16 * z + x, 4);
-            } } }
-            for w in 0..4 { for y in 0..4 { for x in 0..4 {
-                $fwd_axis(block.as_mut_slice(), 64 * w + 4 * y + x, 16);
-            } } }
-            for z in 0..4 { for y in 0..4 { for x in 0..4 {
-                $fwd_axis(block.as_mut_slice(), 16 * z + 4 * y + x, 64);
-            } } }
+            for w in 0..4 {
+                for z in 0..4 {
+                    for y in 0..4 {
+                        $fwd_axis(block.as_mut_slice(), 64 * w + 16 * z + 4 * y, 1);
+                    }
+                }
+            }
+            for w in 0..4 {
+                for z in 0..4 {
+                    for x in 0..4 {
+                        $fwd_axis(block.as_mut_slice(), 64 * w + 16 * z + x, 4);
+                    }
+                }
+            }
+            for w in 0..4 {
+                for y in 0..4 {
+                    for x in 0..4 {
+                        $fwd_axis(block.as_mut_slice(), 64 * w + 4 * y + x, 16);
+                    }
+                }
+            }
+            for z in 0..4 {
+                for y in 0..4 {
+                    for x in 0..4 {
+                        $fwd_axis(block.as_mut_slice(), 16 * z + 4 * y + x, 64);
+                    }
+                }
+            }
         }
         fn $inv4(block: &mut [$int; 256]) {
-            for z in 0..4 { for y in 0..4 { for x in 0..4 {
-                $inv_axis(block.as_mut_slice(), 16 * z + 4 * y + x, 64);
-            } } }
-            for w in 0..4 { for y in 0..4 { for x in 0..4 {
-                $inv_axis(block.as_mut_slice(), 64 * w + 4 * y + x, 16);
-            } } }
-            for w in 0..4 { for z in 0..4 { for x in 0..4 {
-                $inv_axis(block.as_mut_slice(), 64 * w + 16 * z + x, 4);
-            } } }
-            for w in 0..4 { for z in 0..4 { for y in 0..4 {
-                $inv_axis(block.as_mut_slice(), 64 * w + 16 * z + 4 * y, 1);
-            } } }
+            for z in 0..4 {
+                for y in 0..4 {
+                    for x in 0..4 {
+                        $inv_axis(block.as_mut_slice(), 16 * z + 4 * y + x, 64);
+                    }
+                }
+            }
+            for w in 0..4 {
+                for y in 0..4 {
+                    for x in 0..4 {
+                        $inv_axis(block.as_mut_slice(), 64 * w + 4 * y + x, 16);
+                    }
+                }
+            }
+            for w in 0..4 {
+                for z in 0..4 {
+                    for x in 0..4 {
+                        $inv_axis(block.as_mut_slice(), 64 * w + 16 * z + x, 4);
+                    }
+                }
+            }
+            for w in 0..4 {
+                for z in 0..4 {
+                    for y in 0..4 {
+                        $inv_axis(block.as_mut_slice(), 64 * w + 16 * z + 4 * y, 1);
+                    }
+                }
+            }
         }
     };
 }
 
 impl_nd_xform!(
-    fwd_xform_i32_2d, inv_xform_i32_2d,
-    fwd_xform_i32_3d, inv_xform_i32_3d,
-    fwd_xform_i32_4d, inv_xform_i32_4d,
-    fwd_lift_axis_i32, inv_lift_axis_i32, i32
+    fwd_xform_i32_2d,
+    inv_xform_i32_2d,
+    fwd_xform_i32_3d,
+    inv_xform_i32_3d,
+    fwd_xform_i32_4d,
+    inv_xform_i32_4d,
+    fwd_lift_axis_i32,
+    inv_lift_axis_i32,
+    i32
 );
 impl_nd_xform!(
-    fwd_xform_i64_2d, inv_xform_i64_2d,
-    fwd_xform_i64_3d, inv_xform_i64_3d,
-    fwd_xform_i64_4d, inv_xform_i64_4d,
-    fwd_lift_axis_i64, inv_lift_axis_i64, i64
+    fwd_xform_i64_2d,
+    inv_xform_i64_2d,
+    fwd_xform_i64_3d,
+    inv_xform_i64_3d,
+    fwd_xform_i64_4d,
+    inv_xform_i64_4d,
+    fwd_lift_axis_i64,
+    inv_lift_axis_i64,
+    i64
 );
 
 // ---------------------------------------------------------------------------
@@ -688,34 +784,28 @@ impl_nd_xform!(
 // Ordered by polynomial degree / frequency (low-frequency first).
 // ---------------------------------------------------------------------------
 
-const PERM_2: [u8; 16] = [
-    0, 1, 4, 5, 2, 8, 6, 9, 3, 12, 10, 7, 13, 11, 14, 15,
-];
+const PERM_2: [u8; 16] = [0, 1, 4, 5, 2, 8, 6, 9, 3, 12, 10, 7, 13, 11, 14, 15];
 
 const PERM_3: [u8; 64] = [
-    0, 1, 4, 16, 20, 17, 5, 2, 8, 32, 21, 6, 18, 24, 9, 33,
-    36, 3, 12, 48, 22, 25, 37, 40, 34, 10, 7, 19, 28, 13, 49, 52,
-    41, 38, 26, 23, 29, 53, 11, 35, 44, 14, 50, 56, 42, 27, 39, 45,
-    30, 54, 57, 60, 51, 15, 43, 46, 58, 61, 55, 31, 62, 59, 47, 63,
+    0, 1, 4, 16, 20, 17, 5, 2, 8, 32, 21, 6, 18, 24, 9, 33, 36, 3, 12, 48, 22, 25, 37, 40, 34, 10,
+    7, 19, 28, 13, 49, 52, 41, 38, 26, 23, 29, 53, 11, 35, 44, 14, 50, 56, 42, 27, 39, 45, 30, 54,
+    57, 60, 51, 15, 43, 46, 58, 61, 55, 31, 62, 59, 47, 63,
 ];
 
 const PERM_4: [u8; 256] = [
-    0, 1, 4, 16, 64, 5, 80, 17, 68, 65, 20, 2, 8, 32, 128, 84,
-    81, 69, 21, 6, 18, 66, 24, 72, 9, 96, 33, 36, 129, 132, 144, 3,
-    12, 48, 192, 85, 82, 70, 22, 73, 25, 88, 37, 100, 97, 148, 145, 133,
-    10, 160, 34, 136, 130, 40, 7, 19, 67, 28, 76, 13, 112, 49, 52, 193,
-    196, 208, 86, 89, 101, 149, 161, 137, 41, 134, 38, 164, 26, 152, 146, 104,
-    98, 74, 83, 71, 23, 77, 29, 92, 53, 116, 113, 212, 209, 197, 11, 35,
-    131, 44, 140, 14, 176, 50, 56, 194, 200, 224, 90, 165, 102, 153, 150, 105,
-    168, 162, 138, 42, 87, 93, 117, 213, 27, 75, 99, 39, 135, 147, 108, 45,
-    141, 156, 30, 78, 177, 180, 54, 114, 120, 57, 198, 210, 216, 201, 225, 228,
-    15, 240, 51, 204, 195, 60, 169, 166, 154, 106, 91, 103, 151, 109, 157, 94,
-    181, 118, 121, 214, 217, 229, 163, 139, 43, 142, 46, 172, 58, 184, 178, 232,
-    226, 202, 241, 205, 61, 199, 55, 244, 31, 220, 211, 124, 115, 79, 170, 167,
-    155, 107, 158, 110, 173, 122, 185, 182, 233, 230, 218, 95, 245, 119, 221, 215,
-    125, 242, 206, 62, 203, 59, 248, 47, 236, 227, 188, 179, 143, 171, 174, 186,
-    234, 246, 222, 126, 219, 123, 249, 111, 237, 231, 189, 183, 159, 252, 243, 207,
-    63, 175, 250, 187, 238, 235, 190, 253, 247, 223, 127, 254, 251, 239, 191, 255,
+    0, 1, 4, 16, 64, 5, 80, 17, 68, 65, 20, 2, 8, 32, 128, 84, 81, 69, 21, 6, 18, 66, 24, 72, 9,
+    96, 33, 36, 129, 132, 144, 3, 12, 48, 192, 85, 82, 70, 22, 73, 25, 88, 37, 100, 97, 148, 145,
+    133, 10, 160, 34, 136, 130, 40, 7, 19, 67, 28, 76, 13, 112, 49, 52, 193, 196, 208, 86, 89, 101,
+    149, 161, 137, 41, 134, 38, 164, 26, 152, 146, 104, 98, 74, 83, 71, 23, 77, 29, 92, 53, 116,
+    113, 212, 209, 197, 11, 35, 131, 44, 140, 14, 176, 50, 56, 194, 200, 224, 90, 165, 102, 153,
+    150, 105, 168, 162, 138, 42, 87, 93, 117, 213, 27, 75, 99, 39, 135, 147, 108, 45, 141, 156, 30,
+    78, 177, 180, 54, 114, 120, 57, 198, 210, 216, 201, 225, 228, 15, 240, 51, 204, 195, 60, 169,
+    166, 154, 106, 91, 103, 151, 109, 157, 94, 181, 118, 121, 214, 217, 229, 163, 139, 43, 142, 46,
+    172, 58, 184, 178, 232, 226, 202, 241, 205, 61, 199, 55, 244, 31, 220, 211, 124, 115, 79, 170,
+    167, 155, 107, 158, 110, 173, 122, 185, 182, 233, 230, 218, 95, 245, 119, 221, 215, 125, 242,
+    206, 62, 203, 59, 248, 47, 236, 227, 188, 179, 143, 171, 174, 186, 234, 246, 222, 126, 219,
+    123, 249, 111, 237, 231, 189, 183, 159, 252, 243, 207, 63, 175, 250, 187, 238, 235, 190, 253,
+    247, 223, 127, 254, 251, 239, 191, 255,
 ];
 
 // ---------------------------------------------------------------------------
@@ -1134,10 +1224,7 @@ macro_rules! impl_int_block_codec {
             let used = w.position() - start;
             pad_bits(w, maxbits.saturating_sub(used));
         }
-        fn $dec(
-            r: &mut BitReader<'_>,
-            maxbits: usize,
-        ) -> Result<[$int; BLOCK_SIZE], FormatError> {
+        fn $dec(r: &mut BitReader<'_>, maxbits: usize) -> Result<[$int; BLOCK_SIZE], FormatError> {
             let mut ucoeffs = [0 as $uint; BLOCK_SIZE];
             let bits_consumed = $dec_ints(r, maxbits, $intprec, &mut ucoeffs, BLOCK_SIZE);
             skip_bits(r, maxbits.saturating_sub(bits_consumed));
@@ -1152,14 +1239,30 @@ macro_rules! impl_int_block_codec {
 }
 
 impl_int_block_codec!(
-    encode_block_i32, decode_block_i32,
-    i32, u32, fwd_lift_i32, inv_lift_i32, int2uint_i32, uint2int_i32,
-    encode_few_ints_u32, decode_few_ints_u32, 32u32
+    encode_block_i32,
+    decode_block_i32,
+    i32,
+    u32,
+    fwd_lift_i32,
+    inv_lift_i32,
+    int2uint_i32,
+    uint2int_i32,
+    encode_few_ints_u32,
+    decode_few_ints_u32,
+    32u32
 );
 impl_int_block_codec!(
-    encode_block_i64, decode_block_i64,
-    i64, u64, fwd_lift_i64, inv_lift_i64, int2uint_i64, uint2int_i64,
-    encode_few_ints_u64, decode_few_ints_u64, 64u32
+    encode_block_i64,
+    decode_block_i64,
+    i64,
+    u64,
+    fwd_lift_i64,
+    inv_lift_i64,
+    int2uint_i64,
+    uint2int_i64,
+    encode_few_ints_u64,
+    decode_few_ints_u64,
+    64u32
 );
 
 // ---------------------------------------------------------------------------
@@ -1199,10 +1302,7 @@ macro_rules! impl_float_block_nd {
             pad_bits(w, maxbits.saturating_sub(used));
         }
 
-        fn $dec(
-            r: &mut BitReader<'_>,
-            maxbits: usize,
-        ) -> Result<[$scalar; $bs], FormatError> {
+        fn $dec(r: &mut BitReader<'_>, maxbits: usize) -> Result<[$scalar; $bs], FormatError> {
             let nonempty = r.read_bit();
             if !nonempty {
                 let remaining = maxbits.saturating_sub(1);
@@ -1245,10 +1345,7 @@ macro_rules! impl_int_block_nd {
             let used = w.position() - start;
             pad_bits(w, maxbits.saturating_sub(used));
         }
-        fn $dec(
-            r: &mut BitReader<'_>,
-            maxbits: usize,
-        ) -> Result<[$int; $bs], FormatError> {
+        fn $dec(r: &mut BitReader<'_>, maxbits: usize) -> Result<[$int; $bs], FormatError> {
             let mut ucoeffs = [0 as $uint; $bs];
             let bits_consumed = $dec_ints(r, maxbits, $intprec, &mut ucoeffs, $bs);
             skip_bits(r, maxbits.saturating_sub(bits_consumed));
@@ -1264,74 +1361,230 @@ macro_rules! impl_int_block_nd {
 
 // 2D block codec (16 coefs).
 impl_float_block_nd!(
-    encode_block_f32_2d, decode_block_f32_2d, 16, f32, i32, u32, 0.0f32,
-    fwd_cast_f32_slice, inv_cast_f32_slice, fwd_xform_i32_2d, inv_xform_i32_2d,
-    int2uint_i32, uint2int_i32, PERM_2,
-    encode_few_ints_u32, decode_few_ints_u32, 32u32, EBITS_F32, u32
+    encode_block_f32_2d,
+    decode_block_f32_2d,
+    16,
+    f32,
+    i32,
+    u32,
+    0.0f32,
+    fwd_cast_f32_slice,
+    inv_cast_f32_slice,
+    fwd_xform_i32_2d,
+    inv_xform_i32_2d,
+    int2uint_i32,
+    uint2int_i32,
+    PERM_2,
+    encode_few_ints_u32,
+    decode_few_ints_u32,
+    32u32,
+    EBITS_F32,
+    u32
 );
 impl_float_block_nd!(
-    encode_block_f64_2d, decode_block_f64_2d, 16, f64, i64, u64, 0.0f64,
-    fwd_cast_f64_slice, inv_cast_f64_slice, fwd_xform_i64_2d, inv_xform_i64_2d,
-    int2uint_i64, uint2int_i64, PERM_2,
-    encode_few_ints_u64, decode_few_ints_u64, 64u32, EBITS_F64, u64
+    encode_block_f64_2d,
+    decode_block_f64_2d,
+    16,
+    f64,
+    i64,
+    u64,
+    0.0f64,
+    fwd_cast_f64_slice,
+    inv_cast_f64_slice,
+    fwd_xform_i64_2d,
+    inv_xform_i64_2d,
+    int2uint_i64,
+    uint2int_i64,
+    PERM_2,
+    encode_few_ints_u64,
+    decode_few_ints_u64,
+    64u32,
+    EBITS_F64,
+    u64
 );
 impl_int_block_nd!(
-    encode_block_i32_2d, decode_block_i32_2d, 16, i32, u32, 0i32,
-    fwd_xform_i32_2d, inv_xform_i32_2d, int2uint_i32, uint2int_i32, PERM_2,
-    encode_few_ints_u32, decode_few_ints_u32, 32u32
+    encode_block_i32_2d,
+    decode_block_i32_2d,
+    16,
+    i32,
+    u32,
+    0i32,
+    fwd_xform_i32_2d,
+    inv_xform_i32_2d,
+    int2uint_i32,
+    uint2int_i32,
+    PERM_2,
+    encode_few_ints_u32,
+    decode_few_ints_u32,
+    32u32
 );
 impl_int_block_nd!(
-    encode_block_i64_2d, decode_block_i64_2d, 16, i64, u64, 0i64,
-    fwd_xform_i64_2d, inv_xform_i64_2d, int2uint_i64, uint2int_i64, PERM_2,
-    encode_few_ints_u64, decode_few_ints_u64, 64u32
+    encode_block_i64_2d,
+    decode_block_i64_2d,
+    16,
+    i64,
+    u64,
+    0i64,
+    fwd_xform_i64_2d,
+    inv_xform_i64_2d,
+    int2uint_i64,
+    uint2int_i64,
+    PERM_2,
+    encode_few_ints_u64,
+    decode_few_ints_u64,
+    64u32
 );
 
 // 3D block codec (64 coefs).
 impl_float_block_nd!(
-    encode_block_f32_3d, decode_block_f32_3d, 64, f32, i32, u32, 0.0f32,
-    fwd_cast_f32_slice, inv_cast_f32_slice, fwd_xform_i32_3d, inv_xform_i32_3d,
-    int2uint_i32, uint2int_i32, PERM_3,
-    encode_few_ints_u32, decode_few_ints_u32, 32u32, EBITS_F32, u32
+    encode_block_f32_3d,
+    decode_block_f32_3d,
+    64,
+    f32,
+    i32,
+    u32,
+    0.0f32,
+    fwd_cast_f32_slice,
+    inv_cast_f32_slice,
+    fwd_xform_i32_3d,
+    inv_xform_i32_3d,
+    int2uint_i32,
+    uint2int_i32,
+    PERM_3,
+    encode_few_ints_u32,
+    decode_few_ints_u32,
+    32u32,
+    EBITS_F32,
+    u32
 );
 impl_float_block_nd!(
-    encode_block_f64_3d, decode_block_f64_3d, 64, f64, i64, u64, 0.0f64,
-    fwd_cast_f64_slice, inv_cast_f64_slice, fwd_xform_i64_3d, inv_xform_i64_3d,
-    int2uint_i64, uint2int_i64, PERM_3,
-    encode_few_ints_u64, decode_few_ints_u64, 64u32, EBITS_F64, u64
+    encode_block_f64_3d,
+    decode_block_f64_3d,
+    64,
+    f64,
+    i64,
+    u64,
+    0.0f64,
+    fwd_cast_f64_slice,
+    inv_cast_f64_slice,
+    fwd_xform_i64_3d,
+    inv_xform_i64_3d,
+    int2uint_i64,
+    uint2int_i64,
+    PERM_3,
+    encode_few_ints_u64,
+    decode_few_ints_u64,
+    64u32,
+    EBITS_F64,
+    u64
 );
 impl_int_block_nd!(
-    encode_block_i32_3d, decode_block_i32_3d, 64, i32, u32, 0i32,
-    fwd_xform_i32_3d, inv_xform_i32_3d, int2uint_i32, uint2int_i32, PERM_3,
-    encode_few_ints_u32, decode_few_ints_u32, 32u32
+    encode_block_i32_3d,
+    decode_block_i32_3d,
+    64,
+    i32,
+    u32,
+    0i32,
+    fwd_xform_i32_3d,
+    inv_xform_i32_3d,
+    int2uint_i32,
+    uint2int_i32,
+    PERM_3,
+    encode_few_ints_u32,
+    decode_few_ints_u32,
+    32u32
 );
 impl_int_block_nd!(
-    encode_block_i64_3d, decode_block_i64_3d, 64, i64, u64, 0i64,
-    fwd_xform_i64_3d, inv_xform_i64_3d, int2uint_i64, uint2int_i64, PERM_3,
-    encode_few_ints_u64, decode_few_ints_u64, 64u32
+    encode_block_i64_3d,
+    decode_block_i64_3d,
+    64,
+    i64,
+    u64,
+    0i64,
+    fwd_xform_i64_3d,
+    inv_xform_i64_3d,
+    int2uint_i64,
+    uint2int_i64,
+    PERM_3,
+    encode_few_ints_u64,
+    decode_few_ints_u64,
+    64u32
 );
 
 // 4D block codec (256 coefs) — uses `encode_many_ints` / `decode_many_ints`.
 impl_float_block_nd!(
-    encode_block_f32_4d, decode_block_f32_4d, 256, f32, i32, u32, 0.0f32,
-    fwd_cast_f32_slice, inv_cast_f32_slice, fwd_xform_i32_4d, inv_xform_i32_4d,
-    int2uint_i32, uint2int_i32, PERM_4,
-    encode_many_ints_u32, decode_many_ints_u32, 32u32, EBITS_F32, u32
+    encode_block_f32_4d,
+    decode_block_f32_4d,
+    256,
+    f32,
+    i32,
+    u32,
+    0.0f32,
+    fwd_cast_f32_slice,
+    inv_cast_f32_slice,
+    fwd_xform_i32_4d,
+    inv_xform_i32_4d,
+    int2uint_i32,
+    uint2int_i32,
+    PERM_4,
+    encode_many_ints_u32,
+    decode_many_ints_u32,
+    32u32,
+    EBITS_F32,
+    u32
 );
 impl_float_block_nd!(
-    encode_block_f64_4d, decode_block_f64_4d, 256, f64, i64, u64, 0.0f64,
-    fwd_cast_f64_slice, inv_cast_f64_slice, fwd_xform_i64_4d, inv_xform_i64_4d,
-    int2uint_i64, uint2int_i64, PERM_4,
-    encode_many_ints_u64, decode_many_ints_u64, 64u32, EBITS_F64, u64
+    encode_block_f64_4d,
+    decode_block_f64_4d,
+    256,
+    f64,
+    i64,
+    u64,
+    0.0f64,
+    fwd_cast_f64_slice,
+    inv_cast_f64_slice,
+    fwd_xform_i64_4d,
+    inv_xform_i64_4d,
+    int2uint_i64,
+    uint2int_i64,
+    PERM_4,
+    encode_many_ints_u64,
+    decode_many_ints_u64,
+    64u32,
+    EBITS_F64,
+    u64
 );
 impl_int_block_nd!(
-    encode_block_i32_4d, decode_block_i32_4d, 256, i32, u32, 0i32,
-    fwd_xform_i32_4d, inv_xform_i32_4d, int2uint_i32, uint2int_i32, PERM_4,
-    encode_many_ints_u32, decode_many_ints_u32, 32u32
+    encode_block_i32_4d,
+    decode_block_i32_4d,
+    256,
+    i32,
+    u32,
+    0i32,
+    fwd_xform_i32_4d,
+    inv_xform_i32_4d,
+    int2uint_i32,
+    uint2int_i32,
+    PERM_4,
+    encode_many_ints_u32,
+    decode_many_ints_u32,
+    32u32
 );
 impl_int_block_nd!(
-    encode_block_i64_4d, decode_block_i64_4d, 256, i64, u64, 0i64,
-    fwd_xform_i64_4d, inv_xform_i64_4d, int2uint_i64, uint2int_i64, PERM_4,
-    encode_many_ints_u64, decode_many_ints_u64, 64u32
+    encode_block_i64_4d,
+    decode_block_i64_4d,
+    256,
+    i64,
+    u64,
+    0i64,
+    fwd_xform_i64_4d,
+    inv_xform_i64_4d,
+    int2uint_i64,
+    uint2int_i64,
+    PERM_4,
+    encode_many_ints_u64,
+    decode_many_ints_u64,
+    64u32
 );
 
 /// Write `n` zero bits.
@@ -1417,9 +1670,7 @@ macro_rules! impl_codec {
                 rate: f64,
             ) -> Result<Vec<u8>, FormatError> {
                 if !matches!(dims.len(), 1..=4) {
-                    return Err(FormatError::FilterError(
-                        "ZFP: only 1D-4D supported".into(),
-                    ));
+                    return Err(FormatError::FilterError("ZFP: only 1D-4D supported".into()));
                 }
                 validate_rate(rate)?;
                 let expected = dims.iter().product::<usize>() * $esz;
@@ -1445,9 +1696,7 @@ macro_rules! impl_codec {
                 rate: f64,
             ) -> Result<Vec<u8>, FormatError> {
                 if !matches!(dims.len(), 1..=4) {
-                    return Err(FormatError::FilterError(
-                        "ZFP: only 1D-4D supported".into(),
-                    ));
+                    return Err(FormatError::FilterError("ZFP: only 1D-4D supported".into()));
                 }
                 validate_rate(rate)?;
                 match dims.len() {
@@ -1602,14 +1851,11 @@ macro_rules! impl_codec {
                                 // that the partial path emits per block.
                                 for z in 0..4 {
                                     for y in 0..4 {
-                                        let row_off =
-                                            (((z0 + z) * n1 + (y0 + y)) * n0 + x0) * $esz;
+                                        let row_off = (((z0 + z) * n1 + (y0 + y)) * n0 + x0) * $esz;
                                         let row = &data[row_off..row_off + 4 * $esz];
                                         for x in 0..4 {
-                                            let buf: [u8; $esz] = row
-                                                [x * $esz..(x + 1) * $esz]
-                                                .try_into()
-                                                .unwrap();
+                                            let buf: [u8; $esz] =
+                                                row[x * $esz..(x + 1) * $esz].try_into().unwrap();
                                             block[16 * z + 4 * y + x] = $from_le(buf);
                                         }
                                     }
@@ -1619,14 +1865,11 @@ macro_rules! impl_codec {
                                 // pad the rest along each axis.
                                 for z in 0..rz {
                                     for y in 0..ry {
-                                        let row_off =
-                                            (((z0 + z) * n1 + (y0 + y)) * n0 + x0) * $esz;
+                                        let row_off = (((z0 + z) * n1 + (y0 + y)) * n0 + x0) * $esz;
                                         let row = &data[row_off..row_off + rx * $esz];
                                         for x in 0..rx {
-                                            let buf: [u8; $esz] = row
-                                                [x * $esz..(x + 1) * $esz]
-                                                .try_into()
-                                                .unwrap();
+                                            let buf: [u8; $esz] =
+                                                row[x * $esz..(x + 1) * $esz].try_into().unwrap();
                                             block[16 * z + 4 * y + x] = $from_le(buf);
                                         }
                                         $pad_s(block.as_mut_slice(), 16 * z + 4 * y, rx, 1);
@@ -1678,8 +1921,7 @@ macro_rules! impl_codec {
                                 // lets LLVM unroll and vectorize the stores.
                                 for z in 0..4 {
                                     for y in 0..4 {
-                                        let row_off =
-                                            (((z0 + z) * n1 + (y0 + y)) * n0 + x0) * $esz;
+                                        let row_off = (((z0 + z) * n1 + (y0 + y)) * n0 + x0) * $esz;
                                         let row = &mut output[row_off..row_off + 4 * $esz];
                                         for x in 0..4 {
                                             row[x * $esz..(x + 1) * $esz].copy_from_slice(
@@ -1692,8 +1934,7 @@ macro_rules! impl_codec {
                                 // Partial block (edge): write only what fits.
                                 for z in 0..rz {
                                     for y in 0..ry {
-                                        let row_off =
-                                            (((z0 + z) * n1 + (y0 + y)) * n0 + x0) * $esz;
+                                        let row_off = (((z0 + z) * n1 + (y0 + y)) * n0 + x0) * $esz;
                                         let row = &mut output[row_off..row_off + rx * $esz];
                                         for x in 0..rx {
                                             row[x * $esz..(x + 1) * $esz].copy_from_slice(
@@ -1745,14 +1986,12 @@ macro_rules! impl_codec {
                                     for wi in 0..4 {
                                         for z in 0..4 {
                                             for y in 0..4 {
-                                                let row_off = ((((w0 + wi) * n2 + (z0 + z))
-                                                    * n1
+                                                let row_off = ((((w0 + wi) * n2 + (z0 + z)) * n1
                                                     + (y0 + y))
                                                     * n0
                                                     + x0)
                                                     * $esz;
-                                                let row =
-                                                    &data[row_off..row_off + 4 * $esz];
+                                                let row = &data[row_off..row_off + 4 * $esz];
                                                 for x in 0..4 {
                                                     let buf: [u8; $esz] = row
                                                         [x * $esz..(x + 1) * $esz]
@@ -1769,16 +2008,13 @@ macro_rules! impl_codec {
                                         for z in 0..rz {
                                             for y in 0..ry {
                                                 for x in 0..rx {
-                                                    let src = (((w0 + wi) * n2 + (z0 + z))
-                                                        * n1
+                                                    let src = (((w0 + wi) * n2 + (z0 + z)) * n1
                                                         + (y0 + y))
                                                         * n0
                                                         + (x0 + x);
                                                     let off = src * $esz;
                                                     let mut buf = [0u8; $esz];
-                                                    buf.copy_from_slice(
-                                                        &data[off..off + $esz],
-                                                    );
+                                                    buf.copy_from_slice(&data[off..off + $esz]);
                                                     block[64 * wi + 16 * z + 4 * y + x] =
                                                         $from_le(buf);
                                                 }
@@ -1867,23 +2103,17 @@ macro_rules! impl_codec {
                                     for wi in 0..4 {
                                         for z in 0..4 {
                                             for y in 0..4 {
-                                                let row_off = ((((w0 + wi) * n2 + (z0 + z))
-                                                    * n1
+                                                let row_off = ((((w0 + wi) * n2 + (z0 + z)) * n1
                                                     + (y0 + y))
                                                     * n0
                                                     + x0)
                                                     * $esz;
-                                                let row = &mut output
-                                                    [row_off..row_off + 4 * $esz];
+                                                let row = &mut output[row_off..row_off + 4 * $esz];
                                                 for x in 0..4 {
-                                                    row[x * $esz..(x + 1) * $esz]
-                                                        .copy_from_slice(
-                                                            &block[64 * wi
-                                                                + 16 * z
-                                                                + 4 * y
-                                                                + x]
-                                                                .to_le_bytes(),
-                                                        );
+                                                    row[x * $esz..(x + 1) * $esz].copy_from_slice(
+                                                        &block[64 * wi + 16 * z + 4 * y + x]
+                                                            .to_le_bytes(),
+                                                    );
                                                 }
                                             }
                                         }
@@ -1893,15 +2123,13 @@ macro_rules! impl_codec {
                                         for z in 0..rz {
                                             for y in 0..ry {
                                                 for x in 0..rx {
-                                                    let dst = (((w0 + wi) * n2 + (z0 + z))
-                                                        * n1
+                                                    let dst = (((w0 + wi) * n2 + (z0 + z)) * n1
                                                         + (y0 + y))
                                                         * n0
                                                         + (x0 + x);
                                                     let off = dst * $esz;
                                                     output[off..off + $esz].copy_from_slice(
-                                                        &block
-                                                            [64 * wi + 16 * z + 4 * y + x]
+                                                        &block[64 * wi + 16 * z + 4 * y + x]
                                                             .to_le_bytes(),
                                                     );
                                                 }
@@ -1920,36 +2148,72 @@ macro_rules! impl_codec {
 }
 
 impl_codec!(
-    codec_f32, f32, 0.0f32, 4, f32_from_le,
-    pad_partial_block_f32, pad_strided_f32,
-    encode_block_f32, decode_block_f32,
-    encode_block_f32_2d, decode_block_f32_2d,
-    encode_block_f32_3d, decode_block_f32_3d,
-    encode_block_f32_4d, decode_block_f32_4d
+    codec_f32,
+    f32,
+    0.0f32,
+    4,
+    f32_from_le,
+    pad_partial_block_f32,
+    pad_strided_f32,
+    encode_block_f32,
+    decode_block_f32,
+    encode_block_f32_2d,
+    decode_block_f32_2d,
+    encode_block_f32_3d,
+    decode_block_f32_3d,
+    encode_block_f32_4d,
+    decode_block_f32_4d
 );
 impl_codec!(
-    codec_f64, f64, 0.0f64, 8, f64_from_le,
-    pad_partial_block_f64, pad_strided_f64,
-    encode_block_f64, decode_block_f64,
-    encode_block_f64_2d, decode_block_f64_2d,
-    encode_block_f64_3d, decode_block_f64_3d,
-    encode_block_f64_4d, decode_block_f64_4d
+    codec_f64,
+    f64,
+    0.0f64,
+    8,
+    f64_from_le,
+    pad_partial_block_f64,
+    pad_strided_f64,
+    encode_block_f64,
+    decode_block_f64,
+    encode_block_f64_2d,
+    decode_block_f64_2d,
+    encode_block_f64_3d,
+    decode_block_f64_3d,
+    encode_block_f64_4d,
+    decode_block_f64_4d
 );
 impl_codec!(
-    codec_i32, i32, 0i32, 4, i32_from_le,
-    pad_partial_block_i32, pad_strided_i32,
-    encode_block_i32, decode_block_i32,
-    encode_block_i32_2d, decode_block_i32_2d,
-    encode_block_i32_3d, decode_block_i32_3d,
-    encode_block_i32_4d, decode_block_i32_4d
+    codec_i32,
+    i32,
+    0i32,
+    4,
+    i32_from_le,
+    pad_partial_block_i32,
+    pad_strided_i32,
+    encode_block_i32,
+    decode_block_i32,
+    encode_block_i32_2d,
+    decode_block_i32_2d,
+    encode_block_i32_3d,
+    decode_block_i32_3d,
+    encode_block_i32_4d,
+    decode_block_i32_4d
 );
 impl_codec!(
-    codec_i64, i64, 0i64, 8, i64_from_le,
-    pad_partial_block_i64, pad_strided_i64,
-    encode_block_i64, decode_block_i64,
-    encode_block_i64_2d, decode_block_i64_2d,
-    encode_block_i64_3d, decode_block_i64_3d,
-    encode_block_i64_4d, decode_block_i64_4d
+    codec_i64,
+    i64,
+    0i64,
+    8,
+    i64_from_le,
+    pad_partial_block_i64,
+    pad_strided_i64,
+    encode_block_i64,
+    decode_block_i64,
+    encode_block_i64_2d,
+    decode_block_i64_2d,
+    encode_block_i64_3d,
+    decode_block_i64_3d,
+    encode_block_i64_4d,
+    decode_block_i64_4d
 );
 
 /// Compress a raw chunk buffer with ZFP fixed-rate.
@@ -2162,9 +2426,7 @@ pub fn zfp_filter_meta_from_cd_values(cd_values: &[u32]) -> Option<ZfpFilterMeta
     }
     let mut r = BitReader::new(&bytes);
     // Magic (32 bits): 'z', 'f', 'p', codec.
-    if r.read(8) != u64::from(b'z')
-        || r.read(8) != u64::from(b'f')
-        || r.read(8) != u64::from(b'p')
+    if r.read(8) != u64::from(b'z') || r.read(8) != u64::from(b'f') || r.read(8) != u64::from(b'p')
     {
         return None;
     }
@@ -2491,10 +2753,7 @@ mod tests {
         // Probed from h5py + hdf5plugin for an f32 1D 16-value ramp at rate 16:
         // `[0x10105111, 0x0570667a, 0x000000f2, 0x03f00000]`.
         let cd = zfp_cd_values_rate(16.0, ZfpElementType::F32, &[16]).unwrap();
-        assert_eq!(
-            cd,
-            vec![0x10105111, 0x0570667a, 0x000000f2, 0x03f00000],
-        );
+        assert_eq!(cd, vec![0x10105111, 0x0570667a, 0x000000f2, 0x03f00000],);
     }
 
     #[test]
@@ -2572,7 +2831,8 @@ mod tests {
     fn compress_rejects_short_buffer() {
         // 3 f32s worth of bytes, but we claim dims = [4].
         let short = vec![0u8; 3 * 4];
-        let err = compress(&short, &[4], 16.0, ZfpElementType::F32).expect_err("short buffer must error");
+        let err =
+            compress(&short, &[4], 16.0, ZfpElementType::F32).expect_err("short buffer must error");
         assert!(matches!(err, FormatError::FilterError(_)), "{err:?}");
     }
 
@@ -2580,7 +2840,8 @@ mod tests {
     fn compress_rejects_long_buffer() {
         // Too many bytes — also a size mismatch.
         let long = vec![0u8; 5 * 4];
-        let err = compress(&long, &[4], 16.0, ZfpElementType::F32).expect_err("long buffer must error");
+        let err =
+            compress(&long, &[4], 16.0, ZfpElementType::F32).expect_err("long buffer must error");
         assert!(matches!(err, FormatError::FilterError(_)), "{err:?}");
     }
 
@@ -2588,19 +2849,24 @@ mod tests {
     fn compress_rejects_bad_rate() {
         let data = vec![0u8; 16 * 4];
         // Non-finite.
-        let err = compress(&data, &[16], f64::NAN, ZfpElementType::F32).expect_err("NaN must error");
+        let err =
+            compress(&data, &[16], f64::NAN, ZfpElementType::F32).expect_err("NaN must error");
         assert!(matches!(err, FormatError::FilterError(_)));
-        let err = compress(&data, &[16], f64::INFINITY, ZfpElementType::F32).expect_err("inf must error");
+        let err =
+            compress(&data, &[16], f64::INFINITY, ZfpElementType::F32).expect_err("inf must error");
         assert!(matches!(err, FormatError::FilterError(_)));
         // Non-positive.
         let err = compress(&data, &[16], 0.0, ZfpElementType::F32).expect_err("rate=0 must error");
         assert!(matches!(err, FormatError::FilterError(_)));
-        let err = compress(&data, &[16], -1.0, ZfpElementType::F32).expect_err("negative rate must error");
+        let err = compress(&data, &[16], -1.0, ZfpElementType::F32)
+            .expect_err("negative rate must error");
         assert!(matches!(err, FormatError::FilterError(_)));
         // Above scalar width.
-        let err = compress(&data, &[16], 33.0, ZfpElementType::F32).expect_err("rate > 32 must error for f32");
+        let err = compress(&data, &[16], 33.0, ZfpElementType::F32)
+            .expect_err("rate > 32 must error for f32");
         assert!(matches!(err, FormatError::FilterError(_)));
-        let err = compress(&data, &[16], 1e20, ZfpElementType::F32).expect_err("huge rate must error");
+        let err =
+            compress(&data, &[16], 1e20, ZfpElementType::F32).expect_err("huge rate must error");
         assert!(matches!(err, FormatError::FilterError(_)));
     }
 

--- a/tests/cell_array.rs
+++ b/tests/cell_array.rs
@@ -126,7 +126,11 @@ fn vec_of_option_with_none_uses_empty_struct_marker() {
                 .read_scalar::<hdf5::types::FixedAscii<32>>()
                 .unwrap();
             assert_eq!(cls.as_str(), "struct");
-            let empty = ds.attr("MATLAB_empty").unwrap().read_scalar::<u32>().unwrap();
+            let empty = ds
+                .attr("MATLAB_empty")
+                .unwrap()
+                .read_scalar::<u32>()
+                .unwrap();
             assert_eq!(empty, 1);
             empty_struct_count += 1;
         }
@@ -278,7 +282,10 @@ fn from_file_on_cell_array_currently_errors() {
     mat::to_file(&original, &path).unwrap();
 
     let result: Result<PathRoot, _> = mat::from_file(&path);
-    assert!(result.is_err(), "cell-array deserialization not yet implemented");
+    assert!(
+        result.is_err(),
+        "cell-array deserialization not yet implemented"
+    );
 }
 
 #[test]

--- a/tests/csr_multi_dataset.rs
+++ b/tests/csr_multi_dataset.rs
@@ -33,7 +33,10 @@ fn csr_triple_chunked_read() {
     let read_indptr = file.dataset("X/indptr").unwrap().read_i32().unwrap();
 
     assert_eq!(read_data, data, "X/data mismatch");
-    assert_eq!(read_indices, indices, "X/indices mismatch (first regression)");
+    assert_eq!(
+        read_indices, indices,
+        "X/indices mismatch (first regression)"
+    );
     assert_eq!(read_indptr, indptr, "X/indptr mismatch (second regression)");
 }
 

--- a/tests/hdf5_crosscheck.rs
+++ b/tests/hdf5_crosscheck.rs
@@ -131,9 +131,7 @@ fn crosscheck_u8_dataset() {
     let path = dir.path().join("u8.h5");
 
     let mut builder = FileBuilder::new();
-    builder
-        .create_dataset("data")
-        .with_u8_data(&[0, 128, 255]);
+    builder.create_dataset("data").with_u8_data(&[0, 128, 255]);
     builder.write(&path).unwrap();
 
     let file = hdf5::File::open(&path).unwrap();
@@ -228,15 +226,9 @@ fn crosscheck_multiple_datasets() {
     let path = dir.path().join("multi.h5");
 
     let mut builder = FileBuilder::new();
-    builder
-        .create_dataset("x")
-        .with_f64_data(&[1.0, 2.0, 3.0]);
-    builder
-        .create_dataset("y")
-        .with_i32_data(&[10, 20, 30]);
-    builder
-        .create_dataset("z")
-        .with_u8_data(&[0xFF, 0x00]);
+    builder.create_dataset("x").with_f64_data(&[1.0, 2.0, 3.0]);
+    builder.create_dataset("y").with_i32_data(&[10, 20, 30]);
+    builder.create_dataset("z").with_u8_data(&[0xFF, 0x00]);
     builder.write(&path).unwrap();
 
     let file = hdf5::File::open(&path).unwrap();
@@ -284,9 +276,7 @@ fn crosscheck_nested_groups() {
 
     let mut builder = FileBuilder::new();
     let mut outer = builder.create_group("outer");
-    outer
-        .create_dataset("outer_data")
-        .with_f64_data(&[1.0]);
+    outer.create_dataset("outer_data").with_f64_data(&[1.0]);
 
     let mut inner = outer.create_group("inner");
     inner
@@ -607,9 +597,7 @@ fn crosscheck_large_dataset() {
     let data: Vec<f64> = (0..n).map(|i| i as f64).collect();
 
     let mut builder = FileBuilder::new();
-    builder
-        .create_dataset("big")
-        .with_f64_data(&data);
+    builder.create_dataset("big").with_f64_data(&data);
     builder.write(&path).unwrap();
 
     let file = hdf5::File::open(&path).unwrap();
@@ -675,10 +663,7 @@ fn crosscheck_dense_attributes() {
     let ds = builder.create_dataset("data");
     ds.with_f64_data(&[1.0, 2.0, 3.0]);
     for i in 0..20 {
-        ds.set_attr(
-            &format!("attr_{i:03}"),
-            AttrValue::F64(i as f64 * 1.5),
-        );
+        ds.set_attr(&format!("attr_{i:03}"), AttrValue::F64(i as f64 * 1.5));
     }
     builder.write(&path).unwrap();
 
@@ -749,7 +734,9 @@ fn crosscheck_matlab_empty_shape_marker() {
 
     // Verify dataset-level attributes
     let class_attr = ds.attr("MATLAB_class").unwrap();
-    let class_val = class_attr.read_scalar::<hdf5::types::FixedAscii<32>>().unwrap();
+    let class_val = class_attr
+        .read_scalar::<hdf5::types::FixedAscii<32>>()
+        .unwrap();
     assert_eq!(class_val.as_str(), "double");
 
     let empty_attr = ds.attr("MATLAB_empty").unwrap();
@@ -803,8 +790,12 @@ fn crosscheck_matlab_refs_subsystem_pattern() {
 
     // --- #refs# group ---
     let mut refs_grp = builder.create_group("#refs#");
-    refs_grp.create_dataset("a").with_u16_data(&[72, 101, 108, 108, 111]);
-    refs_grp.create_dataset("b").with_u16_data(&[87, 111, 114, 108, 100]);
+    refs_grp
+        .create_dataset("a")
+        .with_u16_data(&[72, 101, 108, 108, 111]);
+    refs_grp
+        .create_dataset("b")
+        .with_u16_data(&[87, 111, 114, 108, 100]);
     refs_grp.create_dataset("c").with_u16_data(&[70, 111, 111]);
 
     // Cross-references within #refs#
@@ -872,7 +863,9 @@ fn crosscheck_matlab_refs_subsystem_pattern() {
 
     // Dataset-level attribute
     let class_attr = data.attr("MATLAB_class").unwrap();
-    let class_val = class_attr.read_scalar::<hdf5::types::FixedAscii<32>>().unwrap();
+    let class_val = class_attr
+        .read_scalar::<hdf5::types::FixedAscii<32>>()
+        .unwrap();
     assert_eq!(class_val.as_str(), "string");
 }
 
@@ -893,15 +886,18 @@ fn crosscheck_varlen_ascii_array_encoding_vs_metno() {
 
     // --- Verify raw bytes: GCOL present and well-formed ---
     let forge_bytes = std::fs::read(&forge_path).unwrap();
-    let fg = forge_bytes.windows(4).position(|w| w == b"GCOL")
+    let fg = forge_bytes
+        .windows(4)
+        .position(|w| w == b"GCOL")
         .expect("forge file missing GCOL signature");
     assert_eq!(forge_bytes[fg + 4], 1, "GCOL version should be 1");
 
     // Collection size must be >= 4096 (H5HG_MINSIZE)
-    let collection_size = u64::from_le_bytes(
-        forge_bytes[fg + 8..fg + 16].try_into().unwrap()
+    let collection_size = u64::from_le_bytes(forge_bytes[fg + 8..fg + 16].try_into().unwrap());
+    assert!(
+        collection_size >= 4096,
+        "GCOL size {collection_size} < H5HG_MINSIZE"
     );
-    assert!(collection_size >= 4096, "GCOL size {collection_size} < H5HG_MINSIZE");
 
     // First object at GCOL+16: index=1, data="x"
     let obj0 = fg + 16;
@@ -956,13 +952,25 @@ fn crosscheck_varlen_ascii_on_nested_group() {
 
     // Verify ASCII attr
     let class_attr = grp.attr("MATLAB_class").unwrap();
-    let class_val = class_attr.read_scalar::<hdf5::types::FixedAscii<32>>().unwrap();
+    let class_val = class_attr
+        .read_scalar::<hdf5::types::FixedAscii<32>>()
+        .unwrap();
     assert_eq!(class_val.as_str(), "struct");
 
     // Verify datasets
-    let x: Vec<f64> = file.dataset("my_struct/x").unwrap().read_1d().unwrap().to_vec();
+    let x: Vec<f64> = file
+        .dataset("my_struct/x")
+        .unwrap()
+        .read_1d()
+        .unwrap()
+        .to_vec();
     assert_eq!(x, vec![1.0, 2.0]);
-    let y: Vec<f64> = file.dataset("my_struct/y").unwrap().read_1d().unwrap().to_vec();
+    let y: Vec<f64> = file
+        .dataset("my_struct/y")
+        .unwrap()
+        .read_1d()
+        .unwrap()
+        .to_vec();
     assert_eq!(y, vec![3.0, 4.0]);
 }
 
@@ -987,7 +995,8 @@ fn crosscheck_userblock_all_address_types() {
 
     // Nested group with its own VL attr (second GCOL)
     let mut grp = builder.create_group("inner");
-    grp.create_dataset("vals").with_f64_data(&[10.0, 20.0, 30.0]);
+    grp.create_dataset("vals")
+        .with_f64_data(&[10.0, 20.0, 30.0]);
     grp.create_dataset("ids").with_i32_data(&[1, 2, 3]);
     grp.set_attr(
         "MATLAB_fields",
@@ -1032,9 +1041,19 @@ fn crosscheck_userblock_all_address_types() {
     let iv = read_vl_ascii_attr(&inner_fields);
     assert_eq!(iv, vec!["vals", "ids"]);
 
-    let inner_vals: Vec<f64> = file.dataset("inner/vals").unwrap().read_1d().unwrap().to_vec();
+    let inner_vals: Vec<f64> = file
+        .dataset("inner/vals")
+        .unwrap()
+        .read_1d()
+        .unwrap()
+        .to_vec();
     assert_eq!(inner_vals, vec![10.0, 20.0, 30.0]);
-    let inner_ids: Vec<i32> = file.dataset("inner/ids").unwrap().read_1d().unwrap().to_vec();
+    let inner_ids: Vec<i32> = file
+        .dataset("inner/ids")
+        .unwrap()
+        .read_1d()
+        .unwrap()
+        .to_vec();
     assert_eq!(inner_ids, vec![1, 2, 3]);
 
     // Reference dataset shape
@@ -1078,14 +1097,26 @@ fn crosscheck_group_only_no_datasets() {
     assert_eq!(cv.as_str(), "struct");
 
     // Leaf data
-    let a_val: Vec<f64> = file.dataset("outer/a/val").unwrap().read_1d().unwrap().to_vec();
+    let a_val: Vec<f64> = file
+        .dataset("outer/a/val")
+        .unwrap()
+        .read_1d()
+        .unwrap()
+        .to_vec();
     assert_eq!(a_val, vec![1.0]);
-    let b_val: Vec<i32> = file.dataset("outer/b/val").unwrap().read_1d().unwrap().to_vec();
+    let b_val: Vec<i32> = file
+        .dataset("outer/b/val")
+        .unwrap()
+        .read_1d()
+        .unwrap()
+        .to_vec();
     assert_eq!(b_val, vec![42]);
 
     // Sub-group attrs
     let a_class = file.group("outer/a").unwrap().attr("MATLAB_class").unwrap();
-    let acv = a_class.read_scalar::<hdf5::types::FixedAscii<32>>().unwrap();
+    let acv = a_class
+        .read_scalar::<hdf5::types::FixedAscii<32>>()
+        .unwrap();
     assert_eq!(acv.as_str(), "double");
 }
 
@@ -1097,8 +1128,10 @@ fn crosscheck_long_ascii_class_attr() {
     let path = dir.path().join("long_class.h5");
 
     let mut builder = FileBuilder::new();
-    builder.create_dataset("x").with_f64_data(&[1.0])
-        .set_attr("MATLAB_class", AttrValue::AsciiString("canonical empty".into()));
+    builder.create_dataset("x").with_f64_data(&[1.0]).set_attr(
+        "MATLAB_class",
+        AttrValue::AsciiString("canonical empty".into()),
+    );
     builder.write(&path).unwrap();
 
     let file = hdf5::File::open(&path).unwrap();
@@ -1153,14 +1186,28 @@ fn crosscheck_matlab_struct_pattern() {
     assert_eq!(fv, vec!["field1", "field2"]);
 
     // Child datasets and their attrs
-    let f1: Vec<f64> = file.dataset("mystruct/field1").unwrap().read_1d().unwrap().to_vec();
+    let f1: Vec<f64> = file
+        .dataset("mystruct/field1")
+        .unwrap()
+        .read_1d()
+        .unwrap()
+        .to_vec();
     assert_eq!(f1, vec![1.0]);
-    let f1_class = file.dataset("mystruct/field1").unwrap()
-        .attr("MATLAB_class").unwrap()
-        .read_scalar::<hdf5::types::FixedAscii<32>>().unwrap();
+    let f1_class = file
+        .dataset("mystruct/field1")
+        .unwrap()
+        .attr("MATLAB_class")
+        .unwrap()
+        .read_scalar::<hdf5::types::FixedAscii<32>>()
+        .unwrap();
     assert_eq!(f1_class.as_str(), "double");
 
-    let f2: Vec<i32> = file.dataset("mystruct/field2").unwrap().read_1d().unwrap().to_vec();
+    let f2: Vec<i32> = file
+        .dataset("mystruct/field2")
+        .unwrap()
+        .read_1d()
+        .unwrap()
+        .to_vec();
     assert_eq!(f2, vec![10, 20]);
 }
 
@@ -1176,7 +1223,8 @@ fn crosscheck_matlab_cell_array() {
     refs_group.create_dataset("ref_1").with_i32_data(&[42]);
     builder.add_group(refs_group.finish());
 
-    builder.create_dataset("mycell")
+    builder
+        .create_dataset("mycell")
         .with_path_references(&["#refs#/ref_0", "#refs#/ref_1"])
         .with_shape(&[1, 2])
         .set_attr("MATLAB_class", AttrValue::AsciiString("cell".into()));
@@ -1188,14 +1236,27 @@ fn crosscheck_matlab_cell_array() {
     // Cell reference dataset
     let mycell = file.dataset("mycell").unwrap();
     assert_eq!(mycell.shape(), vec![1, 2]);
-    let cell_class = mycell.attr("MATLAB_class").unwrap()
-        .read_scalar::<hdf5::types::FixedAscii<32>>().unwrap();
+    let cell_class = mycell
+        .attr("MATLAB_class")
+        .unwrap()
+        .read_scalar::<hdf5::types::FixedAscii<32>>()
+        .unwrap();
     assert_eq!(cell_class.as_str(), "cell");
 
     // Referenced data
-    let r0: Vec<f64> = file.dataset("#refs#/ref_0").unwrap().read_1d().unwrap().to_vec();
+    let r0: Vec<f64> = file
+        .dataset("#refs#/ref_0")
+        .unwrap()
+        .read_1d()
+        .unwrap()
+        .to_vec();
     assert_eq!(r0, vec![1.0]);
-    let r1: Vec<i32> = file.dataset("#refs#/ref_1").unwrap().read_1d().unwrap().to_vec();
+    let r1: Vec<i32> = file
+        .dataset("#refs#/ref_1")
+        .unwrap()
+        .read_1d()
+        .unwrap()
+        .to_vec();
     assert_eq!(r1, vec![42]);
 }
 

--- a/tests/serde_crosscheck.rs
+++ b/tests/serde_crosscheck.rs
@@ -33,7 +33,10 @@ fn c_library_reads_nested_struct_file() {
         trial: 3,
         temperature: 300.0,
         samples: vec![1.0, 2.0, 3.0, 4.0, 5.0],
-        config: Config { threshold: 0.5, tag: "run".into() },
+        config: Config {
+            threshold: 0.5,
+            tag: "run".into(),
+        },
     };
 
     mat::to_file(&e, &path).unwrap();
@@ -60,7 +63,9 @@ fn c_library_reads_nested_struct_file() {
     // Nested group with MATLAB struct class + MATLAB_fields VL attribute.
     let cfg = file.group("config").unwrap();
     let class_attr = cfg.attr("MATLAB_class").unwrap();
-    let class_val = class_attr.read_scalar::<hdf5::types::FixedAscii<32>>().unwrap();
+    let class_val = class_attr
+        .read_scalar::<hdf5::types::FixedAscii<32>>()
+        .unwrap();
     assert_eq!(class_val.as_str(), "struct");
     let fields_attr = cfg.attr("MATLAB_fields").unwrap();
     // MATLAB-compatible encoding is `H5T_VLEN { H5T_STRING { STRSIZE 1 } }`,
@@ -155,7 +160,9 @@ fn c_library_reads_complex_as_compound() {
 
     // MATLAB_class is the real-number class for complex.
     let class_attr = ds.attr("MATLAB_class").unwrap();
-    let cls = class_attr.read_scalar::<hdf5::types::FixedAscii<32>>().unwrap();
+    let cls = class_attr
+        .read_scalar::<hdf5::types::FixedAscii<32>>()
+        .unwrap();
     assert_eq!(cls.as_str(), "double");
 }
 
@@ -170,7 +177,10 @@ fn c_library_reads_logical_as_uint8() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("flags.mat");
 
-    let f = Flags { on: true, bits: vec![true, false, true, true, false] };
+    let f = Flags {
+        on: true,
+        bits: vec![true, false, true, true, false],
+    };
     mat::to_file(&f, &path).unwrap();
 
     let file = hdf5::File::open(&path).unwrap();
@@ -179,8 +189,11 @@ fn c_library_reads_logical_as_uint8() {
     assert_eq!(on.shape(), vec![1, 1]);
     let on_raw: Vec<u8> = on.read_raw().unwrap();
     assert_eq!(on_raw, vec![1]);
-    let cls = on.attr("MATLAB_class").unwrap()
-        .read_scalar::<hdf5::types::FixedAscii<32>>().unwrap();
+    let cls = on
+        .attr("MATLAB_class")
+        .unwrap()
+        .read_scalar::<hdf5::types::FixedAscii<32>>()
+        .unwrap();
     assert_eq!(cls.as_str(), "logical");
 
     let bits = file.dataset("bits").unwrap();
@@ -201,7 +214,10 @@ fn to_file_and_from_file_roundtrip() {
         trial: 9,
         temperature: 77.3,
         samples: vec![0.1, 0.2, 0.3],
-        config: Config { threshold: 0.8, tag: "production".into() },
+        config: Config {
+            threshold: 0.8,
+            tag: "production".into(),
+        },
     };
 
     mat::to_file(&e, &path).unwrap();

--- a/tests/serde_matio_crosscheck.rs
+++ b/tests/serde_matio_crosscheck.rs
@@ -13,7 +13,12 @@
 // FFI bindings to system libmatio.
 // =======================================================================
 
-#[allow(non_camel_case_types, non_snake_case, non_upper_case_globals, dead_code)]
+#[allow(
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    dead_code
+)]
 mod ffi {
     use std::ffi::{c_char, c_int, c_uint, c_void};
 
@@ -132,7 +137,7 @@ mod ffi {
 // lifetime discipline on borrowed struct-field pointers.
 // =======================================================================
 
-use std::ffi::{c_void, CStr, CString};
+use std::ffi::{CStr, CString, c_void};
 use std::path::Path;
 use std::ptr;
 
@@ -164,14 +169,16 @@ impl MatFile {
         if p.is_null() {
             None
         } else {
-            Some(MatVar { ptr: p, owned: true })
+            Some(MatVar {
+                ptr: p,
+                owned: true,
+            })
         }
     }
 
     /// Write a prepared MatVar to this file.
     pub fn write(&self, var: MatVar) {
-        let rc =
-            unsafe { ffi::Mat_VarWrite(self.ptr, var.ptr, ffi::MAT_COMPRESSION_NONE) };
+        let rc = unsafe { ffi::Mat_VarWrite(self.ptr, var.ptr, ffi::MAT_COMPRESSION_NONE) };
         assert_eq!(rc, 0, "Mat_VarWrite failed ({rc})");
         // matio keeps a reference after Mat_VarWrite; still must free on our side.
         drop(var);
@@ -222,13 +229,7 @@ impl MatVar {
         Self::create_numeric(name, ffi::MAT_C_DOUBLE, ffi::MAT_T_DOUBLE, &[1, 1], &[v])
     }
     pub fn f64_row_vec(name: &str, v: &[f64]) -> Self {
-        Self::create_numeric(
-            name,
-            ffi::MAT_C_DOUBLE,
-            ffi::MAT_T_DOUBLE,
-            &[1, v.len()],
-            v,
-        )
+        Self::create_numeric(name, ffi::MAT_C_DOUBLE, ffi::MAT_T_DOUBLE, &[1, v.len()], v)
     }
     /// Build a 2-D f64 matrix. `data` must be in column-major order (MATLAB).
     pub fn f64_matrix(name: &str, rows: usize, cols: usize, col_major: &[f64]) -> Self {
@@ -245,13 +246,7 @@ impl MatVar {
         Self::create_numeric(name, ffi::MAT_C_INT32, ffi::MAT_T_INT32, &[1, 1], &[v])
     }
     pub fn i32_row_vec(name: &str, v: &[i32]) -> Self {
-        Self::create_numeric(
-            name,
-            ffi::MAT_C_INT32,
-            ffi::MAT_T_INT32,
-            &[1, v.len()],
-            v,
-        )
+        Self::create_numeric(name, ffi::MAT_C_INT32, ffi::MAT_T_INT32, &[1, v.len()], v)
     }
     pub fn u32_scalar(name: &str, v: u32) -> Self {
         Self::create_numeric(name, ffi::MAT_C_UINT32, ffi::MAT_T_UINT32, &[1, 1], &[v])
@@ -316,7 +311,10 @@ impl MatVar {
         if p.is_null() {
             None
         } else {
-            Some(MatVar { ptr: p, owned: false })
+            Some(MatVar {
+                ptr: p,
+                owned: false,
+            })
         }
     }
 
@@ -329,8 +327,10 @@ impl MatVar {
         let dims = [1usize, 1];
         // Mat_VarCreateStruct2 expects a NULL-terminated array of C strings
         // (unlike the deprecated Mat_VarCreateStruct which takes a count).
-        let cfields: Vec<CString> =
-            field_names.iter().map(|f| CString::new(*f).unwrap()).collect();
+        let cfields: Vec<CString> = field_names
+            .iter()
+            .map(|f| CString::new(*f).unwrap())
+            .collect();
         let mut cfield_ptrs: Vec<*const std::ffi::c_char> =
             cfields.iter().map(|c| c.as_ptr()).collect();
         cfield_ptrs.push(std::ptr::null());
@@ -392,7 +392,15 @@ fn matio_reads_scalars_from_hdf5_pure() {
     let _g = matio_lock();
     let dir = tempdir().unwrap();
     let path = dir.path().join("scalars.mat");
-    mat::to_file(&Scalars { x: 1.5, n: -7, u: 42 }, &path).unwrap();
+    mat::to_file(
+        &Scalars {
+            x: 1.5,
+            n: -7,
+            u: 42,
+        },
+        &path,
+    )
+    .unwrap();
 
     let f = MatFile::open(&path);
     assert_eq!(f.read("x").unwrap().scalar_f64(), 1.5);
@@ -412,7 +420,10 @@ fn matio_reads_vectors_from_hdf5_pure() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("vectors.mat");
     mat::to_file(
-        &Vectors { xs: vec![1.0, 2.0, 3.0, 4.0], ns: vec![-1, 0, 1] },
+        &Vectors {
+            xs: vec![1.0, 2.0, 3.0, 4.0],
+            ns: vec![-1, 0, 1],
+        },
         &path,
     )
     .unwrap();
@@ -481,7 +492,10 @@ fn matio_reads_nested_struct_from_hdf5_pure() {
     mat::to_file(
         &Nested {
             name: 99,
-            config: Config { threshold: 0.25, trial: 3 },
+            config: Config {
+                threshold: 0.25,
+                trial: 3,
+            },
         },
         &path,
     )
@@ -515,7 +529,14 @@ fn hdf5_pure_reads_scalars_written_by_matio() {
     }
 
     let parsed: Scalars = mat::from_file(&path).unwrap();
-    assert_eq!(parsed, Scalars { x: 1.5, n: -7, u: 42 });
+    assert_eq!(
+        parsed,
+        Scalars {
+            x: 1.5,
+            n: -7,
+            u: 42
+        }
+    );
 }
 
 #[test]
@@ -532,7 +553,10 @@ fn hdf5_pure_reads_vectors_written_by_matio() {
     let parsed: Vectors = mat::from_file(&path).unwrap();
     assert_eq!(
         parsed,
-        Vectors { xs: vec![1.0, 2.0, 3.0, 4.0], ns: vec![-1, 0, 1] }
+        Vectors {
+            xs: vec![1.0, 2.0, 3.0, 4.0],
+            ns: vec![-1, 0, 1]
+        }
     );
 }
 
@@ -578,7 +602,13 @@ fn hdf5_pure_reads_nested_struct_written_by_matio() {
     let parsed: Nested = mat::from_file(&path).unwrap();
     assert_eq!(
         parsed,
-        Nested { name: 99, config: Config { threshold: 0.25, trial: 3 } }
+        Nested {
+            name: 99,
+            config: Config {
+                threshold: 0.25,
+                trial: 3
+            }
+        }
     );
 }
 
@@ -594,7 +624,10 @@ fn full_roundtrip_via_matio() {
     let path2 = dir.path().join("b.mat");
 
     mat::to_file(
-        &Vectors { xs: vec![0.5, 1.5, 2.5], ns: vec![10, 20, 30] },
+        &Vectors {
+            xs: vec![0.5, 1.5, 2.5],
+            ns: vec![10, 20, 30],
+        },
         &path1,
     )
     .unwrap();
@@ -632,7 +665,9 @@ fn hdf5_pure_reads_column_vector_matrix_from_matio() {
     }
 
     #[derive(serde::Deserialize)]
-    struct ColOnly { m: Matrix<f64> }
+    struct ColOnly {
+        m: Matrix<f64>,
+    }
     let parsed: ColOnly = mat::from_file(&path).unwrap();
     assert_eq!(parsed.m.rows(), 3);
     assert_eq!(parsed.m.cols(), 1);
@@ -653,7 +688,9 @@ fn hdf5_pure_reads_row_vector_matrix_from_matio() {
     }
 
     #[derive(serde::Deserialize)]
-    struct RowOnly { m: Matrix<f64> }
+    struct RowOnly {
+        m: Matrix<f64>,
+    }
     let parsed: RowOnly = mat::from_file(&path).unwrap();
     assert_eq!(parsed.m.rows(), 1);
     assert_eq!(parsed.m.cols(), 4);

--- a/tests/serde_roundtrip.rs
+++ b/tests/serde_roundtrip.rs
@@ -23,7 +23,11 @@ struct SimpleRoot {
 
 #[test]
 fn userblock_signature_present() {
-    let v = SimpleRoot { trial: 1, temperature: 23.5, name: "alpha".into() };
+    let v = SimpleRoot {
+        trial: 1,
+        temperature: 23.5,
+        name: "alpha".into(),
+    };
     let bytes = mat::to_bytes(&v).unwrap();
     assert!(bytes.len() > 512, "file must be at least userblock + HDF5");
     assert_eq!(&bytes[..6], b"MATLAB");
@@ -32,7 +36,11 @@ fn userblock_signature_present() {
 
 #[test]
 fn serialize_top_level_struct_produces_three_variables() {
-    let v = SimpleRoot { trial: 7, temperature: 300.0, name: "beta".into() };
+    let v = SimpleRoot {
+        trial: 7,
+        temperature: 300.0,
+        name: "beta".into(),
+    };
     let bytes = mat::to_bytes(&v).unwrap();
 
     let file = File::from_bytes(bytes).unwrap();
@@ -140,7 +148,10 @@ struct Inner {
 fn nested_struct_becomes_group() {
     let v = WithNested {
         x: 1.5,
-        inner: Inner { y: 42, z: vec![10.0, 20.0] },
+        inner: Inner {
+            y: 42,
+            z: vec![10.0, 20.0],
+        },
     };
     let file = File::from_bytes(mat::to_bytes(&v).unwrap()).unwrap();
 
@@ -179,7 +190,10 @@ struct WithOption {
 
 #[test]
 fn option_none_is_omitted() {
-    let v = WithOption { required: 1.0, maybe: None };
+    let v = WithOption {
+        required: 1.0,
+        maybe: None,
+    };
     let file = File::from_bytes(mat::to_bytes(&v).unwrap()).unwrap();
     assert!(file.dataset("required").is_ok());
     assert!(file.dataset("maybe").is_err());
@@ -187,7 +201,10 @@ fn option_none_is_omitted() {
 
 #[test]
 fn option_some_serializes_underlying() {
-    let v = WithOption { required: 1.0, maybe: Some("hello".into()) };
+    let v = WithOption {
+        required: 1.0,
+        maybe: Some("hello".into()),
+    };
     let file = File::from_bytes(mat::to_bytes(&v).unwrap()).unwrap();
     let ds = file.dataset("maybe").unwrap();
     assert_eq!(ds.shape().unwrap(), vec![5, 1]);
@@ -220,7 +237,10 @@ fn complex_scalar_and_vector() {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
-enum Flag { On, Off }
+enum Flag {
+    On,
+    Off,
+}
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 struct WithEnum {
@@ -246,7 +266,10 @@ struct WithBool {
 
 #[test]
 fn bool_fields_are_logical_uint8() {
-    let v = WithBool { flag: true, flags: vec![true, false, true] };
+    let v = WithBool {
+        flag: true,
+        flags: vec![true, false, true],
+    };
     let file = File::from_bytes(mat::to_bytes(&v).unwrap()).unwrap();
 
     let f = file.dataset("flag").unwrap();
@@ -274,7 +297,11 @@ fn rt<T: Serialize + serde::de::DeserializeOwned + PartialEq + std::fmt::Debug>(
 
 #[test]
 fn roundtrip_simple_primitives() {
-    rt(SimpleRoot { trial: 9, temperature: 273.15, name: "hello".into() });
+    rt(SimpleRoot {
+        trial: 9,
+        temperature: 273.15,
+        name: "hello".into(),
+    });
 }
 
 #[test]
@@ -290,8 +317,11 @@ fn roundtrip_vectors() {
 fn roundtrip_matrix_f64() {
     rt(WithMatrix {
         m: Matrix::from_row_major(
-            3, 4,
-            vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0],
+            3,
+            4,
+            vec![
+                1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
+            ],
         ),
     });
 }
@@ -300,21 +330,34 @@ fn roundtrip_matrix_f64() {
 fn roundtrip_nested() {
     rt(WithNested {
         x: 1.5,
-        inner: Inner { y: 42, z: vec![10.0, 20.0, 30.0] },
+        inner: Inner {
+            y: 42,
+            z: vec![10.0, 20.0, 30.0],
+        },
     });
 }
 
 #[test]
 fn roundtrip_option_some_and_none() {
-    rt(WithOption { required: 1.0, maybe: Some("world".into()) });
-    rt(WithOption { required: 2.5, maybe: None });
+    rt(WithOption {
+        required: 1.0,
+        maybe: Some("world".into()),
+    });
+    rt(WithOption {
+        required: 2.5,
+        maybe: None,
+    });
 }
 
 #[test]
 fn roundtrip_complex_scalar_and_vec() {
     rt(WithComplex {
         z: Complex64::new(2.0, -1.0),
-        zs: vec![Complex64::new(1.0, 0.0), Complex64::new(0.0, 1.0), Complex64::new(-1.0, -1.0)],
+        zs: vec![
+            Complex64::new(1.0, 0.0),
+            Complex64::new(0.0, 1.0),
+            Complex64::new(-1.0, -1.0),
+        ],
     });
 }
 
@@ -326,7 +369,10 @@ fn roundtrip_unit_enum() {
 
 #[test]
 fn roundtrip_bool() {
-    rt(WithBool { flag: true, flags: vec![false, true, false, true] });
+    rt(WithBool {
+        flag: true,
+        flags: vec![false, true, false, true],
+    });
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
@@ -336,7 +382,9 @@ struct WithStringUnicode {
 
 #[test]
 fn roundtrip_non_ascii_string() {
-    rt(WithStringUnicode { tag: "résumé 💡 αβγ".into() });
+    rt(WithStringUnicode {
+        tag: "résumé 💡 αβγ".into(),
+    });
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
@@ -347,10 +395,7 @@ struct VecOfVec {
 #[test]
 fn roundtrip_vec_of_vec_as_matrix() {
     rt(VecOfVec {
-        grid: vec![
-            vec![1.0, 2.0, 3.0],
-            vec![4.0, 5.0, 6.0],
-        ],
+        grid: vec![vec![1.0, 2.0, 3.0], vec![4.0, 5.0, 6.0]],
     });
 }
 
@@ -402,13 +447,15 @@ fn roundtrip_int_matrices() {
 #[test]
 fn roundtrip_bool_matrix() {
     #[derive(Serialize, Deserialize, Debug, PartialEq)]
-    struct BoolMat { m: Matrix<bool> }
+    struct BoolMat {
+        m: Matrix<bool>,
+    }
     rt(BoolMat {
-        m: Matrix::from_row_major(3, 3, vec![
-            true, false, true,
-            false, true, false,
-            true, false, true,
-        ]),
+        m: Matrix::from_row_major(
+            3,
+            3,
+            vec![true, false, true, false, true, false, true, false, true],
+        ),
     });
 }
 
@@ -502,15 +549,29 @@ fn roundtrip_integer_extremes() {
 #[test]
 fn roundtrip_deep_nested() {
     #[derive(Serialize, Deserialize, Debug, PartialEq)]
-    struct L1 { label: String, l2: L2 }
+    struct L1 {
+        label: String,
+        l2: L2,
+    }
     #[derive(Serialize, Deserialize, Debug, PartialEq)]
-    struct L2 { depth: u32, l3: L3 }
+    struct L2 {
+        depth: u32,
+        l3: L3,
+    }
     #[derive(Serialize, Deserialize, Debug, PartialEq)]
-    struct L3 { tag: String, l4: L4 }
+    struct L3 {
+        tag: String,
+        l4: L4,
+    }
     #[derive(Serialize, Deserialize, Debug, PartialEq)]
-    struct L4 { id: u64, values: Vec<f64> }
+    struct L4 {
+        id: u64,
+        values: Vec<f64>,
+    }
     #[derive(Serialize, Deserialize, Debug, PartialEq)]
-    struct Root { root: L1 }
+    struct Root {
+        root: L1,
+    }
     rt(Root {
         root: L1 {
             label: "top".into(),
@@ -518,7 +579,10 @@ fn roundtrip_deep_nested() {
                 depth: 2,
                 l3: L3 {
                     tag: "middle".into(),
-                    l4: L4 { id: 999, values: vec![1.5, 2.5, 3.5] },
+                    l4: L4 {
+                        id: 999,
+                        values: vec![1.5, 2.5, 3.5],
+                    },
                 },
             },
         },
@@ -529,7 +593,10 @@ fn roundtrip_deep_nested() {
 #[test]
 fn roundtrip_surrogate_pair() {
     #[derive(Serialize, Deserialize, Debug, PartialEq)]
-    struct Emoji { party: String, mixed: String }
+    struct Emoji {
+        party: String,
+        mixed: String,
+    }
     rt(Emoji {
         party: "🎉".into(),
         mixed: "é日🎉A".into(),
@@ -562,7 +629,9 @@ fn roundtrip_empty_variants() {
 #[test]
 fn roundtrip_large_matrix() {
     #[derive(Serialize, Deserialize, Debug, PartialEq)]
-    struct Big { m: Matrix<f64> }
+    struct Big {
+        m: Matrix<f64>,
+    }
     let rows = 100;
     let cols = 50;
     let mut data = Vec::with_capacity(rows * cols);
@@ -571,7 +640,9 @@ fn roundtrip_large_matrix() {
             data.push((r * 1000 + c) as f64);
         }
     }
-    rt(Big { m: Matrix::from_row_major(rows, cols, data) });
+    rt(Big {
+        m: Matrix::from_row_major(rows, cols, data),
+    });
 }
 
 /// Complex32 scalar and vec survive roundtrip preserving precision.
@@ -596,7 +667,9 @@ fn roundtrip_complex32() {
 #[test]
 fn roundtrip_matrix_with_specials() {
     #[derive(Serialize, Deserialize)]
-    struct MatS { m: Matrix<f64> }
+    struct MatS {
+        m: Matrix<f64>,
+    }
     let m = Matrix::from_row_major(
         2,
         3,
@@ -619,7 +692,10 @@ fn roundtrip_matrix_with_specials() {
 #[test]
 fn roundtrip_option_complex_inner() {
     #[derive(Serialize, Deserialize, Debug, PartialEq)]
-    struct Inner { k: u32, v: f64 }
+    struct Inner {
+        k: u32,
+        v: f64,
+    }
     #[derive(Serialize, Deserialize, Debug, PartialEq)]
     struct Outer {
         some_struct: Option<Inner>,

--- a/tests/write_read_roundtrip.rs
+++ b/tests/write_read_roundtrip.rs
@@ -60,10 +60,7 @@ fn roundtrip_with_attributes() {
 
     let ds = file.dataset("data").unwrap();
     let ds_attrs = ds.attrs().unwrap();
-    assert_eq!(
-        ds_attrs.get("unit"),
-        Some(&AttrValue::String("m/s".into()))
-    );
+    assert_eq!(ds_attrs.get("unit"), Some(&AttrValue::String("m/s".into())));
 }
 
 #[test]
@@ -96,21 +93,24 @@ fn roundtrip_group_with_dataset() {
 #[test]
 fn roundtrip_multiple_datasets() {
     let mut builder = FileBuilder::new();
-    builder
-        .create_dataset("x")
-        .with_f64_data(&[1.0, 2.0, 3.0]);
-    builder
-        .create_dataset("y")
-        .with_f64_data(&[4.0, 5.0, 6.0]);
-    builder
-        .create_dataset("z")
-        .with_i32_data(&[7, 8, 9]);
+    builder.create_dataset("x").with_f64_data(&[1.0, 2.0, 3.0]);
+    builder.create_dataset("y").with_f64_data(&[4.0, 5.0, 6.0]);
+    builder.create_dataset("z").with_i32_data(&[7, 8, 9]);
     let bytes = builder.finish().unwrap();
 
     let file = File::from_bytes(bytes).unwrap();
-    assert_eq!(file.dataset("x").unwrap().read_f64().unwrap(), vec![1.0, 2.0, 3.0]);
-    assert_eq!(file.dataset("y").unwrap().read_f64().unwrap(), vec![4.0, 5.0, 6.0]);
-    assert_eq!(file.dataset("z").unwrap().read_i32().unwrap(), vec![7, 8, 9]);
+    assert_eq!(
+        file.dataset("x").unwrap().read_f64().unwrap(),
+        vec![1.0, 2.0, 3.0]
+    );
+    assert_eq!(
+        file.dataset("y").unwrap().read_f64().unwrap(),
+        vec![4.0, 5.0, 6.0]
+    );
+    assert_eq!(
+        file.dataset("z").unwrap().read_i32().unwrap(),
+        vec![7, 8, 9]
+    );
 }
 
 #[test]
@@ -119,13 +119,14 @@ fn roundtrip_write_to_file() {
     let path = dir.path().join("test.h5");
 
     let mut builder = FileBuilder::new();
-    builder
-        .create_dataset("data")
-        .with_f64_data(&[1.0, 2.0]);
+    builder.create_dataset("data").with_f64_data(&[1.0, 2.0]);
     builder.write(&path).unwrap();
 
     let file = File::open(&path).unwrap();
-    assert_eq!(file.dataset("data").unwrap().read_f64().unwrap(), vec![1.0, 2.0]);
+    assert_eq!(
+        file.dataset("data").unwrap().read_f64().unwrap(),
+        vec![1.0, 2.0]
+    );
 }
 
 #[test]
@@ -234,7 +235,9 @@ fn roundtrip_compound_complex64() {
 fn roundtrip_userblock_512() {
     let mut builder = FileBuilder::new();
     builder.with_userblock(512);
-    builder.create_dataset("data").with_f64_data(&[1.0, 2.0, 3.0]);
+    builder
+        .create_dataset("data")
+        .with_f64_data(&[1.0, 2.0, 3.0]);
     let mut bytes = builder.finish().unwrap();
 
     // Verify userblock is at the start (512 zero bytes)
@@ -261,7 +264,9 @@ fn roundtrip_nested_groups() {
     outer.create_dataset("outer_data").with_f64_data(&[1.0]);
 
     let mut inner = outer.create_group("inner");
-    inner.create_dataset("inner_data").with_f64_data(&[2.0, 3.0]);
+    inner
+        .create_dataset("inner_data")
+        .with_f64_data(&[2.0, 3.0]);
     inner.set_attr("depth", AttrValue::I64(2));
     outer.add_group(inner.finish());
 
@@ -375,8 +380,12 @@ fn roundtrip_path_references() {
 
     // Create #refs# group with two child datasets
     let mut refs_grp = builder.create_group("#refs#");
-    refs_grp.create_dataset("child_a").with_f64_data(&[1.0, 2.0]);
-    refs_grp.create_dataset("child_b").with_i32_data(&[10, 20, 30]);
+    refs_grp
+        .create_dataset("child_a")
+        .with_f64_data(&[1.0, 2.0]);
+    refs_grp
+        .create_dataset("child_b")
+        .with_i32_data(&[10, 20, 30]);
     builder.add_group(refs_grp.finish());
 
     // Create a reference dataset pointing to those children by path
@@ -523,8 +532,12 @@ fn roundtrip_matlab_refs_subsystem_pattern() {
     let mut refs_grp = builder.create_group("#refs#");
 
     // String-value datasets (simulating MATLAB string objects)
-    refs_grp.create_dataset("a").with_u16_data(&[72, 101, 108, 108, 111]); // "Hello" UTF-16
-    refs_grp.create_dataset("b").with_u16_data(&[87, 111, 114, 108, 100]); // "World"
+    refs_grp
+        .create_dataset("a")
+        .with_u16_data(&[72, 101, 108, 108, 111]); // "Hello" UTF-16
+    refs_grp
+        .create_dataset("b")
+        .with_u16_data(&[87, 111, 114, 108, 100]); // "World"
     refs_grp.create_dataset("c").with_u16_data(&[70, 111, 111]); // "Foo"
 
     // A child dataset that itself references siblings (cross-references within #refs#)
@@ -619,8 +632,14 @@ fn roundtrip_varlen_ascii_on_nested_group() {
     assert!(datasets.contains(&"y".to_string()));
 
     // Verify data
-    assert_eq!(file.dataset("my_struct/x").unwrap().read_f64().unwrap(), vec![1.0, 2.0]);
-    assert_eq!(file.dataset("my_struct/y").unwrap().read_f64().unwrap(), vec![3.0, 4.0]);
+    assert_eq!(
+        file.dataset("my_struct/x").unwrap().read_f64().unwrap(),
+        vec![1.0, 2.0]
+    );
+    assert_eq!(
+        file.dataset("my_struct/y").unwrap().read_f64().unwrap(),
+        vec![3.0, 4.0]
+    );
 }
 
 #[test]
@@ -653,6 +672,12 @@ fn roundtrip_group_only_no_datasets() {
     assert!(groups.contains(&"b".to_string()));
     assert_eq!(outer_grp.datasets().unwrap().len(), 0);
 
-    assert_eq!(file.dataset("outer/a/val").unwrap().read_f64().unwrap(), vec![1.0]);
-    assert_eq!(file.dataset("outer/b/val").unwrap().read_i32().unwrap(), vec![42]);
+    assert_eq!(
+        file.dataset("outer/a/val").unwrap().read_f64().unwrap(),
+        vec![1.0]
+    );
+    assert_eq!(
+        file.dataset("outer/b/val").unwrap().read_i32().unwrap(),
+        vec![42]
+    );
 }

--- a/tests/zfp_crosscheck.rs
+++ b/tests/zfp_crosscheck.rs
@@ -65,8 +65,12 @@ fn fixture_dir() -> PathBuf {
 
 fn load_manifest() -> Manifest {
     let path = fixture_dir().join("manifest.json");
-    let text = fs::read_to_string(&path)
-        .unwrap_or_else(|e| panic!("read {}: {e}\n(run regen.py to produce fixtures)", path.display()));
+    let text = fs::read_to_string(&path).unwrap_or_else(|e| {
+        panic!(
+            "read {}: {e}\n(run regen.py to produce fixtures)",
+            path.display()
+        )
+    });
     serde_json::from_str(&text).expect("parse manifest.json")
 }
 
@@ -140,37 +144,85 @@ fn decode_and_max_err(
     let decoded = zfp::decompress(reference, dims, rate, elem_ty).map_err(|e| format!("{e:?}"))?;
     match dtype {
         "f32" => {
-            let expected: Vec<f32> = raw.chunks_exact(4).map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]])).collect();
-            let got: Vec<f32> = decoded.chunks_exact(4).map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]])).collect();
+            let expected: Vec<f32> = raw
+                .chunks_exact(4)
+                .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+                .collect();
+            let got: Vec<f32> = decoded
+                .chunks_exact(4)
+                .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+                .collect();
             if got.len() != expected.len() {
-                return Err(format!("decoded {} != expected {}", got.len(), expected.len()));
+                return Err(format!(
+                    "decoded {} != expected {}",
+                    got.len(),
+                    expected.len()
+                ));
             }
             Ok(max_abs(&expected, &got))
         }
         "f64" => {
-            let expected: Vec<f64> = raw.chunks_exact(8).map(|c| f64::from_le_bytes(c.try_into().unwrap())).collect();
-            let got: Vec<f64> = decoded.chunks_exact(8).map(|c| f64::from_le_bytes(c.try_into().unwrap())).collect();
+            let expected: Vec<f64> = raw
+                .chunks_exact(8)
+                .map(|c| f64::from_le_bytes(c.try_into().unwrap()))
+                .collect();
+            let got: Vec<f64> = decoded
+                .chunks_exact(8)
+                .map(|c| f64::from_le_bytes(c.try_into().unwrap()))
+                .collect();
             if got.len() != expected.len() {
-                return Err(format!("decoded {} != expected {}", got.len(), expected.len()));
+                return Err(format!(
+                    "decoded {} != expected {}",
+                    got.len(),
+                    expected.len()
+                ));
             }
             Ok(max_abs(&expected, &got))
         }
         "i32" => {
-            let expected: Vec<i32> = raw.chunks_exact(4).map(|c| i32::from_le_bytes([c[0], c[1], c[2], c[3]])).collect();
-            let got: Vec<i32> = decoded.chunks_exact(4).map(|c| i32::from_le_bytes([c[0], c[1], c[2], c[3]])).collect();
+            let expected: Vec<i32> = raw
+                .chunks_exact(4)
+                .map(|c| i32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+                .collect();
+            let got: Vec<i32> = decoded
+                .chunks_exact(4)
+                .map(|c| i32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+                .collect();
             if got.len() != expected.len() {
-                return Err(format!("decoded {} != expected {}", got.len(), expected.len()));
+                return Err(format!(
+                    "decoded {} != expected {}",
+                    got.len(),
+                    expected.len()
+                ));
             }
-            let max = expected.iter().zip(got.iter()).map(|(&a, &b)| (a as f64 - b as f64).abs()).fold(0f64, f64::max);
+            let max = expected
+                .iter()
+                .zip(got.iter())
+                .map(|(&a, &b)| (a as f64 - b as f64).abs())
+                .fold(0f64, f64::max);
             Ok(max)
         }
         "i64" => {
-            let expected: Vec<i64> = raw.chunks_exact(8).map(|c| i64::from_le_bytes(c.try_into().unwrap())).collect();
-            let got: Vec<i64> = decoded.chunks_exact(8).map(|c| i64::from_le_bytes(c.try_into().unwrap())).collect();
+            let expected: Vec<i64> = raw
+                .chunks_exact(8)
+                .map(|c| i64::from_le_bytes(c.try_into().unwrap()))
+                .collect();
+            let got: Vec<i64> = decoded
+                .chunks_exact(8)
+                .map(|c| i64::from_le_bytes(c.try_into().unwrap()))
+                .collect();
             if got.len() != expected.len() {
-                return Err(format!("decoded {} != expected {}", got.len(), expected.len()));
+                return Err(format!(
+                    "decoded {} != expected {}",
+                    got.len(),
+                    expected.len()
+                ));
             }
-            let max = expected.iter().zip(got.iter()).map(|(&a, &b)| (a as f64 - b as f64).abs()).fold(0f64, f64::max);
+            let max = expected
+                .iter()
+                .zip(got.iter())
+                .map(|(&a, &b)| (a as f64 - b as f64).abs())
+                .fold(0f64, f64::max);
             Ok(max)
         }
         other => Err(format!("unknown dtype {other}")),


### PR DESCRIPTION
Follow-up to #9. Adds a `lint` job to CI that runs `cargo fmt --all -- --check` and `cargo clippy --features serde --all-targets -- -D warnings`, and brings the existing codebase to a passing state under both.

## Two commits

**`Apply cargo fmt and quiet clippy`** (cleanup): mostly mechanical rustfmt reflow across 58 files. Two real clippy findings genuinely fixed:
- `src/attribute.rs`: replaced a `while ... { ...; break; }` with `if` (the loop never iterated twice).
- `src/mat/de/value_de.rs`: dropped an unused `'de` lifetime on `mismatch`.

A `[lints.clippy]` table in `Cargo.toml` mutes style-preference lints crate-wide (`too_many_arguments`, `vec_init_then_push`, `same_item_push`, `needless_range_loop`, `collapsible_if/match/else_if`, `manual_div_ceil`, `manual_is_multiple_of`, `unnecessary_map_or`, `approx_constant`). The rest of the clippy surface stays on, so genuinely problematic patterns still fail the build.

**`Enforce fmt and clippy in CI`** (workflow): adds the `lint` job to `.github/workflows/ci.yml`. Fast — no test compilation, just `clippy` + `rustfmt` rustup components plus the existing `Swatinem/rust-cache`.

## Test plan
- [x] `cargo fmt --all -- --check` passes locally
- [x] `cargo clippy --features serde --all-targets --locked -- -D warnings` passes locally
- [x] `cargo test --features serde` still passes (537 tests, no regressions from the cleanup)
- [ ] CI green on first run