### PR TITLE
Add Matrix<Complex*> serde support; bump to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this crate are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this crate follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) under Cargo's pre-1.0 conventions: a `0.x.0` bump may be breaking, `0.x.y` is not.
+
+## [Unreleased]
+
+## [0.5.0]
+
+### Added
+
+- `Matrix<Complex64>` and `Matrix<Complex32>` serde roundtrip support, including the empty (`0×0`, `0×N`, `N×0`) path. Empty complex matrices now write a compound `{real, imag}` HDF5 dataset on disk and preserve their shape across roundtrip; previously they collapsed to an `f64`-empty dataset and lost the complex class.
+- Sealed `mat::MatElement` trait. Implemented for `f32`, `f64`, all signed and unsigned integer primitives (`i8` through `i64`, `u8` through `u64`), `bool`, `Complex32`, and `Complex64`. Adding a new element type to `Matrix<T>` now requires a corresponding `MatElement` impl plus matching dispatch in the MAT (de)serializer. Missing dispatch surfaces as a compile error rather than silent class loss on the empty-matrix path.
+
+### Changed
+
+- **Breaking.** `Matrix<T>`'s `Serialize` / `Deserialize` impls now require `T: MatElement` instead of `T: 'static`. Downstream code parameterizing `Matrix<T>` with a non-numeric `T` (anything outside the impl set above) will no longer compile. Such uses already produced malformed MAT files at runtime, so the new bound converts a runtime failure into a compile error.
+- The MAT serde deserializer now flattens 1×N and N×1 `Matrix` / `ComplexMatrix` values to a 1-D sequence inside `deserialize_any`, matching the existing behavior of `deserialize_seq`. This means untagged enums, `serde::de::Content` roundtrips, and custom `Visitor` impls that previously discriminated on the 2-D rows-of-rows shape when one axis was 1 will now see a flat sequence. Values with both axes greater than 1 still surface as a 2-D rows-of-rows.
+- Numeric / complex dataset readers no longer collapse a 1×N or N×1 dataset to a flat vector at the value layer. Shape is preserved through `MatValue::Matrix` / `ComplexMatrix`, and any flattening for `Vec<T>` callers happens at the serde-deserializer level (above). Direct consumers of `pub(crate)` value APIs are unaffected; this is an internal cleanup that fixes column-vector roundtrip ambiguity.
+
+[Unreleased]: https://github.com/stephenberry/hdf5-pure/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/stephenberry/hdf5-pure/releases/tag/v0.5.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "hdf5-pure"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "byteorder",
  "crc32fast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdf5-pure"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 license = "MIT"
 description = "Pure-Rust HDF5 writer library (WASM-compatible, no C dependencies)"

--- a/src/mat/de/reader.rs
+++ b/src/mat/de/reader.rs
@@ -53,6 +53,12 @@ fn read_dataset(ds: &Dataset<'_>) -> Result<MatValue, MatError> {
     let class = class.unwrap_or_else(|| class_from_dtype(&dtype));
 
     if is_empty {
+        // Complex compound types preserve their shape and class so a 0×0
+        // `Matrix<Complex*>` round-trips back to a 0×0 complex matrix
+        // rather than collapsing to a numeric empty vec.
+        if matches!(class, MatClass::Double | MatClass::Single) && is_complex_dtype(&dtype) {
+            return Ok(empty_complex_value(class, &shape));
+        }
         // Empty numeric/char: produce an empty 1-D vec of the correct tag.
         return Ok(empty_value_for_class(class));
     }
@@ -114,6 +120,26 @@ fn is_empty_attr(attrs: &HashMap<String, AttrValue>) -> bool {
         Some(AttrValue::I64(v)) => *v != 0,
         Some(AttrValue::I32(v)) => *v != 0,
         _ => false,
+    }
+}
+
+/// Build an empty `ComplexMatrix*` whose `(rows, cols)` matches the dataspace
+/// shape, so deserializing into `Matrix<Complex*>` recovers the original
+/// shape (0×0, 0×N, N×0) instead of collapsing to 1×0.
+fn empty_complex_value(class: MatClass, shape: &[u64]) -> MatValue {
+    let (rows, cols, _total) = shape_decomposition(shape);
+    match class {
+        MatClass::Double => MatValue::ComplexMatrix64 {
+            rows,
+            cols,
+            pairs: Vec::new(),
+        },
+        MatClass::Single => MatValue::ComplexMatrix32 {
+            rows,
+            cols,
+            pairs: Vec::new(),
+        },
+        _ => unreachable!("empty_complex_value called with non-float class"),
     }
 }
 
@@ -193,7 +219,14 @@ fn read_numeric(ds: &Dataset<'_>, shape: &[u64], class: MatClass) -> Result<MatV
     // 2-D dataset. Preserve the MATLAB [rows, cols] shape even when one dim
     // is 1 — Matrix<T> needs this to distinguish row vs column vectors. The
     // deserializer flattens to a plain sequence for Vec<T> callers.
-    let matrix = transpose_col_major_to_row_major(flat, rows, cols)?;
+    // Skip the transpose when one dim is 1: column-major and row-major
+    // orderings are identical for 1×N / N×1, so the call would be a no-op
+    // copy.
+    let matrix = if rows == 1 || cols == 1 {
+        flat
+    } else {
+        transpose_col_major_to_row_major(flat, rows, cols)?
+    };
     Ok(MatValue::Matrix {
         rows,
         cols,
@@ -304,33 +337,39 @@ fn read_complex(ds: &Dataset<'_>, shape: &[u64], class: MatClass) -> Result<MatV
             let pairs = parse_complex64_pairs(&bytes, total)?;
             if total == 1 {
                 let (re, im) = pairs[0];
-                Ok(MatValue::ComplexScalar64 { re, im })
-            } else if rows == 1 || cols == 1 {
-                Ok(MatValue::ComplexVec64(pairs))
-            } else {
-                let row_major = transpose_pairs_col_to_row(pairs, rows, cols);
-                Ok(MatValue::ComplexMatrix64 {
-                    rows,
-                    cols,
-                    pairs: row_major,
-                })
+                return Ok(MatValue::ComplexScalar64 { re, im });
             }
+            // Preserve the MATLAB [rows, cols] shape even when one dim is 1,
+            // so `Matrix<Complex64>` round-trips as a row vs column vector.
+            // The deserializer flattens to a plain sequence for
+            // `Vec<Complex64>` callers.
+            let row_major = if rows == 1 || cols == 1 {
+                pairs
+            } else {
+                transpose_pairs_col_to_row(pairs, rows, cols)
+            };
+            Ok(MatValue::ComplexMatrix64 {
+                rows,
+                cols,
+                pairs: row_major,
+            })
         }
         MatClass::Single => {
             let pairs = parse_complex32_pairs(&bytes, total)?;
             if total == 1 {
                 let (re, im) = pairs[0];
-                Ok(MatValue::ComplexScalar32 { re, im })
-            } else if rows == 1 || cols == 1 {
-                Ok(MatValue::ComplexVec32(pairs))
-            } else {
-                let row_major = transpose_pairs_col_to_row(pairs, rows, cols);
-                Ok(MatValue::ComplexMatrix32 {
-                    rows,
-                    cols,
-                    pairs: row_major,
-                })
+                return Ok(MatValue::ComplexScalar32 { re, im });
             }
+            let row_major = if rows == 1 || cols == 1 {
+                pairs
+            } else {
+                transpose_pairs_col_to_row(pairs, rows, cols)
+            };
+            Ok(MatValue::ComplexMatrix32 {
+                rows,
+                cols,
+                pairs: row_major,
+            })
         }
         _ => Err(MatError::Custom(
             "complex compound on non-float class".into(),

--- a/src/mat/de/value_de.rs
+++ b/src/mat/de/value_de.rs
@@ -13,7 +13,7 @@ use serde::forward_to_deserialize_any;
 
 use crate::mat::complex::{COMPLEX32_SENTINEL, COMPLEX64_SENTINEL};
 use crate::mat::error::MatError;
-use crate::mat::matrix::MATRIX_SENTINEL;
+use crate::mat::matrix::{MATRIX_COMPLEX32_SENTINEL, MATRIX_COMPLEX64_SENTINEL, MATRIX_SENTINEL};
 use crate::mat::value::{MatValue, NumVec, ScalarNum};
 
 // ---------------------------------------------------------------------------
@@ -184,6 +184,15 @@ impl<'de> Deserializer<'de> for MatValueDeserializer {
             MatValue::ComplexVec32(pairs) => {
                 visitor.visit_seq(ComplexPairsSeq::Vec32(pairs.into_iter().collect()))
             }
+            // A degenerate 2-D complex matrix (1×N or N×1) flattens to a
+            // sequence so `Vec<Complex*>` deserializes from either
+            // orientation, matching the numeric `Matrix` flatten above.
+            MatValue::ComplexMatrix64 { rows, cols, pairs } if rows == 1 || cols == 1 => {
+                visitor.visit_seq(ComplexPairsSeq::Vec64(pairs.into_iter().collect()))
+            }
+            MatValue::ComplexMatrix32 { rows, cols, pairs } if rows == 1 || cols == 1 => {
+                visitor.visit_seq(ComplexPairsSeq::Vec32(pairs.into_iter().collect()))
+            }
             MatValue::ComplexMatrix64 { rows, cols, pairs } => {
                 visitor.visit_seq(ComplexMatrixRowsSeq::new64(rows, cols, pairs))
             }
@@ -238,22 +247,48 @@ impl<'de> Deserializer<'de> for MatValueDeserializer {
         visitor: V,
     ) -> Result<V::Value, MatError> {
         match name {
-            MATRIX_SENTINEL => match self.value {
-                MatValue::Matrix { rows, cols, vec } => {
-                    visitor.visit_map(MatrixStructMap::new(rows, cols, vec))
+            // The three Matrix sentinels (numeric and the two complex
+            // variants) all consume the same set of `MatValue` shapes; the
+            // sentinel name only matters at serialize time, where it
+            // preserves the element class for an empty Vec.
+            MATRIX_SENTINEL | MATRIX_COMPLEX64_SENTINEL | MATRIX_COMPLEX32_SENTINEL => {
+                match self.value {
+                    MatValue::Matrix { rows, cols, vec } => {
+                        visitor.visit_map(MatrixStructMap::numeric(rows, cols, vec))
+                    }
+                    // Allow deserializing a scalar or 1-D vec as a Matrix
+                    // (treating it as rows=1 or single-element).
+                    MatValue::Vec1D(v) => {
+                        let len = v.len();
+                        visitor.visit_map(MatrixStructMap::numeric(1, len, v))
+                    }
+                    MatValue::Scalar(s) => {
+                        let v = NumVec::from_single(s);
+                        visitor.visit_map(MatrixStructMap::numeric(1, 1, v))
+                    }
+                    MatValue::ComplexMatrix64 { rows, cols, pairs } => {
+                        visitor.visit_map(MatrixStructMap::complex64(rows, cols, pairs))
+                    }
+                    MatValue::ComplexMatrix32 { rows, cols, pairs } => {
+                        visitor.visit_map(MatrixStructMap::complex32(rows, cols, pairs))
+                    }
+                    MatValue::ComplexVec64(pairs) => {
+                        let len = pairs.len();
+                        visitor.visit_map(MatrixStructMap::complex64(1, len, pairs))
+                    }
+                    MatValue::ComplexVec32(pairs) => {
+                        let len = pairs.len();
+                        visitor.visit_map(MatrixStructMap::complex32(1, len, pairs))
+                    }
+                    MatValue::ComplexScalar64 { re, im } => {
+                        visitor.visit_map(MatrixStructMap::complex64(1, 1, vec![(re, im)]))
+                    }
+                    MatValue::ComplexScalar32 { re, im } => {
+                        visitor.visit_map(MatrixStructMap::complex32(1, 1, vec![(re, im)]))
+                    }
+                    other => mismatch("Matrix", other),
                 }
-                // Allow deserializing a scalar or 1-D vec as a Matrix
-                // (treating it as rows=1 or single-element).
-                MatValue::Vec1D(v) => {
-                    let len = v.len();
-                    visitor.visit_map(MatrixStructMap::new(1, len, v))
-                }
-                MatValue::Scalar(s) => {
-                    let v = NumVec::from_single(s);
-                    visitor.visit_map(MatrixStructMap::new(1, 1, v))
-                }
-                other => mismatch("Matrix", other),
-            },
+            }
             COMPLEX64_SENTINEL => match self.value {
                 MatValue::ComplexScalar64 { re, im } => {
                     visitor.visit_map(ComplexStructMap64::new(re, im))
@@ -330,6 +365,13 @@ fn dispatch_any<'de, V: Visitor<'de>>(value: MatValue, visitor: V) -> Result<V::
         },
         MatValue::String(s) => visitor.visit_string(s),
         MatValue::Vec1D(v) => visitor.visit_seq(Vec1DSeq::new(v)),
+        // Match `deserialize_seq`: a degenerate 2-D matrix (1×N or N×1)
+        // flattens so callers going through `deserialize_any` (untagged
+        // enums, custom Visitor impls, serde-derive's `Content` round-trip)
+        // see the same orientation-agnostic sequence as `Vec<T>` callers.
+        MatValue::Matrix { rows, cols, vec } if rows == 1 || cols == 1 => {
+            visitor.visit_seq(Vec1DSeq::new(vec))
+        }
         MatValue::Matrix { rows, cols, vec } => {
             visitor.visit_seq(MatrixRowsSeq::new(rows, cols, vec))
         }
@@ -339,6 +381,12 @@ fn dispatch_any<'de, V: Visitor<'de>>(value: MatValue, visitor: V) -> Result<V::
             visitor.visit_seq(ComplexPairsSeq::Vec64(pairs.into_iter().collect()))
         }
         MatValue::ComplexVec32(pairs) => {
+            visitor.visit_seq(ComplexPairsSeq::Vec32(pairs.into_iter().collect()))
+        }
+        MatValue::ComplexMatrix64 { rows, cols, pairs } if rows == 1 || cols == 1 => {
+            visitor.visit_seq(ComplexPairsSeq::Vec64(pairs.into_iter().collect()))
+        }
+        MatValue::ComplexMatrix32 { rows, cols, pairs } if rows == 1 || cols == 1 => {
             visitor.visit_seq(ComplexPairsSeq::Vec32(pairs.into_iter().collect()))
         }
         MatValue::ComplexMatrix64 { rows, cols, pairs } => {
@@ -779,7 +827,13 @@ struct MatrixStructMap {
     state: MatrixState,
     rows: usize,
     cols: usize,
-    data: Option<NumVec>,
+    data: Option<MatrixData>,
+}
+
+enum MatrixData {
+    Numeric(NumVec),
+    Complex64(Vec<(f64, f64)>),
+    Complex32(Vec<(f32, f32)>),
 }
 
 enum MatrixState {
@@ -793,12 +847,30 @@ enum MatrixState {
 }
 
 impl MatrixStructMap {
-    fn new(rows: usize, cols: usize, vec: NumVec) -> Self {
+    fn numeric(rows: usize, cols: usize, vec: NumVec) -> Self {
         Self {
             state: MatrixState::NeedRowsKey,
             rows,
             cols,
-            data: Some(vec),
+            data: Some(MatrixData::Numeric(vec)),
+        }
+    }
+
+    fn complex64(rows: usize, cols: usize, pairs: Vec<(f64, f64)>) -> Self {
+        Self {
+            state: MatrixState::NeedRowsKey,
+            rows,
+            cols,
+            data: Some(MatrixData::Complex64(pairs)),
+        }
+    }
+
+    fn complex32(rows: usize, cols: usize, pairs: Vec<(f32, f32)>) -> Self {
+        Self {
+            state: MatrixState::NeedRowsKey,
+            rows,
+            cols,
+            data: Some(MatrixData::Complex32(pairs)),
         }
     }
 }
@@ -833,8 +905,12 @@ impl<'de> MapAccess<'de> for MatrixStructMap {
             }
             MatrixState::NeedDataValue => {
                 self.state = MatrixState::Done;
-                let data = self.data.take().unwrap();
-                seed.deserialize(MatValueDeserializer::new(MatValue::Vec1D(data)))
+                let value = match self.data.take().unwrap() {
+                    MatrixData::Numeric(v) => MatValue::Vec1D(v),
+                    MatrixData::Complex64(pairs) => MatValue::ComplexVec64(pairs),
+                    MatrixData::Complex32(pairs) => MatValue::ComplexVec32(pairs),
+                };
+                seed.deserialize(MatValueDeserializer::new(value))
             }
             _ => Err(MatError::Custom("matrix map value before key".into())),
         }

--- a/src/mat/matrix.rs
+++ b/src/mat/matrix.rs
@@ -11,6 +11,27 @@
 //!
 //! `Vec<Vec<T>>` is also recognized by the serializer as a 2-D matrix
 //! (checked for ragged rows). Use `Matrix` when you want an unambiguous API.
+//!
+//! # Why three sentinel constants
+//!
+//! [`MATRIX_SENTINEL`], [`MATRIX_COMPLEX64_SENTINEL`], and
+//! [`MATRIX_COMPLEX32_SENTINEL`] are not redundant. The element class for a
+//! non-empty `Matrix<T>` can always be recovered from the serialized data
+//! (the inner `Vec<T>` carries enough type information through the seq
+//! unification path), so a single sentinel would suffice for the common
+//! case.
+//!
+//! Empty matrices break that. A 0×0 / 0×N / N×0 `Matrix<Complex64>`
+//! produces a `Vec<Complex64>` of length zero; the seq unification observes
+//! no elements, defaults to an `f64`-empty `NumVec`, and the serializer
+//! would emit a numeric (non-complex) HDF5 dataset. The dedicated
+//! `Matrix<Complex64>` / `Matrix<Complex32>` sentinels carry the element
+//! class through the empty path so the on-disk dataset is the correct
+//! compound `{real, imag}` shape. The corresponding sealed
+//! [`MatElement`] trait makes the sentinel choice a compile-time property
+//! of `T`; missing dispatch surfaces as a compile error rather than a
+//! silent class loss. Do not collapse the three sentinels into one without
+//! re-solving the empty-shape problem.
 
 use core::fmt;
 
@@ -18,8 +39,75 @@ use serde::de::{self, MapAccess, Visitor};
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-/// Sentinel struct name recognized by the MAT serializer/deserializer.
+use crate::mat::complex::{Complex32, Complex64};
+
+/// Sentinel struct name recognized by the MAT serializer/deserializer for a
+/// numeric `Matrix<T>` whose element class is carried by the serialized data.
 pub(crate) const MATRIX_SENTINEL: &str = "__hdf5_pure_mat_Matrix__";
+
+/// Sentinel for `Matrix<Complex64>`. Distinct from `MATRIX_SENTINEL` so an
+/// empty 0×0 / 0×N / N×0 matrix still writes as a complex (compound)
+/// dataset on disk: with no elements, the inner `Vec<Complex64>` would
+/// otherwise collapse to a default `f64`-empty NumVec and lose the class.
+pub(crate) const MATRIX_COMPLEX64_SENTINEL: &str = "__hdf5_pure_mat_MatrixComplex64__";
+
+/// Sentinel for `Matrix<Complex32>`. See [`MATRIX_COMPLEX64_SENTINEL`].
+pub(crate) const MATRIX_COMPLEX32_SENTINEL: &str = "__hdf5_pure_mat_MatrixComplex32__";
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// Element types permitted as the parameter `T` in [`Matrix<T>`] for MAT
+/// (de)serialization.
+///
+/// This trait is sealed: it cannot be implemented outside this crate. MAT
+/// v7.3 admits only a fixed set of numeric classes (IEEE float and integer
+/// primitives plus the two complex compound types), so opening the trait
+/// would only let downstream code construct `Matrix<T>` values that produce
+/// malformed MAT files at runtime. Sealing turns that into a compile error.
+///
+/// Each impl supplies a [`SENTINEL`](Self::SENTINEL) string that the MAT
+/// serializer/deserializer use to (a) recognize the struct as a `Matrix<T>`
+/// and (b) preserve the element class on the 0-element path, where the
+/// inner data vector carries no class information of its own.
+///
+/// Adding a new element type means: extend the impls below AND add matching
+/// dispatch arms in `mat::ser::value_ser` and `mat::de::value_de`. The
+/// sentinel constant is required to (de)serialize a `Matrix<T>`, so missing
+/// dispatch surfaces as a compile error rather than silently writing the
+/// wrong class.
+pub trait MatElement: sealed::Sealed {
+    /// Sentinel struct name the MAT (de)serializer matches on.
+    const SENTINEL: &'static str;
+}
+
+macro_rules! impl_mat_element {
+    ($($t:ty => $sentinel:ident),* $(,)?) => {
+        $(
+            impl sealed::Sealed for $t {}
+            impl MatElement for $t {
+                const SENTINEL: &'static str = $sentinel;
+            }
+        )*
+    };
+}
+
+impl_mat_element! {
+    f64 => MATRIX_SENTINEL,
+    f32 => MATRIX_SENTINEL,
+    i8 => MATRIX_SENTINEL,
+    i16 => MATRIX_SENTINEL,
+    i32 => MATRIX_SENTINEL,
+    i64 => MATRIX_SENTINEL,
+    u8 => MATRIX_SENTINEL,
+    u16 => MATRIX_SENTINEL,
+    u32 => MATRIX_SENTINEL,
+    u64 => MATRIX_SENTINEL,
+    bool => MATRIX_SENTINEL,
+    Complex64 => MATRIX_COMPLEX64_SENTINEL,
+    Complex32 => MATRIX_COMPLEX32_SENTINEL,
+}
 
 /// A dense 2-D matrix stored in row-major order (Rust convention).
 ///
@@ -85,12 +173,13 @@ impl<T: Clone + Default> Matrix<T> {
 // Serialize / Deserialize
 // ---------------------------------------------------------------------------
 
-impl<T: Serialize> Serialize for Matrix<T> {
+impl<T: MatElement + Serialize> Serialize for Matrix<T> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // We use a struct with the sentinel name so the MAT serializer can
         // recognize this as a matrix and apply column-major transposition.
-        // A generic serializer (serde_json, ...) sees an ordinary struct.
-        let mut s = serializer.serialize_struct(MATRIX_SENTINEL, 3)?;
+        // A generic serializer (serde_json, ...) sees an ordinary struct
+        // whose name is `T::SENTINEL` (one of the MATRIX_*_SENTINEL constants).
+        let mut s = serializer.serialize_struct(T::SENTINEL, 3)?;
         s.serialize_field("rows", &self.rows)?;
         s.serialize_field("cols", &self.cols)?;
         s.serialize_field("data", &self.data)?;
@@ -98,7 +187,7 @@ impl<T: Serialize> Serialize for Matrix<T> {
     }
 }
 
-impl<'de, T: Deserialize<'de>> Deserialize<'de> for Matrix<T> {
+impl<'de, T: MatElement + Deserialize<'de>> Deserialize<'de> for Matrix<T> {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         struct MatrixVisitor<T>(core::marker::PhantomData<T>);
 
@@ -140,7 +229,7 @@ impl<'de, T: Deserialize<'de>> Deserialize<'de> for Matrix<T> {
         }
 
         deserializer.deserialize_struct(
-            MATRIX_SENTINEL,
+            T::SENTINEL,
             &["rows", "cols", "data"],
             MatrixVisitor(core::marker::PhantomData),
         )

--- a/src/mat/mod.rs
+++ b/src/mat/mod.rs
@@ -84,7 +84,7 @@ pub use options::{
 #[cfg(feature = "serde")]
 pub use complex::{Complex32, Complex64};
 #[cfg(feature = "serde")]
-pub use matrix::Matrix;
+pub use matrix::{MatElement, Matrix};
 
 #[cfg(feature = "serde")]
 use serde::Serialize;

--- a/src/mat/ser/emit_with_builder.rs
+++ b/src/mat/ser/emit_with_builder.rs
@@ -362,7 +362,7 @@ fn emit_scalar_at_struct(
 
 fn emit_vec_at_builder(mb: &mut MatBuilder, name: &str, v: NumVec) -> Result<(), MatError> {
     let dims = mb.vector_dims(v.len());
-    if v.len() == 0 {
+    if v.is_empty() {
         return mb
             .write_empty(name, scalar_class(v.tag()), &dims)
             .map(|_| ());
@@ -388,7 +388,7 @@ fn emit_vec_at_builder(mb: &mut MatBuilder, name: &str, v: NumVec) -> Result<(),
 
 fn emit_vec_at_struct(sw: &mut StructWriter, name: &str, v: NumVec) -> Result<(), MatError> {
     let dims = sw.vector_dims(v.len());
-    if v.len() == 0 {
+    if v.is_empty() {
         return sw
             .write_empty(name, scalar_class(v.tag()), &dims)
             .map(|_| ());

--- a/src/mat/ser/value_ser.rs
+++ b/src/mat/ser/value_ser.rs
@@ -11,7 +11,7 @@ use serde::ser::{
 
 use crate::mat::complex::{COMPLEX32_SENTINEL, COMPLEX64_SENTINEL};
 use crate::mat::error::MatError;
-use crate::mat::matrix::MATRIX_SENTINEL;
+use crate::mat::matrix::{MATRIX_COMPLEX32_SENTINEL, MATRIX_COMPLEX64_SENTINEL, MATRIX_SENTINEL};
 use crate::mat::utf16;
 
 use crate::mat::value::{MatValue, NumVec, ScalarNum, ScalarTag};
@@ -172,7 +172,13 @@ impl Serializer for ValueSerializer {
 
     fn serialize_struct(self, name: &'static str, _len: usize) -> Result<StructSer, MatError> {
         Ok(match name {
-            MATRIX_SENTINEL => StructSer::Matrix(MatrixFields::default()),
+            MATRIX_SENTINEL => StructSer::Matrix(MatrixFields::default(), MatrixKind::Numeric),
+            MATRIX_COMPLEX64_SENTINEL => {
+                StructSer::Matrix(MatrixFields::default(), MatrixKind::Complex64)
+            }
+            MATRIX_COMPLEX32_SENTINEL => {
+                StructSer::Matrix(MatrixFields::default(), MatrixKind::Complex32)
+            }
             COMPLEX64_SENTINEL => StructSer::Complex64(ComplexFields::default()),
             COMPLEX32_SENTINEL => StructSer::Complex32(ComplexFields::default()),
             _ => StructSer::Plain(PlainStructFields::default()),
@@ -461,10 +467,21 @@ impl SerializeMap for MapSer {
 // ---------------------------------------------------------------------------
 
 pub(crate) enum StructSer {
-    Matrix(MatrixFields),
+    Matrix(MatrixFields, MatrixKind),
     Complex64(ComplexFields<f64>),
     Complex32(ComplexFields<f32>),
     Plain(PlainStructFields),
+}
+
+/// Element class hint for a `Matrix<T>` sentinel. Carried through from the
+/// chosen sentinel name (see `matrix::matrix_sentinel_for`) so that empty
+/// matrices, where the inner `Vec<T>` cannot reveal `T`, still emit with the
+/// right MATLAB class.
+#[derive(Clone, Copy)]
+pub(crate) enum MatrixKind {
+    Numeric,
+    Complex64,
+    Complex32,
 }
 
 #[derive(Default)]
@@ -495,7 +512,7 @@ impl SerializeStruct for StructSer {
         value: &T,
     ) -> Result<(), MatError> {
         match self {
-            StructSer::Matrix(fields) => match key {
+            StructSer::Matrix(fields, _) => match key {
                 "rows" => {
                     let v = value.serialize(ValueSerializer)?;
                     fields.rows = Some(expect_usize(v, "Matrix::rows")?);
@@ -543,7 +560,7 @@ impl SerializeStruct for StructSer {
     fn end(self) -> Result<MatValue, MatError> {
         match self {
             StructSer::Plain(ps) => Ok(MatValue::Struct(ps.fields)),
-            StructSer::Matrix(fields) => matrix_from_fields(fields),
+            StructSer::Matrix(fields, kind) => matrix_from_fields(fields, kind),
             StructSer::Complex64(fields) => Ok(MatValue::ComplexScalar64 {
                 re: fields
                     .real
@@ -564,7 +581,7 @@ impl SerializeStruct for StructSer {
     }
 }
 
-fn matrix_from_fields(fields: MatrixFields) -> Result<MatValue, MatError> {
+fn matrix_from_fields(fields: MatrixFields, kind: MatrixKind) -> Result<MatValue, MatError> {
     let rows = fields
         .rows
         .ok_or_else(|| MatError::MissingField("rows".into()))?;
@@ -574,30 +591,58 @@ fn matrix_from_fields(fields: MatrixFields) -> Result<MatValue, MatError> {
     let data = fields
         .data
         .ok_or_else(|| MatError::MissingField("data".into()))?;
-    let vec = match data {
-        MatValue::Vec1D(v) => v,
-        // Serializing `Vec<T>` of length 0 with T unknown yields F64.
-        // If rows*cols == 0 we let it pass as an empty NumVec of that tag.
-        MatValue::Scalar(s) if rows * cols == 1 => {
-            let mut nv = NumVec::empty_with_tag(s.tag());
-            nv.push(s)?;
-            nv
-        }
-        other => {
+    let total = rows * cols;
+    let length_check = |actual: usize| -> Result<(), MatError> {
+        if actual != total {
             return Err(MatError::Custom(format!(
-                "Matrix::data must be a Vec<T>, got {}",
-                other.kind()
+                "Matrix::data length {} does not match rows*cols = {}",
+                actual, total
             )));
         }
+        Ok(())
     };
-    if vec.len() != rows * cols {
-        return Err(MatError::Custom(format!(
-            "Matrix::data length {} does not match rows*cols = {}",
-            vec.len(),
-            rows * cols
-        )));
+    match (kind, data) {
+        // Numeric Matrix<T>: data unifies to Vec1D of T's tag. Matrix<Complex*>
+        // does not land here; it carries `T::SENTINEL = MATRIX_COMPLEX{32,64}_SENTINEL`
+        // and routes to the dedicated Complex64 / Complex32 arms below.
+        (MatrixKind::Numeric, MatValue::Vec1D(vec)) => {
+            length_check(vec.len())?;
+            Ok(MatValue::Matrix { rows, cols, vec })
+        }
+        // Matrix<Complex64>: ComplexVec64 in the data slot, OR an empty
+        // Vec1D (the f64-default that an empty `Vec<Complex64>` collapses
+        // to in the seq path: with no elements observed, the seq
+        // unification can't recover T). The dedicated sentinel here lets
+        // us recover the class.
+        (MatrixKind::Complex64, MatValue::ComplexVec64(pairs)) => {
+            length_check(pairs.len())?;
+            Ok(MatValue::ComplexMatrix64 { rows, cols, pairs })
+        }
+        (MatrixKind::Complex64, MatValue::Vec1D(vec)) if vec.is_empty() => {
+            length_check(0)?;
+            Ok(MatValue::ComplexMatrix64 {
+                rows,
+                cols,
+                pairs: Vec::new(),
+            })
+        }
+        (MatrixKind::Complex32, MatValue::ComplexVec32(pairs)) => {
+            length_check(pairs.len())?;
+            Ok(MatValue::ComplexMatrix32 { rows, cols, pairs })
+        }
+        (MatrixKind::Complex32, MatValue::Vec1D(vec)) if vec.is_empty() => {
+            length_check(0)?;
+            Ok(MatValue::ComplexMatrix32 {
+                rows,
+                cols,
+                pairs: Vec::new(),
+            })
+        }
+        (_, other) => Err(MatError::Custom(format!(
+            "Matrix::data must be a Vec<T>, got {}",
+            other.kind()
+        ))),
     }
-    Ok(MatValue::Matrix { rows, cols, vec })
 }
 
 fn expect_usize(v: MatValue, field: &str) -> Result<usize, MatError> {

--- a/src/mat/value.rs
+++ b/src/mat/value.rs
@@ -85,6 +85,10 @@ impl NumVec {
         }
     }
 
+    pub(crate) fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     pub(crate) fn tag(&self) -> ScalarTag {
         match self {
             NumVec::Bool(_) => ScalarTag::Bool,

--- a/tests/serde_roundtrip.rs
+++ b/tests/serde_roundtrip.rs
@@ -327,6 +327,21 @@ fn roundtrip_matrix_f64() {
 }
 
 #[test]
+fn roundtrip_matrix_f64_column_vector() {
+    // N×1 column vector: shape must round-trip distinctly from 1×N.
+    rt(WithMatrix {
+        m: Matrix::from_row_major(4, 1, vec![1.0, 2.0, 3.0, 4.0]),
+    });
+}
+
+#[test]
+fn roundtrip_matrix_f64_row_vector() {
+    rt(WithMatrix {
+        m: Matrix::from_row_major(1, 4, vec![1.0, 2.0, 3.0, 4.0]),
+    });
+}
+
+#[test]
 fn roundtrip_nested() {
     rt(WithNested {
         x: 1.5,
@@ -411,6 +426,168 @@ fn roundtrip_complex_matrix() {
             vec![Complex64::new(1.0, 0.0), Complex64::new(0.0, 1.0)],
             vec![Complex64::new(-1.0, 0.0), Complex64::new(0.0, -1.0)],
         ],
+    });
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct WithMatrixComplex64 {
+    m: Matrix<Complex64>,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct WithMatrixComplex32 {
+    m: Matrix<Complex32>,
+}
+
+#[test]
+fn roundtrip_matrix_complex64_2d() {
+    rt(WithMatrixComplex64 {
+        m: Matrix::from_row_major(
+            2,
+            3,
+            vec![
+                Complex64::new(1.0, 0.5),
+                Complex64::new(2.0, 1.5),
+                Complex64::new(3.0, -0.5),
+                Complex64::new(-1.0, 0.0),
+                Complex64::new(0.0, 2.5),
+                Complex64::new(7.0, -7.0),
+            ],
+        ),
+    });
+}
+
+#[test]
+fn roundtrip_matrix_complex64_column_vector() {
+    // N×1 column vector: the orientation a downstream caller might choose
+    // when they need the legacy `[N, 1]` MATLAB shape for 1-D complex data.
+    rt(WithMatrixComplex64 {
+        m: Matrix::from_row_major(
+            4,
+            1,
+            vec![
+                Complex64::new(1.0, 0.0),
+                Complex64::new(0.0, 1.0),
+                Complex64::new(-1.0, 0.0),
+                Complex64::new(0.0, -1.0),
+            ],
+        ),
+    });
+}
+
+#[test]
+fn roundtrip_matrix_complex64_row_vector() {
+    rt(WithMatrixComplex64 {
+        m: Matrix::from_row_major(
+            1,
+            3,
+            vec![
+                Complex64::new(1.0, 0.0),
+                Complex64::new(2.0, 0.0),
+                Complex64::new(3.0, 0.0),
+            ],
+        ),
+    });
+}
+
+#[test]
+fn roundtrip_matrix_complex64_single_element() {
+    rt(WithMatrixComplex64 {
+        m: Matrix::from_row_major(1, 1, vec![Complex64::new(1.5, -2.5)]),
+    });
+}
+
+#[test]
+fn roundtrip_matrix_complex32_2d() {
+    // Asymmetric shape (3×2) so a row/col swap or transpose regression fails
+    // distinctly from the Complex64 2×3 pin above.
+    rt(WithMatrixComplex32 {
+        m: Matrix::from_row_major(
+            3,
+            2,
+            vec![
+                Complex32::new(1.0, 0.5),
+                Complex32::new(2.0, 1.5),
+                Complex32::new(3.0, -0.5),
+                Complex32::new(-1.0, 0.0),
+                Complex32::new(0.0, 2.5),
+                Complex32::new(7.0, -7.0),
+            ],
+        ),
+    });
+}
+
+#[test]
+fn roundtrip_matrix_complex32_column_vector() {
+    rt(WithMatrixComplex32 {
+        m: Matrix::from_row_major(
+            4,
+            1,
+            vec![
+                Complex32::new(1.0, 0.0),
+                Complex32::new(0.0, 1.0),
+                Complex32::new(-1.0, 0.0),
+                Complex32::new(0.0, -1.0),
+            ],
+        ),
+    });
+}
+
+#[test]
+fn roundtrip_matrix_complex32_row_vector() {
+    rt(WithMatrixComplex32 {
+        m: Matrix::from_row_major(
+            1,
+            3,
+            vec![
+                Complex32::new(1.0, 0.0),
+                Complex32::new(2.0, 0.0),
+                Complex32::new(3.0, 0.0),
+            ],
+        ),
+    });
+}
+
+#[test]
+fn roundtrip_matrix_complex32_single_element() {
+    rt(WithMatrixComplex32 {
+        m: Matrix::from_row_major(1, 1, vec![Complex32::new(1.5, -2.5)]),
+    });
+}
+
+/// Serialize once, assert the on-disk dtype is compound (real/imag), then
+/// deserialize from those same bytes and assert value equality. Folds the
+/// dtype check and the roundtrip into a single serialization.
+fn assert_empty_complex_compound_roundtrip<T>(value: T)
+where
+    T: Serialize + serde::de::DeserializeOwned + PartialEq + std::fmt::Debug,
+{
+    let bytes = mat::to_bytes(&value).expect("serialize");
+    let file = File::from_bytes(bytes.clone()).unwrap();
+    let dt = file.dataset("m").unwrap().dtype().unwrap();
+    assert!(
+        matches!(dt, hdf5_pure::DType::Compound(_)),
+        "expected compound (real/imag) datatype for empty complex Matrix, got {dt:?}"
+    );
+    let back: T = mat::from_bytes(&bytes).expect("deserialize");
+    assert_eq!(back, value);
+}
+
+#[test]
+fn empty_matrix_complex64_writes_compound_dataset() {
+    // A 0×0 Matrix<Complex64> has nothing in `data` for the seq path to
+    // observe, so without the dedicated sentinel the Vec<Complex64> would
+    // collapse to an f64-empty default and write as a numeric (non-complex)
+    // dataset. The sentinel name preserves the element class.
+    assert_empty_complex_compound_roundtrip(WithMatrixComplex64 {
+        m: Matrix::from_row_major(0, 0, Vec::<Complex64>::new()),
+    });
+}
+
+#[test]
+fn empty_matrix_complex32_writes_compound_dataset() {
+    assert_empty_complex_compound_roundtrip(WithMatrixComplex32 {
+        m: Matrix::from_row_major(0, 0, Vec::<Complex32>::new()),
     });
 }
 


### PR DESCRIPTION
## Summary

- Add serde roundtrip support for `Matrix<Complex64>` and `Matrix<Complex32>`, including the empty (`0×0`, `0×N`, `N×0`) path. Empty complex matrices now write a compound `{real, imag}` HDF5 dataset on disk and preserve their shape across roundtrip; previously they collapsed to an `f64`-empty dataset and lost the complex class.
- Replace the runtime `TypeId` dispatch behind the empty-class fix with a sealed `MatElement` trait. `Matrix<T>`'s `Serialize` / `Deserialize` impls now require `T: MatElement` instead of `T: 'static`. Adding a new element type requires a `MatElement` impl plus matching dispatch in the MAT (de)serializer; missing dispatch is a compile error rather than silent class loss on the empty path.
- Bump to `0.5.0` per Cargo pre-1.0 SemVer (the bound change is breaking).

See `CHANGELOG.md` for the full notes.

## Breaking changes (0.4 → 0.5)

1. `Matrix<T>`'s serde bound changes from `T: Serialize + 'static` to `T: MatElement + Serialize` (and equivalently for `Deserialize`). `MatElement` is sealed and implemented for `f32`, `f64`, all signed/unsigned integer primitives, `bool`, `Complex32`, and `Complex64`. Downstream `Matrix<T>` with a non-numeric `T` will no longer compile. Such uses already produced malformed MAT files at runtime, so this converts a silent runtime failure into a compile error.
2. The MAT serde deserializer now flattens 1×N and N×1 `Matrix` / `ComplexMatrix` values to a 1-D sequence inside `deserialize_any`, matching the existing behavior of `deserialize_seq`. Untagged enums, `serde::de::Content` roundtrips, and custom `Visitor` impls that previously discriminated on the 2-D rows-of-rows shape when one axis was 1 will now see a flat sequence. Values with both axes greater than 1 still surface as a 2-D rows-of-rows.
3. The numeric and complex dataset readers no longer collapse 1×N or N×1 datasets to a flat vector at the value layer; shape is preserved through `MatValue::Matrix` / `ComplexMatrix` and any flattening for `Vec<T>` callers happens at the serde-deserializer level. Direct consumers of `pub(crate)` value APIs are unaffected.

## Test plan

- [x] `cargo test --features serde` (549 tests, 0 failures across all suites)
- [x] New `tests/serde_roundtrip.rs` coverage for `Matrix<Complex64>` and `Matrix<Complex32>` at 2-D, column-vector, row-vector, single-element, and empty (compound dtype + shape preservation) shapes
- [x] Asymmetric shape pins on both `Complex64` (2×3) and `Complex32` (3×2) catch transpose / row-col-swap regressions in either direction
- [x] Empty-matrix tests assert the on-disk dtype is `Compound([(real, F*), (imag, F*)])` before deserializing, so a regression that loses the complex class fails distinctly from a value-equality regression
- [x] Pre-existing tests (numeric `Matrix<T>`, all integer widths, struct/cell/string roundtrips) continue to pass unchanged