### PR TITLE
Support paged Fixed Array data blocks (read + write)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Chunked datasets indexed by a Fixed Array now use the paged data block layout when the chunk count exceeds the page size (`2^max_nelmts_bits`, i.e. more than 1024 chunks at the default). Previously the writer always emitted a flat data block while still advertising the paged page size, producing files that a spec-compliant reader rejects as corrupt. The reader likewise now decodes paged Fixed Array data blocks (page-init bitmap plus fixed-stride, individually checksummed pages) instead of returning `paged Fixed Array data blocks not yet supported`. Verified both directions against the reference C HDF5 library. ([#14](https://github.com/stephenberry/hdf5-pure/issues/14))
+
 ## [0.5.0]
 
 ### Added

--- a/src/chunked_write.rs
+++ b/src/chunked_write.rs
@@ -501,37 +501,65 @@ pub fn build_fixed_array_at(
 
     assert_eq!(fahd.len(), fahd_total_size);
 
-    // Build FADB
+    // Append one element record (chunk address, plus filtered size + mask).
+    let write_element = |buf: &mut Vec<u8>, chunk: &WrittenChunk| {
+        match offset_size {
+            4 => buf.extend_from_slice(&(chunk.address as u32).to_le_bytes()),
+            _ => buf.extend_from_slice(&chunk.address.to_le_bytes()),
+        }
+        if has_filters {
+            // Compressed size, written using the variable chunk_size_bytes width.
+            let cs_bytes = chunk.compressed_size.to_le_bytes();
+            buf.extend_from_slice(&cs_bytes[..chunk_size_bytes]);
+            buf.extend_from_slice(&chunk.filter_mask.to_le_bytes());
+        }
+    };
+
+    // Build FADB prefix: signature + version + client_id + header address.
     let mut fadb = Vec::new();
     fadb.extend_from_slice(b"FADB");
     fadb.push(0); // version
     fadb.push(client_id);
-
-    // header address
     match offset_size {
         4 => fadb.extend_from_slice(&(fa_base_address as u32).to_le_bytes()),
-        8 => fadb.extend_from_slice(&fa_base_address.to_le_bytes()),
         _ => fadb.extend_from_slice(&fa_base_address.to_le_bytes()),
     }
 
-    // Element data
-    for chunk in chunks {
-        match offset_size {
-            4 => fadb.extend_from_slice(&(chunk.address as u32).to_le_bytes()),
-            8 => fadb.extend_from_slice(&chunk.address.to_le_bytes()),
-            _ => fadb.extend_from_slice(&chunk.address.to_le_bytes()),
+    let page_size = 1usize << max_bits;
+    if num_elements <= page_size {
+        // Non-paged: elements stored directly, then a single checksum.
+        for chunk in chunks {
+            write_element(&mut fadb, chunk);
         }
-        if has_filters {
-            // Write compressed size using chunk_size_bytes (variable width)
-            let cs_bytes = chunk.compressed_size.to_le_bytes();
-            fadb.extend_from_slice(&cs_bytes[..chunk_size_bytes]);
-            fadb.extend_from_slice(&chunk.filter_mask.to_le_bytes());
+        let fadb_checksum = jenkins_lookup3(&fadb);
+        fadb.extend_from_slice(&fadb_checksum.to_le_bytes());
+    } else {
+        // Paged: a page-init bitmap and checksum follow the prefix, then each
+        // page stores its elements followed by its own checksum. We write every
+        // chunk densely, so all pages are initialized.
+        let npages = num_elements.div_ceil(page_size);
+        let bitmap_size = npages.div_ceil(8);
+        let mut bitmap = vec![0u8; bitmap_size];
+        for page in 0..npages {
+            // Most-significant-bit-first ordering, matching H5VM_bit_set.
+            bitmap[page / 8] |= 1 << (7 - (page % 8));
+        }
+        fadb.extend_from_slice(&bitmap);
+        let prefix_checksum = jenkins_lookup3(&fadb);
+        fadb.extend_from_slice(&prefix_checksum.to_le_bytes());
+
+        for page in 0..npages {
+            let start = page * page_size;
+            let end = core::cmp::min(start + page_size, num_elements);
+            let mut page_buf = Vec::with_capacity((end - start) * elem_size);
+            for chunk in &chunks[start..end] {
+                write_element(&mut page_buf, chunk);
+            }
+            let page_checksum = jenkins_lookup3(&page_buf);
+            page_buf.extend_from_slice(&page_checksum.to_le_bytes());
+            fadb.extend_from_slice(&page_buf);
         }
     }
-
-    // FADB checksum
-    let fadb_checksum = jenkins_lookup3(&fadb);
-    fadb.extend_from_slice(&fadb_checksum.to_le_bytes());
 
     let mut combined = fahd;
     combined.extend_from_slice(&fadb);

--- a/src/chunked_write.rs
+++ b/src/chunked_write.rs
@@ -25,7 +25,7 @@ use crate::filters::{ChunkContext, ZfpElementTypeWhenEnabled, compress_chunk};
 /// the paged data-block layout. The value mirrors the HDF5 C library's
 /// `H5D_FARRAY_MAX_DBLK_PAGE_NELMTS_BITS`. The reader does not use this constant:
 /// it honors whatever page size a file declares in its FAHD.
-pub const FIXED_ARRAY_PAGE_BITS: u8 = 10;
+pub(crate) const FIXED_ARRAY_PAGE_BITS: u8 = 10;
 
 /// Round a file offset up to the next cache-line boundary.
 ///

--- a/src/chunked_write.rs
+++ b/src/chunked_write.rs
@@ -16,6 +16,17 @@ use crate::filter_pipeline::{
 };
 use crate::filters::{ChunkContext, ZfpElementTypeWhenEnabled, compress_chunk};
 
+/// Log2 of the Fixed Array data-block page size (`2^10 = 1024` elements).
+///
+/// Single source of truth for the page exponent the writer emits: it is both
+/// the `max_nelmts_bits` field stored in the Fixed Array header (FAHD) and the
+/// `max_dblk_page_nelmts_bits` field in the v4 chunked layout message, which the
+/// HDF5 spec requires to be equal. Above this many chunks the writer switches to
+/// the paged data-block layout. The value mirrors the HDF5 C library's
+/// `H5D_FARRAY_MAX_DBLK_PAGE_NELMTS_BITS`. The reader does not use this constant:
+/// it honors whatever page size a file declares in its FAHD.
+pub const FIXED_ARRAY_PAGE_BITS: u8 = 10;
+
 /// Round a file offset up to the next cache-line boundary.
 ///
 /// This ensures chunk data starts at an address that is a multiple of the
@@ -479,8 +490,7 @@ pub fn build_fixed_array_at(
     fahd.push(client_id);
     fahd.push(elem_size as u8);
 
-    // max_nelmts_bits: use 10 as default (page_size = 1024), matching h5py convention
-    let max_bits: u8 = 10;
+    let max_bits = FIXED_ARRAY_PAGE_BITS;
     fahd.push(max_bits);
 
     match length_size {
@@ -1070,7 +1080,6 @@ pub fn build_chunked_data_at_ext(
         )
     } else {
         let fa_address = base_address + data_buf.len() as u64;
-        let max_bits: u8 = 10;
 
         let fa_bytes = build_fixed_array_at(
             &written_chunks,
@@ -1086,7 +1095,7 @@ pub fn build_chunked_data_at_ext(
             fa_address,
             offset_size,
             element_size as u32,
-            max_bits,
+            FIXED_ARRAY_PAGE_BITS,
         )
     };
 

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -4,7 +4,10 @@
 extern crate alloc;
 
 #[cfg(not(feature = "std"))]
-use alloc::{format, vec, vec::Vec};
+use alloc::{vec, vec::Vec};
+// `format!` is only reached by the zfp-gated code paths below.
+#[cfg(all(not(feature = "std"), feature = "zfp"))]
+use alloc::format;
 
 use crate::error::FormatError;
 #[cfg(feature = "zfp")]

--- a/src/fixed_array.rs
+++ b/src/fixed_array.rs
@@ -111,6 +111,12 @@ impl FixedArrayHeader {
 /// Returns a `Vec<ChunkInfo>` with one entry per allocated chunk.
 /// `chunk_dimensions` should be the spatial chunk dims only (not including the element-size dim).
 /// `element_size` is the datatype size in bytes.
+///
+/// Handles both the non-paged layout (elements stored directly after the data
+/// block prefix) and the paged layout used when the chunk count exceeds the
+/// page size (`2^max_nelmts_bits`). In the paged layout the data block prefix
+/// is followed by a page-initialization bitmap and a checksum, after which the
+/// elements live in fixed-stride pages, each terminated by its own checksum.
 #[allow(clippy::too_many_arguments)]
 pub fn read_fixed_array_chunks(
     file_data: &[u8],
@@ -123,9 +129,10 @@ pub fn read_fixed_array_chunks(
 ) -> Result<Vec<ChunkInfo>, FormatError> {
     let db_offset = header.data_block_address as usize;
     let rank = chunk_dimensions.len();
+    let os = offset_size as usize;
 
-    // Parse data block header: FADB(4) + version(1) + client_id(1) + header_address(offset_size)
-    let db_header_size = 4 + 1 + 1 + offset_size as usize;
+    // Parse data block prefix: FADB(4) + version(1) + client_id(1) + header_address(offset_size)
+    let db_header_size = 4 + 1 + 1 + os;
     if db_offset + db_header_size > file_data.len() {
         return Err(FormatError::UnexpectedEof {
             expected: db_offset + db_header_size,
@@ -133,34 +140,30 @@ pub fn read_fixed_array_chunks(
         });
     }
 
-    let d = &file_data[db_offset..];
-    if &d[0..4] != b"FADB" {
+    if &file_data[db_offset..db_offset + 4] != b"FADB" {
         return Err(FormatError::ChunkedReadError(
             "invalid Fixed Array data block signature".into(),
         ));
     }
 
-    // Skip version(1) + client_id(1) + header_address(offset_size)
-    let mut pos = db_header_size;
+    // Per-element encoding width. Non-filtered: just the chunk address.
+    // Filtered: address + variable-width chunk size + 4-byte filter mask.
+    let chunk_size_bytes = if header.client_id == 0 {
+        0
+    } else {
+        (header.element_size as usize)
+            .checked_sub(os + 4)
+            .ok_or_else(|| {
+                FormatError::ChunkedReadError("Fixed Array element size too small".into())
+            })?
+    };
+    let elem_size = if header.client_id == 0 {
+        os
+    } else {
+        header.element_size as usize
+    };
 
-    // Check if paged
-    let page_size = 1u64 << header.max_nelmts_bits;
-    let is_paged = header.num_elements > page_size;
-
-    if is_paged {
-        // For paged data blocks, we need to handle page bitmap + pages
-        // For now, implement non-paged path (covers most real-world cases)
-        return Err(FormatError::ChunkedReadError(
-            "paged Fixed Array data blocks not yet supported".into(),
-        ));
-    }
-
-    // Non-paged: elements stored directly
-    let num_elements = header.num_elements as usize;
-    let os = offset_size as usize;
-
-    // Compute chunk offsets based on index
-    // Chunks are stored in row-major order within the dataset space
+    // Number of chunks along each dimension (row-major ordering in dataset space).
     let mut num_chunks_per_dim = Vec::with_capacity(rank);
     for d_idx in 0..rank {
         let ds_dim = dataset_dims[d_idx];
@@ -171,68 +174,97 @@ pub fn read_fixed_array_chunks(
     let chunk_byte_size: u64 =
         chunk_dimensions.iter().map(|&d| d as u64).product::<u64>() * element_size as u64;
 
-    let mut chunks = Vec::new();
-
-    for i in 0..num_elements {
-        let elem_data = &file_data[db_offset + pos..];
+    // Decode the element at absolute file position `elem_pos`, whose linear
+    // index across the whole array is `index`. Returns `None` for the "all
+    // 0xFF" sentinel that marks an unallocated chunk.
+    let parse_element = |elem_pos: usize, index: usize| -> Result<Option<ChunkInfo>, FormatError> {
+        if elem_pos + elem_size > file_data.len() {
+            return Err(FormatError::UnexpectedEof {
+                expected: elem_pos + elem_size,
+                available: file_data.len(),
+            });
+        }
+        if is_undefined(file_data, elem_pos, offset_size) {
+            return Ok(None);
+        }
+        let address = read_offset(file_data, elem_pos, offset_size)?;
+        let offsets = index_to_chunk_offsets(index, &num_chunks_per_dim, chunk_dimensions);
         if header.client_id == 0 {
-            // Non-filtered: just address
-            if pos + os > file_data.len() - db_offset {
-                return Err(FormatError::UnexpectedEof {
-                    expected: db_offset + pos + os,
-                    available: file_data.len(),
-                });
-            }
-            let address = read_offset(elem_data, 0, offset_size)?;
-            pos += os;
-
-            if is_undefined(file_data, db_offset + pos - os, offset_size) {
-                continue; // unallocated chunk
-            }
-
-            let offsets = index_to_chunk_offsets(i, &num_chunks_per_dim, chunk_dimensions);
-            chunks.push(ChunkInfo {
+            Ok(Some(ChunkInfo {
                 chunk_size: chunk_byte_size as u32,
                 filter_mask: 0,
                 offsets,
                 address,
-            });
+            }))
         } else {
-            // Filtered: address(offset_size) + chunk_size(variable) + filter_mask(4)
-            let chunk_size_bytes = header.element_size as usize - os - 4;
-            let elem_total = os + chunk_size_bytes + 4;
-            if pos + elem_total > file_data.len() - db_offset {
-                return Err(FormatError::UnexpectedEof {
-                    expected: db_offset + pos + elem_total,
-                    available: file_data.len(),
-                });
-            }
-
-            let address = read_offset(elem_data, 0, offset_size)?;
-
-            // Read chunk_size (variable length, little-endian)
-            let chunk_size = read_variable_length(&elem_data[os..], chunk_size_bytes)?;
-
-            let fm_off = os + chunk_size_bytes;
+            let chunk_size = read_variable_length(&file_data[elem_pos + os..], chunk_size_bytes)?;
+            let fm_off = elem_pos + os + chunk_size_bytes;
             let filter_mask = u32::from_le_bytes([
-                elem_data[fm_off],
-                elem_data[fm_off + 1],
-                elem_data[fm_off + 2],
-                elem_data[fm_off + 3],
+                file_data[fm_off],
+                file_data[fm_off + 1],
+                file_data[fm_off + 2],
+                file_data[fm_off + 3],
             ]);
-            pos += elem_total;
-
-            if is_undefined(file_data, db_offset + pos - elem_total, offset_size) {
-                continue; // unallocated chunk
-            }
-
-            let offsets = index_to_chunk_offsets(i, &num_chunks_per_dim, chunk_dimensions);
-            chunks.push(ChunkInfo {
+            Ok(Some(ChunkInfo {
                 chunk_size: chunk_size as u32,
                 filter_mask,
                 offsets,
                 address,
-            });
+            }))
+        }
+    };
+
+    let num_elements = header.num_elements as usize;
+    let page_size = (1u64 << header.max_nelmts_bits) as usize;
+    let is_paged = num_elements > page_size;
+
+    let mut chunks = Vec::new();
+
+    if !is_paged {
+        // Elements stored directly after the data block prefix.
+        let mut pos = db_offset + db_header_size;
+        for index in 0..num_elements {
+            if let Some(info) = parse_element(pos, index)? {
+                chunks.push(info);
+            }
+            pos += elem_size;
+        }
+        return Ok(chunks);
+    }
+
+    // Paged: prefix is followed by a page-init bitmap (one bit per page,
+    // most-significant-bit first) and a 4-byte checksum. Pages then follow at a
+    // fixed stride of `page_size` elements plus a 4-byte checksum each; the
+    // whole block is allocated contiguously, so the last (partial) page still
+    // begins at its full-stride offset.
+    let npages = num_elements.div_ceil(page_size);
+    let bitmap_size = npages.div_ceil(8);
+    let bitmap_pos = db_offset + db_header_size;
+    if bitmap_pos + bitmap_size + 4 > file_data.len() {
+        return Err(FormatError::UnexpectedEof {
+            expected: bitmap_pos + bitmap_size + 4,
+            available: file_data.len(),
+        });
+    }
+    let bitmap = &file_data[bitmap_pos..bitmap_pos + bitmap_size];
+    let pages_start = bitmap_pos + bitmap_size + 4;
+    let page_stride = page_size * elem_size + 4;
+
+    for page in 0..npages {
+        let nelem_in_page = core::cmp::min(page_size, num_elements - page * page_size);
+        // A cleared bit means the page was never initialized: every chunk it
+        // would hold is unallocated, so skip it without reading.
+        let initialized = (bitmap[page / 8] >> (7 - (page % 8))) & 1 == 1;
+        if !initialized {
+            continue;
+        }
+        let page_start = pages_start + page * page_stride;
+        for j in 0..nelem_in_page {
+            let index = page * page_size + j;
+            let elem_pos = page_start + j * elem_size;
+            if let Some(info) = parse_element(elem_pos, index)? {
+                chunks.push(info);
+            }
         }
     }
 
@@ -500,5 +532,80 @@ mod tests {
         assert_eq!(chunks[1].chunk_size, 115);
         assert_eq!(chunks[2].address, 0x3000);
         assert_eq!(chunks[2].chunk_size, 100);
+    }
+
+    /// Build a synthetic paged (non-filtered) Fixed Array and verify both that
+    /// initialized pages are read and that pages with a cleared bitmap bit are
+    /// skipped as entirely unallocated.
+    ///
+    /// `bitmap` is the single page-init byte (MSB-first: page 0 = 0x80).
+    /// Returns the chunks decoded from a 3-element array split across two
+    /// pages of size 2 (`max_nelmts_bits = 1`).
+    fn read_paged(bitmap: u8) -> Vec<ChunkInfo> {
+        let offset_size: u8 = 8;
+        let length_size: u8 = 8;
+        let os = offset_size as usize;
+        let num_chunks = 3u64; // > page_size(2) => paged, npages = 2
+
+        let mut file_data = vec![0u8; 0x400];
+
+        let fahd_offset = 0x100usize;
+        let db_offset = 0x200usize;
+        file_data[fahd_offset..fahd_offset + 4].copy_from_slice(b"FAHD");
+        file_data[fahd_offset + 4] = 0; // version
+        file_data[fahd_offset + 5] = 0; // client_id = non-filtered
+        file_data[fahd_offset + 6] = os as u8; // element_size
+        file_data[fahd_offset + 7] = 1; // max_nelmts_bits => page_size = 2
+        file_data[fahd_offset + 8..fahd_offset + 16].copy_from_slice(&num_chunks.to_le_bytes());
+        file_data[fahd_offset + 16..fahd_offset + 24]
+            .copy_from_slice(&(db_offset as u64).to_le_bytes());
+
+        // FADB prefix: sig + version + client_id + header_addr + bitmap + checksum
+        file_data[db_offset..db_offset + 4].copy_from_slice(b"FADB");
+        file_data[db_offset + 4] = 0; // version
+        file_data[db_offset + 5] = 0; // client_id
+        file_data[db_offset + 6..db_offset + 14]
+            .copy_from_slice(&(fahd_offset as u64).to_le_bytes());
+        file_data[db_offset + 14] = bitmap; // page-init bitmap (1 byte for 2 pages)
+        // checksum at db_offset+15..+19 left zero (reader does not validate)
+
+        // Pages: stride = page_size(2)*elem_size(8) + 4 checksum = 20 bytes.
+        let pages_start = db_offset + 14 + 1 + 4;
+        let stride = 2 * os + 4;
+        let addrs = [0x1000u64, 0x2000, 0x3000];
+        for (i, &addr) in addrs.iter().enumerate() {
+            let page = i / 2;
+            let j = i % 2;
+            let pos = pages_start + page * stride + j * os;
+            file_data[pos..pos + os].copy_from_slice(&addr.to_le_bytes());
+        }
+
+        let header =
+            FixedArrayHeader::parse(&file_data, fahd_offset, offset_size, length_size).unwrap();
+        assert_eq!(header.num_elements, 3);
+        read_fixed_array_chunks(&file_data, &header, &[3], &[1], 8, offset_size, length_size)
+            .unwrap()
+    }
+
+    #[test]
+    fn read_paged_all_pages_initialized() {
+        // bitmap 0xC0 => both pages initialized (page 0 and page 1).
+        let chunks = read_paged(0b1100_0000);
+        assert_eq!(chunks.len(), 3);
+        assert_eq!(chunks[0].address, 0x1000);
+        assert_eq!(chunks[0].offsets, vec![0]);
+        assert_eq!(chunks[1].address, 0x2000);
+        assert_eq!(chunks[1].offsets, vec![1]);
+        assert_eq!(chunks[2].address, 0x3000);
+        assert_eq!(chunks[2].offsets, vec![2]);
+    }
+
+    #[test]
+    fn read_paged_skips_uninitialized_page() {
+        // bitmap 0x80 => only page 0 initialized; page 1's chunk is unallocated.
+        let chunks = read_paged(0b1000_0000);
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0].address, 0x1000);
+        assert_eq!(chunks[1].address, 0x2000);
     }
 }

--- a/tests/hdf5_crosscheck.rs
+++ b/tests/hdf5_crosscheck.rs
@@ -596,6 +596,49 @@ fn crosscheck_read_paged_fixed_array_from_c_lib() {
 }
 
 #[test]
+fn crosscheck_read_paged_fixed_array_with_uninitialized_page() {
+    // The reference C library writes a paged Fixed Array but, with incremental
+    // allocation, only the first page's chunks are written. The second page is
+    // never allocated, so its page-init bitmap bit stays cleared. hdf5-pure must
+    // skip that page (no chunk records) and fill the unwritten tail with the
+    // dataset's fill value, exercising the bitmap-skip path against real bytes.
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("c_paged_fa_sparse.h5");
+
+    let n = 2000usize; // 2 pages of 1024; page 1 (chunks 1024..) left untouched
+    let written = 1000usize; // entirely within page 0
+    let head: Vec<f64> = (0..written).map(|i| (i + 1) as f64).collect();
+    {
+        let file = hdf5::FileBuilder::new()
+            .with_fapl(|fapl| fapl.libver_v110())
+            .create(&path)
+            .unwrap();
+        let ds = file
+            .new_dataset::<f64>()
+            .chunk([1])
+            .shape([n])
+            .create("data")
+            .unwrap();
+        // Write only the first `written` chunks; the rest stay unallocated.
+        ds.write_slice(head.as_slice(), 0..written).unwrap();
+        file.close().unwrap();
+    }
+
+    let bytes = std::fs::read(&path).unwrap();
+    let file = hdf5_pure::File::from_bytes(bytes).unwrap();
+    let ds = file.dataset("data").unwrap();
+    let values = ds.read_f64().unwrap();
+    assert_eq!(values.len(), n);
+    for (i, &v) in values.iter().enumerate() {
+        let expected = if i < written { (i + 1) as f64 } else { 0.0 };
+        assert!(
+            (v - expected).abs() < 1e-10,
+            "index {i}: got {v}, expected {expected}"
+        );
+    }
+}
+
+#[test]
 fn crosscheck_deflate_compressed() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("deflate.h5");

--- a/tests/hdf5_crosscheck.rs
+++ b/tests/hdf5_crosscheck.rs
@@ -506,6 +506,96 @@ fn crosscheck_chunked_dataset() {
 }
 
 #[test]
+fn crosscheck_paged_fixed_array() {
+    // > 1024 chunks pushes the Fixed Array index into its paged data block
+    // layout. A non-compliant (flat) data block makes the C library reject the
+    // file or misread it; this asserts the reference reader accepts ours.
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("paged_fa.h5");
+
+    let n = 2500usize;
+    let data: Vec<f64> = (0..n).map(|i| i as f64 * 0.25).collect();
+    let mut builder = FileBuilder::new();
+    builder
+        .create_dataset("data")
+        .with_f64_data(&data)
+        .with_shape(&[n as u64])
+        .with_chunks(&[1]);
+    builder.write(&path).unwrap();
+
+    let file = hdf5::File::open(&path).unwrap();
+    let ds = file.dataset("data").unwrap();
+    let values = ds.read_raw::<f64>().unwrap();
+    assert_eq!(values.len(), n);
+    for (i, &v) in values.iter().enumerate() {
+        assert!((v - i as f64 * 0.25).abs() < 1e-10);
+    }
+}
+
+#[test]
+fn crosscheck_paged_fixed_array_deflate() {
+    // Paged data block on the filtered element path, read back by the reference
+    // C library (which validates each page checksum).
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("paged_fa_deflate.h5");
+
+    let n = 1500usize;
+    let data: Vec<f64> = (0..n).map(|i| (i % 11) as f64).collect();
+    let mut builder = FileBuilder::new();
+    builder
+        .create_dataset("data")
+        .with_f64_data(&data)
+        .with_shape(&[n as u64])
+        .with_chunks(&[1])
+        .with_deflate(4);
+    builder.write(&path).unwrap();
+
+    let file = hdf5::File::open(&path).unwrap();
+    let ds = file.dataset("data").unwrap();
+    let values = ds.read_raw::<f64>().unwrap();
+    assert_eq!(values.len(), n);
+    for (i, &v) in values.iter().enumerate() {
+        assert!((v - (i % 11) as f64).abs() < 1e-10);
+    }
+}
+
+#[test]
+fn crosscheck_read_paged_fixed_array_from_c_lib() {
+    // Reverse direction: the reference C library writes a paged Fixed Array
+    // (the layout that previously triggered "paged Fixed Array data blocks not
+    // yet supported"), and hdf5-pure must read it back. `libver_v110` forces the
+    // v110+ Fixed Array index; > 1024 fixed-shape chunks make it paged.
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("c_paged_fa.h5");
+
+    let n = 2500usize;
+    let data: Vec<f64> = (0..n).map(|i| i as f64 * 0.25).collect();
+    {
+        let file = hdf5::FileBuilder::new()
+            .with_fapl(|fapl| fapl.libver_v110())
+            .create(&path)
+            .unwrap();
+        let ds = file
+            .new_dataset::<f64>()
+            .chunk([1])
+            .shape([n])
+            .create("data")
+            .unwrap();
+        ds.write_raw(data.as_slice()).unwrap();
+        file.close().unwrap();
+    }
+
+    let bytes = std::fs::read(&path).unwrap();
+    let file = hdf5_pure::File::from_bytes(bytes).unwrap();
+    let ds = file.dataset("data").unwrap();
+    let values = ds.read_f64().unwrap();
+    assert_eq!(values.len(), n);
+    for (i, &v) in values.iter().enumerate() {
+        assert!((v - i as f64 * 0.25).abs() < 1e-10);
+    }
+}
+
+#[test]
 fn crosscheck_deflate_compressed() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("deflate.h5");

--- a/tests/write_read_roundtrip.rs
+++ b/tests/write_read_roundtrip.rs
@@ -681,3 +681,46 @@ fn roundtrip_group_only_no_datasets() {
         vec![42]
     );
 }
+
+#[test]
+fn roundtrip_paged_fixed_array_many_chunks() {
+    // More than 1024 chunks forces the Fixed Array index into its paged data
+    // block layout (page size = 2^10 = 1024). 2500 chunks of size 1 spans three
+    // pages, with a partial final page.
+    let n = 2500usize;
+    let data: Vec<f64> = (0..n).map(|i| i as f64 * 0.5).collect();
+
+    let mut builder = FileBuilder::new();
+    builder
+        .create_dataset("data")
+        .with_f64_data(&data)
+        .with_shape(&[n as u64])
+        .with_chunks(&[1]);
+    let bytes = builder.finish().unwrap();
+
+    let file = File::from_bytes(bytes).unwrap();
+    let ds = file.dataset("data").unwrap();
+    assert_eq!(ds.shape().unwrap(), vec![n as u64]);
+    assert_eq!(ds.read_f64().unwrap(), data);
+}
+
+#[test]
+fn roundtrip_paged_fixed_array_deflate() {
+    // Paged data block on the filtered (client_id = 1) path: each element record
+    // carries an address plus a variable-width compressed size and filter mask.
+    let n = 1500usize;
+    let data: Vec<f64> = (0..n).map(|i| (i % 7) as f64).collect();
+
+    let mut builder = FileBuilder::new();
+    builder
+        .create_dataset("data")
+        .with_f64_data(&data)
+        .with_shape(&[n as u64])
+        .with_chunks(&[1])
+        .with_deflate(4);
+    let bytes = builder.finish().unwrap();
+
+    let file = File::from_bytes(bytes).unwrap();
+    let ds = file.dataset("data").unwrap();
+    assert_eq!(ds.read_f64().unwrap(), data);
+}


### PR DESCRIPTION
Fixes #14.

## The problem

The Fixed Array chunk index (used for non-resizable chunked datasets) advertises a page size of `2^max_nelmts_bits` (1024 at the default). Per the HDF5 spec, once the chunk count exceeds that page size the data block must switch to a *paged* layout: a page-initialization bitmap followed by fixed-stride pages, each terminated by its own checksum.

Neither side handled this:

- **Write side** (the corruption reported in the issue comment): the writer always emitted a flat element list while still advertising `max_nelmts_bits = 10`, so any dataset with **more than 1024 chunks** produced a file that a spec-compliant reader rejects as corrupt.
- **Read side** (the issue title): the reader returned `paged Fixed Array data blocks not yet supported` for any such file, e.g. one written by h5py or the C HDF5 library.

## The fix

Implement the paged layout on both sides, matching what the reference library produces:

- **`src/fixed_array.rs`** — `read_fixed_array_chunks` decodes the page-init bitmap (MSB-first ordering), walks pages at the fixed stride, skips uninitialized pages as unallocated, and handles the partial final page. The filtered/non-filtered element decoding is unified into a single helper.
- **`src/chunked_write.rs`** — `build_fixed_array_at` emits the bitmap, prefix checksum, and per-page elements with per-page checksums when the chunk count exceeds the page size, and the flat layout otherwise. The page-bits exponent (the paging threshold, and the two header fields the spec requires to be equal) now derives from a single internal `FIXED_ARRAY_PAGE_BITS` constant, so the FAHD and layout-message copies can't silently diverge.

## Verification

Both directions, against the **reference C HDF5 library** (via the existing `hdf5-metno` dev-dependency):

- hdf5-pure writes 2500 chunks (filtered and unfiltered) → C library reads them back.
- C library writes a paged Fixed Array (`libver_v110`, 2500 chunks) → hdf5-pure reads it. This is the exact scenario from the issue title.

Plus pure-Rust round-trips, a reverse crosscheck where the C library writes a *sparse* paged array (a whole page left unallocated) that hdf5-pure must skip and backfill with the fill value, and a synthetic unit test for the bitmap-skip logic. Full suite green (557 passing); `cargo fmt --check`, the CI clippy invocation (`--features serde --all-targets -- -D warnings`), and the `no_std` / wasm `--no-default-features` builds all clean.

## Also

Gates the `no_std` `alloc::format` import in `src/filters.rs` behind the `zfp` feature (its only caller), removing a pre-existing unused-import warning in `--no-default-features` builds. Unrelated to the paging fix, but it surfaced while verifying the no_std path.

## Out of scope

The Extensible Array index (resizable datasets) is a separate structure with its own paging parameters and is untouched here.