### PR TITLE
Fix Extensible Array block-size geometry (read + write)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Extensible Array chunk index (used for chunked datasets with one unlimited dimension): reading a dataset with more than 20 chunks along the unlimited axis silently returned wrong data, and writing more than 244 chunks silently dropped the excess. The reader's data-block size progression did not match the HDF5 format (it diverged past the inline elements plus the first data block), and the writer never emitted super blocks or paged data blocks. Reader and writer now share a single block-size geometry derived from the array's creation parameters; the writer emits super blocks and, above 131060 chunks, paged data blocks; and the array header statistics match the reference C library byte-for-byte. Verified against the reference C HDF5 library in both directions across the inline, direct-block, super-block, and paged ranges. Found while implementing SWMR support ([#17](https://github.com/stephenberry/hdf5-pure/issues/17)).
+
 ## [0.6.0]
 
 ### Added

--- a/src/chunked_write.rs
+++ b/src/chunked_write.rs
@@ -9,6 +9,7 @@ use alloc::{vec, vec::Vec};
 use crate::checksum::jenkins_lookup3;
 use crate::chunk_cache::{CACHE_LINE_SIZE, align_to_cache_line};
 use crate::error::FormatError;
+use crate::extensible_array::{EaGeometry, ExtensibleArrayHeader};
 #[cfg(feature = "zfp")]
 use crate::filter_pipeline::FILTER_ZFP;
 use crate::filter_pipeline::{
@@ -678,11 +679,147 @@ fn serialize_v4_extensible_array(
     buf
 }
 
+/// Write an offset-sized address (little-endian) to `buf`.
+fn write_ea_addr(buf: &mut Vec<u8>, val: u64, offset_size: u8) {
+    match offset_size {
+        4 => buf.extend_from_slice(&(val as u32).to_le_bytes()),
+        _ => buf.extend_from_slice(&val.to_le_bytes()),
+    }
+}
+
+/// Build a single Extensible Array Data Block (`EADB`) holding the chunk
+/// elements for `[elem_start, elem_start + dblk_nelmts)`. Slots whose absolute
+/// element index reaches `num_elements` are written as undefined.
+///
+/// When `dblk_nelmts` exceeds the page size the block is *paged*: the header
+/// carries its own checksum and the elements are split into contiguous pages of
+/// `page_nelmts` slots, each followed by a checksum. Returns the block bytes and
+/// the number of leading pages that contain at least one real element (used by
+/// the owning super block to build its page-init bitmap). For non-paged blocks
+/// the returned page count is 0.
+#[allow(clippy::too_many_arguments)]
+fn build_eadb(
+    chunks: &[WrittenChunk],
+    num_elements: usize,
+    elem_start: usize,
+    dblk_nelmts: usize,
+    block_offset_rel: u64,
+    ea_base_address: u64,
+    offset_size: u8,
+    has_filters: bool,
+    chunk_size_bytes: usize,
+    client_id: u8,
+    page_nelmts: usize,
+    blk_off_size: usize,
+) -> (Vec<u8>, usize) {
+    let mut buf = Vec::new();
+    buf.extend_from_slice(b"EADB");
+    buf.push(0); // version
+    buf.push(client_id);
+    write_ea_addr(&mut buf, ea_base_address, offset_size);
+    buf.extend_from_slice(&block_offset_rel.to_le_bytes()[..blk_off_size]);
+
+    if dblk_nelmts <= page_nelmts {
+        // Non-paged: elements inline, single checksum.
+        for slot in 0..dblk_nelmts {
+            let idx = elem_start + slot;
+            if idx < num_elements {
+                write_chunk_element(
+                    &mut buf,
+                    &chunks[idx],
+                    offset_size,
+                    has_filters,
+                    chunk_size_bytes,
+                );
+            } else {
+                write_undefined_element(&mut buf, offset_size, has_filters, chunk_size_bytes);
+            }
+        }
+        let cks = jenkins_lookup3(&buf);
+        buf.extend_from_slice(&cks.to_le_bytes());
+        (buf, 0)
+    } else {
+        // Paged: the header has its own checksum, then full pages follow. We
+        // reserve every page (matching the C library's allocation) and report
+        // how many leading pages hold real data so the super block can mark
+        // them initialized in its bitmap.
+        let header_cks = jenkins_lookup3(&buf);
+        buf.extend_from_slice(&header_cks.to_le_bytes());
+
+        let npages = dblk_nelmts / page_nelmts;
+        let mut pages_init = 0usize;
+        for page in 0..npages {
+            let page_start = elem_start + page * page_nelmts;
+            let mut page_buf = Vec::new();
+            let mut has_real = false;
+            for slot in 0..page_nelmts {
+                let idx = page_start + slot;
+                if idx < num_elements {
+                    write_chunk_element(
+                        &mut page_buf,
+                        &chunks[idx],
+                        offset_size,
+                        has_filters,
+                        chunk_size_bytes,
+                    );
+                    has_real = true;
+                } else {
+                    write_undefined_element(
+                        &mut page_buf,
+                        offset_size,
+                        has_filters,
+                        chunk_size_bytes,
+                    );
+                }
+            }
+            let page_cks = jenkins_lookup3(&page_buf);
+            page_buf.extend_from_slice(&page_cks.to_le_bytes());
+            buf.extend_from_slice(&page_buf);
+            if has_real {
+                pages_init += 1;
+            }
+        }
+        (buf, pages_init)
+    }
+}
+
+/// Build an Extensible Array Super (secondary) Block (`EASB`) referencing
+/// `dblk_addrs`. When `page_bitmap` is non-empty the block's data blocks are
+/// paged and the bitmap (already populated by the caller) is written between
+/// the block offset and the data block addresses.
+fn build_aesb(
+    ea_base_address: u64,
+    block_offset_rel: u64,
+    page_bitmap: &[u8],
+    dblk_addrs: &[u64],
+    offset_size: u8,
+    blk_off_size: usize,
+    client_id: u8,
+) -> Vec<u8> {
+    let mut buf = Vec::new();
+    buf.extend_from_slice(b"EASB");
+    buf.push(0); // version
+    buf.push(client_id);
+    write_ea_addr(&mut buf, ea_base_address, offset_size);
+    buf.extend_from_slice(&block_offset_rel.to_le_bytes()[..blk_off_size]);
+    buf.extend_from_slice(page_bitmap);
+    for &addr in dblk_addrs {
+        write_ea_addr(&mut buf, addr, offset_size);
+    }
+    let cks = jenkins_lookup3(&buf);
+    buf.extend_from_slice(&cks.to_le_bytes());
+    buf
+}
+
 /// Build a complete Extensible Array at a known absolute address.
 ///
-/// For simplicity, we put all elements inline in the index block when the
-/// number of chunks is small (up to idx_blk_elmts), otherwise use inline +
-/// direct data blocks.
+/// Lays out the header (`EAHD`), index block (`EAIB`), and — for datasets with
+/// more than `idx_blk_elmts + sum(direct data blocks)` chunks — the on-disk
+/// super blocks (`EASB`) and their data blocks (`EADB`, paged when large). The
+/// super-block / data-block size progression comes from the shared
+/// [`EaGeometry`], so the writer and reader cannot drift. Byte-for-byte
+/// compatible with the reference HDF5 C library across inline, direct, super
+/// block, and paged ranges (verified by crosscheck tests).
 pub fn build_extensible_array_at(
     chunks: &[WrittenChunk],
     offset_size: u8,
@@ -715,60 +852,184 @@ pub fn build_extensible_array_at(
 
     let client_id: u8 = if has_filters { 1 } else { 0 };
 
-    // EA creation parameters — must match HDF5 C library defaults exactly
+    // EA creation parameters — must match the HDF5 C library defaults exactly.
     let max_nelmts_bits: u8 = 32;
     let idx_blk_elmts: u8 = 4;
     let min_dblk_nelmts: u8 = 16;
     let super_blk_min_nelmts: u8 = 4;
     let max_dblk_nelmts_bits: u8 = 10;
 
-    // EAHD size: fixed(12) + 6 stats(6*length_size) + addr(offset_size) + checksum(4)
-    let aehd_size = 4 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 6 * length_size as usize + os + 4;
+    // Derive the block-size geometry from the shared helper (single source of
+    // truth shared with the reader).
+    let geom_header = ExtensibleArrayHeader {
+        client_id,
+        element_size: elem_size as u8,
+        max_nelmts_bits,
+        idx_blk_elmts,
+        min_dblk_nelmts,
+        super_blk_min_nelmts,
+        max_dblk_nelmts_bits,
+        num_elements: 0,
+        index_block_address: 0,
+    };
+    let geom = EaGeometry::from_header(&geom_header);
+    let page_nelmts = 1usize << max_dblk_nelmts_bits;
+    let blk_off_size = (max_nelmts_bits as usize).div_ceil(8);
+    let inline = idx_blk_elmts as usize;
+
+    let aehd_size = ExtensibleArrayHeader::serialized_size(offset_size, length_size);
     let aeib_address = ea_base_address + aehd_size as u64;
 
-    // Determine how many elements go inline vs data blocks
-    let n_inline = (idx_blk_elmts as usize).min(num_elements);
-    let remaining_after_inline = num_elements.saturating_sub(n_inline);
-
-    // Compute super block layout per HDF5 spec:
-    // nsblks = floor(log2((2^max_nelmts_bits - idx_blk_elmts) / data_blk_min_elmts)) + 1
-    // For each super block i:
-    //   ndblks_in_sblk = 2^floor(i/2)
-    //   dblk_nelmts = data_blk_min_elmts * 2^ceil(i/2)
-    // Super blocks 0..sup_blk_min_data_ptrs-1 have their data block addrs in EAIB directly.
-    // Super blocks sup_blk_min_data_ptrs..nsblks-1 get super block addresses.
-    let sblk_min = super_blk_min_nelmts as usize; // sup_blk_min_data_ptrs
-    // nsblks = log2(2^max_nelmts_bits / data_blk_min_elmts) + 1
-    //        = max_nelmts_bits - log2(data_blk_min_elmts) + 1
-    let log2_dblk_min = if min_dblk_nelmts <= 1 {
-        0
-    } else {
-        (min_dblk_nelmts as u32).trailing_zeros() as usize
-    };
-    let nsblks = (max_nelmts_bits as usize).saturating_sub(log2_dblk_min) + 1;
-
-    // Direct data block addresses (from super blocks 0..sblk_min-1)
-    let mut dblk_sizes: Vec<usize> = Vec::new();
-    for sblk_idx in 0..sblk_min.min(nsblks) {
-        let ndblks = 1usize << (sblk_idx / 2);
-        let dblk_nelmts = (min_dblk_nelmts as usize) * (1 << sblk_idx.div_ceil(2));
-        for _ in 0..ndblks {
-            dblk_sizes.push(dblk_nelmts);
-        }
-    }
-    let n_direct_dblks = dblk_sizes.len();
-
-    // Super block addresses (for super blocks sblk_min..nsblks-1)
-    let n_sblk_addrs = nsblks.saturating_sub(sblk_min);
-
-    // EAIB size: header + inline elements + direct dblk addresses + sblk addresses + checksum
-    let aeib_size = 4 + 1 + 1 + os // sig+ver+client+hdr_addr
-        + idx_blk_elmts as usize * elem_size // inline elements (always all slots)
-        + n_direct_dblks * os // direct data block addresses
-        + n_sblk_addrs * os // super block addresses
+    let ndblk_addrs = geom.direct_dblk_nelmts.len();
+    let nsblk_addrs = geom.nsblk_addrs;
+    let aeib_size = 4 + 1 + 1 + os // sig + ver + client + hdr_addr
+        + inline * elem_size       // inline elements (always all slots)
+        + ndblk_addrs * os         // direct data block addresses
+        + nsblk_addrs * os         // super block addresses
         + 4; // checksum
+    let body_base = aeib_address + aeib_size as u64;
 
-    // Build AEHD
+    let undef_addr: u64 = match offset_size {
+        4 => 0xFFFF_FFFF,
+        _ => u64::MAX,
+    };
+
+    // ---- Build the body (direct data blocks, then super blocks) -----------
+    // Addresses are absolute, computed from `body_base`, so the body can be
+    // built before the index block that references it.
+    let mut body: Vec<u8> = Vec::new();
+    let mut direct_addrs: Vec<u64> = Vec::with_capacity(ndblk_addrs);
+    let mut sblk_addrs: Vec<u64> = Vec::with_capacity(nsblk_addrs);
+
+    // Stats (match the C library's EAHD fields exactly).
+    let mut ndata_blks: u64 = 0;
+    let mut data_blk_size: u64 = 0;
+    let mut nsuper_blks: u64 = 0;
+    let mut super_blk_size: u64 = 0;
+    let mut alloc_slots: u64 = inline as u64; // nelmts: idx slots + every allocated data block
+
+    let mut elem_cursor = inline; // absolute element index past the inline slots
+
+    // Direct data blocks: addresses stored directly in the index block.
+    for &dblk_nelmts in &geom.direct_dblk_nelmts {
+        let dblk_nelmts = dblk_nelmts as usize;
+        if elem_cursor >= num_elements {
+            direct_addrs.push(undef_addr);
+            elem_cursor += dblk_nelmts;
+            continue;
+        }
+        let addr = body_base + body.len() as u64;
+        let (db_bytes, _) = build_eadb(
+            chunks,
+            num_elements,
+            elem_cursor,
+            dblk_nelmts,
+            (elem_cursor - inline) as u64,
+            ea_base_address,
+            offset_size,
+            has_filters,
+            chunk_size_bytes,
+            client_id,
+            page_nelmts,
+            blk_off_size,
+        );
+        ndata_blks += 1;
+        data_blk_size += db_bytes.len() as u64;
+        alloc_slots += dblk_nelmts as u64;
+        body.extend_from_slice(&db_bytes);
+        direct_addrs.push(addr);
+        elem_cursor += dblk_nelmts;
+    }
+
+    // Super blocks: addresses stored in the index block; super-block pointer `j`
+    // refers to super block `first_indirect_sblk + j`.
+    for j in 0..nsblk_addrs {
+        let sblk_idx = geom.first_indirect_sblk + j;
+        let (ndblks, dblk_nelmts) = geom.sblks[sblk_idx];
+        let ndblks = ndblks as usize;
+        let dblk_nelmts = dblk_nelmts as usize;
+        let sb_span = ndblks * dblk_nelmts;
+        if elem_cursor >= num_elements {
+            sblk_addrs.push(undef_addr);
+            elem_cursor += sb_span;
+            continue;
+        }
+
+        let is_paged = dblk_nelmts > page_nelmts;
+        let npages = if is_paged {
+            dblk_nelmts / page_nelmts
+        } else {
+            0
+        };
+        let sb_block_offset = (elem_cursor - inline) as u64;
+        let bitmap_size = if is_paged {
+            ndblks * npages.div_ceil(8)
+        } else {
+            0
+        };
+        let mut page_bitmap = vec![0u8; bitmap_size];
+
+        let mut sb_dblk_addrs: Vec<u64> = Vec::with_capacity(ndblks);
+        let mut local_elem = elem_cursor;
+        for db_local in 0..ndblks {
+            if local_elem >= num_elements {
+                sb_dblk_addrs.push(undef_addr);
+                local_elem += dblk_nelmts;
+                continue;
+            }
+            let addr = body_base + body.len() as u64;
+            let (db_bytes, pages_init) = build_eadb(
+                chunks,
+                num_elements,
+                local_elem,
+                dblk_nelmts,
+                (local_elem - inline) as u64,
+                ea_base_address,
+                offset_size,
+                has_filters,
+                chunk_size_bytes,
+                client_id,
+                page_nelmts,
+                blk_off_size,
+            );
+            ndata_blks += 1;
+            data_blk_size += db_bytes.len() as u64;
+            alloc_slots += dblk_nelmts as u64;
+            body.extend_from_slice(&db_bytes);
+            sb_dblk_addrs.push(addr);
+            if is_paged {
+                for p in 0..pages_init {
+                    let global_page = db_local * npages + p;
+                    page_bitmap[global_page / 8] |= 0x80 >> (global_page % 8);
+                }
+            }
+            local_elem += dblk_nelmts;
+        }
+
+        let aesb_addr = body_base + body.len() as u64;
+        let aesb = build_aesb(
+            ea_base_address,
+            sb_block_offset,
+            &page_bitmap,
+            &sb_dblk_addrs,
+            offset_size,
+            blk_off_size,
+            client_id,
+        );
+        nsuper_blks += 1;
+        super_blk_size += aesb.len() as u64;
+        body.extend_from_slice(&aesb);
+        sblk_addrs.push(aesb_addr);
+
+        elem_cursor += sb_span;
+    }
+
+    // ---- Build the header (EAHD) ------------------------------------------
+    let write_length = |buf: &mut Vec<u8>, val: u64| match length_size {
+        4 => buf.extend_from_slice(&(val as u32).to_le_bytes()),
+        _ => buf.extend_from_slice(&val.to_le_bytes()),
+    };
+
     let mut aehd = Vec::with_capacity(aehd_size);
     aehd.extend_from_slice(b"EAHD");
     aehd.push(0); // version
@@ -780,96 +1041,33 @@ pub fn build_extensible_array_at(
     aehd.push(super_blk_min_nelmts);
     aehd.push(max_dblk_nelmts_bits);
 
-    // 6 stats fields matching HDF5 C library:
-    // [0] = 0 (unknown/reserved), [1] = 0 (unknown/reserved),
-    // [2] = ndata_blks, [3] = data_blk_total_size (computed after building data blocks),
-    // [4] = nelmts, [5] = max_idx_set
-    // We'll compute ndata_blks and data_blk_size below, and fill with placeholder for now.
-    // Actually, we need to compute these before writing EAHD.
-    // Count data blocks that will have chunks:
-    let n_active_dblks: u64 = if remaining_after_inline > 0 {
-        let mut count = 0u64;
-        let mut ci = n_inline;
-        for &sz in &dblk_sizes {
-            if ci < num_elements {
-                count += 1;
-                ci += sz;
-            }
-        }
-        count
-    } else {
-        0
-    };
-    // Compute total data block size (we'll update after building, but estimate here)
-    // For now, compute the AEDB size per block: sig(4) + ver(1) + cid(1) + hdr_addr(os) + nelmts*elem_size + checksum(4)
-    let aedb_header_overhead = 4 + 1 + 1 + os + 4;
-    let data_blk_total_size: u64 = if remaining_after_inline > 0 {
-        let mut total = 0u64;
-        let mut ci = n_inline;
-        for &sz in &dblk_sizes {
-            if ci < num_elements {
-                total += (aedb_header_overhead + sz * elem_size) as u64;
-                ci += sz;
-            }
-        }
-        total
-    } else {
-        0
-    };
-    // max_idx_set: idx_blk_elmts + sum of data block sizes for active blocks
-    let max_idx_set: u64 = if remaining_after_inline > 0 {
-        let mut max_set = idx_blk_elmts as u64;
-        let mut ci = n_inline;
-        for &sz in &dblk_sizes {
-            if ci < num_elements {
-                max_set += sz as u64;
-                ci += sz;
-            }
-        }
-        max_set
-    } else {
-        idx_blk_elmts as u64
-    };
+    // 6 statistics, in the C library's order:
+    //   [0] nsuper_blks   [1] super_blk_size   [2] ndata_blks
+    //   [3] data_blk_size [4] max_idx_set      [5] nelmts
+    write_length(&mut aehd, nsuper_blks);
+    write_length(&mut aehd, super_blk_size);
+    write_length(&mut aehd, ndata_blks);
+    write_length(&mut aehd, data_blk_size);
+    write_length(&mut aehd, num_elements as u64); // max_idx_set (dense fill)
+    write_length(&mut aehd, alloc_slots); // nelmts (allocated slots)
 
-    let write_length = |buf: &mut Vec<u8>, val: u64| match length_size {
-        4 => buf.extend_from_slice(&(val as u32).to_le_bytes()),
-        _ => buf.extend_from_slice(&val.to_le_bytes()),
-    };
-    let write_addr = |buf: &mut Vec<u8>, val: u64| match offset_size {
-        4 => buf.extend_from_slice(&(val as u32).to_le_bytes()),
-        _ => buf.extend_from_slice(&val.to_le_bytes()),
-    };
-
-    write_length(&mut aehd, 0); // stat[0]: reserved/unknown
-    write_length(&mut aehd, 0); // stat[1]: reserved/unknown
-    write_length(&mut aehd, n_active_dblks); // stat[2]: ndata_blks
-    write_length(&mut aehd, data_blk_total_size); // stat[3]: data_blk_total_size
-    write_length(&mut aehd, num_elements as u64); // stat[4]: nelmts
-    write_length(&mut aehd, max_idx_set); // stat[5]: max_idx_set
-
-    write_addr(&mut aehd, aeib_address);
+    write_ea_addr(&mut aehd, aeib_address, offset_size);
 
     let aehd_checksum = jenkins_lookup3(&aehd);
     aehd.extend_from_slice(&aehd_checksum.to_le_bytes());
     debug_assert_eq!(aehd.len(), aehd_size);
 
-    // Build AEIB
+    // ---- Build the index block (EAIB) -------------------------------------
     let mut aeib = Vec::with_capacity(aeib_size);
     aeib.extend_from_slice(b"EAIB");
     aeib.push(0); // version
     aeib.push(client_id);
+    write_ea_addr(&mut aeib, ea_base_address, offset_size);
 
-    // header address
-    match offset_size {
-        4 => aeib.extend_from_slice(&(ea_base_address as u32).to_le_bytes()),
-        8 => aeib.extend_from_slice(&ea_base_address.to_le_bytes()),
-        _ => aeib.extend_from_slice(&ea_base_address.to_le_bytes()),
-    }
-
-    // Inline elements (always write idx_blk_elmts slots, fill unused with undefined)
+    // Inline elements (always write idx_blk_elmts slots; fill unused as undefined).
     #[allow(clippy::needless_range_loop)]
-    for i in 0..idx_blk_elmts as usize {
-        if i < n_inline {
+    for i in 0..inline {
+        if i < num_elements {
             write_chunk_element(
                 &mut aeib,
                 &chunks[i],
@@ -881,89 +1079,21 @@ pub fn build_extensible_array_at(
             write_undefined_element(&mut aeib, offset_size, has_filters, chunk_size_bytes);
         }
     }
-
-    // Data block addresses + build data blocks
-    let mut data_blocks_buf = Vec::new();
-    let dblks_base = aeib_address + aeib_size as u64;
-    let mut dblk_cursor = dblks_base;
-    let mut chunk_idx = n_inline;
-
-    for &nelmts in &dblk_sizes {
-        if chunk_idx >= num_elements {
-            // No more chunks — write undefined address
-            match offset_size {
-                4 => aeib.extend_from_slice(&u32::MAX.to_le_bytes()),
-                8 => aeib.extend_from_slice(&u64::MAX.to_le_bytes()),
-                _ => aeib.extend_from_slice(&u64::MAX.to_le_bytes()),
-            }
-            continue;
-        }
-
-        // Write this data block's address
-        match offset_size {
-            4 => aeib.extend_from_slice(&(dblk_cursor as u32).to_le_bytes()),
-            8 => aeib.extend_from_slice(&dblk_cursor.to_le_bytes()),
-            _ => aeib.extend_from_slice(&dblk_cursor.to_le_bytes()),
-        }
-
-        // Build EADB
-        let mut aedb = Vec::new();
-        aedb.extend_from_slice(b"EADB");
-        aedb.push(0); // version
-        aedb.push(client_id);
-        match offset_size {
-            4 => aedb.extend_from_slice(&(ea_base_address as u32).to_le_bytes()),
-            8 => aedb.extend_from_slice(&ea_base_address.to_le_bytes()),
-            _ => aedb.extend_from_slice(&ea_base_address.to_le_bytes()),
-        }
-
-        // Block offset: encoded in ceil(max_nelmts_bits/8) bytes
-        // This is the EA-relative index of the first element in this data block
-        let blk_off_size = (max_nelmts_bits as usize).div_ceil(8);
-        let blk_off_val = (chunk_idx - n_inline) as u64;
-        aedb.extend_from_slice(&blk_off_val.to_le_bytes()[..blk_off_size]);
-
-        // Write elements (fill all nelmts slots, use undefined for empty)
-        for slot in 0..nelmts {
-            if chunk_idx + slot < num_elements {
-                write_chunk_element(
-                    &mut aedb,
-                    &chunks[chunk_idx + slot],
-                    offset_size,
-                    has_filters,
-                    chunk_size_bytes,
-                );
-            } else {
-                // Undefined slot
-                write_undefined_element(&mut aedb, offset_size, has_filters, chunk_size_bytes);
-            }
-        }
-
-        let aedb_checksum = jenkins_lookup3(&aedb);
-        aedb.extend_from_slice(&aedb_checksum.to_le_bytes());
-
-        dblk_cursor += aedb.len() as u64;
-        data_blocks_buf.extend_from_slice(&aedb);
-        chunk_idx += nelmts;
+    // Direct data block addresses, then super block addresses.
+    for &addr in &direct_addrs {
+        write_ea_addr(&mut aeib, addr, offset_size);
+    }
+    for &addr in &sblk_addrs {
+        write_ea_addr(&mut aeib, addr, offset_size);
     }
 
-    // Super block addresses (all undefined for now — we don't create super blocks)
-    for _ in 0..n_sblk_addrs {
-        match offset_size {
-            4 => aeib.extend_from_slice(&u32::MAX.to_le_bytes()),
-            8 => aeib.extend_from_slice(&u64::MAX.to_le_bytes()),
-            _ => aeib.extend_from_slice(&u64::MAX.to_le_bytes()),
-        }
-    }
-
-    // AEIB checksum
     let aeib_checksum = jenkins_lookup3(&aeib);
     aeib.extend_from_slice(&aeib_checksum.to_le_bytes());
     debug_assert_eq!(aeib.len(), aeib_size);
 
     let mut combined = aehd;
     combined.extend_from_slice(&aeib);
-    combined.extend_from_slice(&data_blocks_buf);
+    combined.extend_from_slice(&body);
     combined
 }
 
@@ -1632,6 +1762,31 @@ mod tests {
     fn ea_roundtrip_1d_many_chunks() {
         let values: Vec<f64> = (0..100).map(|i| i as f64).collect();
         let result = roundtrip_ea(&values, &[100], &[10], &[u64::MAX]);
+        assert_eq!(result, values);
+    }
+
+    /// One chunk per element across the inline, direct-data-block, and
+    /// super-block ranges. Before the geometry fix these silently corrupted
+    /// past 20 chunks (4 inline + the first 16-element direct block).
+    #[test]
+    fn ea_roundtrip_super_block_sizes() {
+        for &n in &[245u64, 300, 2000, 50000] {
+            let values: Vec<f64> = (0..n).map(|i| i as f64).collect();
+            let result = roundtrip_ea(&values, &[n], &[1], &[u64::MAX]);
+            assert_eq!(result.len(), n as usize, "length mismatch at n={n}");
+            assert_eq!(result, values, "data mismatch at n={n}");
+        }
+    }
+
+    /// Cross the paging boundary (131060 = 4 inline + 240 direct + super blocks
+    /// SB4..SB12), exercising paged data blocks in super block 13 (the first
+    /// whose data blocks exceed 1024 elements) on both write and read.
+    #[test]
+    fn ea_roundtrip_paged_data_blocks() {
+        let n: u64 = 132_000;
+        let values: Vec<f64> = (0..n).map(|i| i as f64).collect();
+        let result = roundtrip_ea(&values, &[n], &[1], &[u64::MAX]);
+        assert_eq!(result.len(), n as usize);
         assert_eq!(result, values);
     }
 

--- a/src/extensible_array.rs
+++ b/src/extensible_array.rs
@@ -128,14 +128,18 @@ impl ExtensibleArrayHeader {
         let max_dblk_nelmts_bits = d[11];
 
         let mut pos = 12;
-        // 6 stats fields: [0] unknown, [1] unknown, [2] nsuper_blks_created,
-        // [3] super_blk_size, [4] nelmts, [5] max_idx_set
-        // We only need nelmts (field[4]) and skip the rest.
+        // 6 statistics fields, in the HDF5 C library's stored order:
+        //   [0] nsuper_blks   [1] super_blk_size   [2] ndata_blks
+        //   [3] data_blk_size [4] max_idx_set      [5] nelmts
+        // We read max_idx_set (field [4]) — the count of elements that have been
+        // set, which bounds the live region. For a densely written array it
+        // equals the chunk count; `nelmts` (field [5]) is the larger
+        // rounded-up-to-block-boundary slot count, which we do not need.
         let ls = length_size as usize;
-        pos += 4 * ls; // skip first 4 stats fields
-        let num_elements = read_offset(d, pos, length_size)?;
-        pos += ls; // skip nelmts
-        pos += ls; // skip max_idx_set (6th stats field)
+        pos += 4 * ls; // skip [0]..[3]
+        let num_elements = read_offset(d, pos, length_size)?; // [4] max_idx_set
+        pos += ls;
+        pos += ls; // skip [5] nelmts
         let index_block_address = read_offset(d, pos, offset_size)?;
 
         Ok(ExtensibleArrayHeader {
@@ -154,6 +158,80 @@ impl ExtensibleArrayHeader {
     /// Compute the size of this header in bytes (for write support).
     pub fn serialized_size(offset_size: u8, length_size: u8) -> usize {
         4 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 6 * length_size as usize + offset_size as usize + 4
+    }
+}
+
+/// Geometry of an Extensible Array, derived from its header creation parameters.
+///
+/// This is the single source of truth for the super-block / data-block size
+/// progression, shared by both the reader (this module) and the writer
+/// (`chunked_write`). It mirrors libhdf5's `H5EA__hdr_init`: starting from
+/// `(ndblks = 1, dblk_nelmts = min_dblk_nelmts)`, each successive super block
+/// alternately doubles the elements-per-data-block (even index) and the
+/// number-of-data-blocks (odd index):
+///
+/// ```text
+///   super block i:  ndblks = 2^floor(i/2)   dblk_nelmts = min_dblk * 2^ceil(i/2)
+///   SB0: 1 x 16   SB1: 1 x 32   SB2: 2 x 32   SB3: 2 x 64   SB4: 4 x 64 ...
+/// ```
+///
+/// The first `super_blk_min_nelmts` super blocks have their data-block
+/// addresses stored directly in the index block; the rest are reached through
+/// on-disk super blocks (`EASB`) whose addresses are stored in the index block.
+#[derive(Debug, Clone)]
+pub(crate) struct EaGeometry {
+    /// `(ndblks, dblk_nelmts)` for each super block index `0..nsblks`.
+    pub sblks: Vec<(u64, u64)>,
+    /// Element count of each direct data block whose address is stored in the
+    /// index block. `len()` equals the number of direct data-block pointers.
+    pub direct_dblk_nelmts: Vec<u64>,
+    /// Number of super-block pointers stored in the index block.
+    pub nsblk_addrs: usize,
+    /// Super-block index of the first super block reached via a super-block
+    /// pointer in the index block (i.e. `super_blk_min_nelmts`).
+    pub first_indirect_sblk: usize,
+}
+
+impl EaGeometry {
+    /// Derive the geometry from a parsed header.
+    pub fn from_header(h: &ExtensibleArrayHeader) -> Self {
+        let min_dblk = h.min_dblk_nelmts as u64;
+        let sup_blk_min = h.super_blk_min_nelmts as usize;
+        // nsblks = max_nelmts_bits - log2(min_dblk_nelmts) + 1
+        let log2_min = if min_dblk <= 1 {
+            0
+        } else {
+            min_dblk.trailing_zeros() as u64
+        };
+        let nsblks = (h.max_nelmts_bits as u64).saturating_sub(log2_min) as usize + 1;
+
+        let mut sblks = Vec::with_capacity(nsblks);
+        let mut ndblks = 1u64;
+        let mut dblk_nelmts = min_dblk;
+        for u in 0..nsblks {
+            sblks.push((ndblks, dblk_nelmts));
+            if u % 2 == 0 {
+                dblk_nelmts = dblk_nelmts.saturating_mul(2);
+            } else {
+                ndblks = ndblks.saturating_mul(2);
+            }
+        }
+
+        let mut direct_dblk_nelmts = Vec::new();
+        for sb in sblks.iter().take(sup_blk_min.min(nsblks)) {
+            let (nd, dn) = *sb;
+            for _ in 0..nd {
+                direct_dblk_nelmts.push(dn);
+            }
+        }
+
+        let nsblk_addrs = nsblks.saturating_sub(sup_blk_min);
+        EaGeometry {
+            sblks,
+            direct_dblk_nelmts,
+            nsblk_addrs,
+            first_indirect_sblk: sup_blk_min,
+        }
     }
 }
 
@@ -281,14 +359,92 @@ fn read_data_block_elements(
     let blk_off_size = (header.max_nelmts_bits as usize).div_ceil(8);
     let mut pos = db_offset + db_header_size + blk_off_size;
 
-    // Check if paged
-    let page_nelmts = 1usize << header.max_nelmts_bits;
-    let is_paged = nelmts > page_nelmts;
+    // Direct data blocks and non-paged super-block data blocks store their
+    // elements inline. Paged data blocks (only ever found inside a super block
+    // whose `dblk_nelmts` exceeds the page size) are handled separately by
+    // `read_paged_data_block`, which is driven by the page-init bitmap stored
+    // in the owning super block.
+    let mut chunks = Vec::new();
+    for i in 0..nelmts {
+        let (info, consumed) = read_element(
+            file_data,
+            pos,
+            header.client_id,
+            header.element_size,
+            offset_size,
+            chunk_byte_size,
+            start_index + i,
+            num_chunks_per_dim,
+            chunk_dimensions,
+        )?;
+        if let Some(ci) = info {
+            chunks.push(ci);
+        }
+        pos += consumed;
+    }
+
+    Ok(chunks)
+}
+
+/// Test whether page `page_idx` is initialized in a super-block page-init
+/// bitmap. The bitmap is a contiguous, MSB-first bit stream: page 0 is bit 7 of
+/// byte 0, page 1 is bit 6, page 8 is bit 7 of byte 1, and so on.
+fn page_is_initialized(bitmap: &[u8], page_idx: usize) -> bool {
+    let byte = page_idx / 8;
+    let mask = 0x80u8 >> (page_idx % 8);
+    byte < bitmap.len() && (bitmap[byte] & mask) != 0
+}
+
+/// Read a paged Extensible Array data block.
+///
+/// A paged data block has a 22-byte header (signature, version, client id,
+/// header address, block offset) *followed by its own checksum*, after which
+/// the data block's pages are laid out contiguously. Each page holds
+/// `page_nelmts` element slots followed by a 4-byte checksum, and is written
+/// only when initialized. Whether page `p` of this data block is initialized is
+/// recorded in the owning super block's bitmap at global page index
+/// `db_local_idx * npages + p`. Pages are filled sequentially, so the first
+/// uninitialized page marks the end of populated data for this block.
+#[allow(clippy::too_many_arguments)]
+fn read_paged_data_block(
+    file_data: &[u8],
+    db_offset: usize,
+    page_nelmts: usize,
+    npages: usize,
+    db_local_idx: usize,
+    page_bitmap: &[u8],
+    header: &ExtensibleArrayHeader,
+    offset_size: u8,
+    chunk_byte_size: u64,
+    start_index: usize,
+    num_chunks_per_dim: &[u64],
+    chunk_dimensions: &[u32],
+) -> Result<Vec<ChunkInfo>, FormatError> {
+    let blk_off_size = (header.max_nelmts_bits as usize).div_ceil(8);
+    // Header includes its own checksum: sig(4)+ver(1)+cid(1)+hdr_addr+block_offset+checksum(4)
+    let db_header_size = 4 + 1 + 1 + offset_size as usize + blk_off_size + 4;
+    if db_offset + db_header_size > file_data.len() {
+        return Err(FormatError::UnexpectedEof {
+            expected: db_offset + db_header_size,
+            available: file_data.len(),
+        });
+    }
+    if &file_data[db_offset..db_offset + 4] != b"EADB" {
+        return Err(FormatError::ChunkedReadError(
+            "invalid Extensible Array data block signature".into(),
+        ));
+    }
 
     let mut chunks = Vec::new();
-
-    if !is_paged {
-        for i in 0..nelmts {
+    let mut pos = db_offset + db_header_size;
+    for page in 0..npages {
+        let global_page = db_local_idx * npages + page;
+        if !page_is_initialized(page_bitmap, global_page) {
+            // Pages are populated sequentially; nothing initialized after this.
+            break;
+        }
+        let page_start = start_index + page * page_nelmts;
+        for i in 0..page_nelmts {
             let (info, consumed) = read_element(
                 file_data,
                 pos,
@@ -296,7 +452,7 @@ fn read_data_block_elements(
                 header.element_size,
                 offset_size,
                 chunk_byte_size,
-                start_index + i,
+                page_start + i,
                 num_chunks_per_dim,
                 chunk_dimensions,
             )?;
@@ -305,72 +461,8 @@ fn read_data_block_elements(
             }
             pos += consumed;
         }
-    } else {
-        // Paged: elements are split into pages of page_nelmts.
-        // After the data block header comes a page bitmap, then each page
-        // has page_nelmts elements followed by a 4-byte checksum.
-        let npages = nelmts.div_ceil(page_nelmts);
-        // Page bitmap: ceil(npages / 8) bytes
-        let bitmap_size = npages.div_ceil(8);
-        // Read bitmap
-        if pos + bitmap_size > file_data.len() {
-            return Err(FormatError::UnexpectedEof {
-                expected: pos + bitmap_size,
-                available: file_data.len(),
-            });
-        }
-        let bitmap = &file_data[pos..pos + bitmap_size];
-        pos += bitmap_size;
-
-        let elem_bytes = if header.client_id == 0 {
-            offset_size as usize
-        } else {
-            header.element_size as usize
-        };
-
-        let mut global_idx = start_index;
-        for page_idx in 0..npages {
-            let byte_idx = page_idx / 8;
-            let bit_idx = page_idx % 8;
-            let page_has_data = (bitmap[byte_idx] >> bit_idx) & 1 != 0;
-
-            let elems_this_page = if page_idx == npages - 1 {
-                let remainder = nelmts % page_nelmts;
-                if remainder == 0 {
-                    page_nelmts
-                } else {
-                    remainder
-                }
-            } else {
-                page_nelmts
-            };
-
-            if page_has_data {
-                for i in 0..elems_this_page {
-                    let (info, consumed) = read_element(
-                        file_data,
-                        pos,
-                        header.client_id,
-                        header.element_size,
-                        offset_size,
-                        chunk_byte_size,
-                        global_idx + i,
-                        num_chunks_per_dim,
-                        chunk_dimensions,
-                    )?;
-                    if let Some(ci) = info {
-                        chunks.push(ci);
-                    }
-                    pos += consumed;
-                }
-                // Skip page checksum (4 bytes)
-                pos += 4;
-            } else {
-                // Empty page: skip all elements + checksum
-                pos += elems_this_page * elem_bytes + 4;
-            }
-            global_idx += elems_this_page;
-        }
+        // Skip the page checksum.
+        pos += 4;
     }
 
     Ok(chunks)
@@ -454,125 +546,74 @@ pub fn read_extensible_array_chunks(
         return Ok(chunks);
     }
 
-    // Compute data block and super block counts
-    let min_dblk = header.min_dblk_nelmts as usize;
-    let sblk_min = header.super_blk_min_nelmts as usize;
+    // Derive the (shared) extensible-array geometry from the header. This is
+    // the same progression the writer uses, so reader and writer cannot drift.
+    let geom = EaGeometry::from_header(header);
 
-    // The first sblk_min super block levels have their data blocks listed directly
-    // in the index block. Compute their sizes.
-    let mut n_direct_dblks = 0usize;
-    let mut dblk_sizes: Vec<usize> = Vec::new();
-    {
-        let mut nelmts = min_dblk;
-        for sb_level in 0..sblk_min {
-            let ndblks = 1usize << sb_level;
-            for _ in 0..ndblks {
-                dblk_sizes.push(nelmts);
-                n_direct_dblks += 1;
-            }
-            if sb_level > 0 {
-                nelmts *= 2;
-            }
-        }
-    }
-
-    // Read direct data block addresses from index block
-    let mut dblk_addrs: Vec<u64> = Vec::with_capacity(n_direct_dblks);
-    for _ in 0..n_direct_dblks {
-        if pos + os > file_data.len() {
-            break;
-        }
-        let addr = read_offset(file_data, pos, offset_size)?;
-        dblk_addrs.push(addr);
+    // 2. Direct data blocks: their addresses are listed in the index block,
+    //    one per entry in `geom.direct_dblk_nelmts`.
+    let mut direct_addrs: Vec<u64> = Vec::with_capacity(geom.direct_dblk_nelmts.len());
+    for _ in 0..geom.direct_dblk_nelmts.len() {
+        direct_addrs.push(read_offset(file_data, pos, offset_size)?);
         pos += os;
     }
-
-    // Read elements from direct data blocks
-    for (i, &addr) in dblk_addrs.iter().enumerate() {
-        if i >= dblk_sizes.len() {
+    for (i, &addr) in direct_addrs.iter().enumerate() {
+        if global_index >= total_elements {
             break;
         }
-        let nelmts = dblk_sizes[i];
-        if is_undefined_addr(addr, offset_size) {
-            global_index += nelmts;
-            continue;
+        let nelmts = geom.direct_dblk_nelmts[i] as usize;
+        if !is_undefined_addr(addr, offset_size) {
+            let block_chunks = read_data_block_elements(
+                file_data,
+                addr as usize,
+                nelmts,
+                header,
+                offset_size,
+                chunk_byte_size,
+                global_index,
+                &num_chunks_per_dim,
+                chunk_dimensions,
+            )?;
+            chunks.extend(block_chunks);
         }
-        let block_chunks = read_data_block_elements(
-            file_data,
-            addr as usize,
-            nelmts,
-            header,
-            offset_size,
-            chunk_byte_size,
-            global_index,
-            &num_chunks_per_dim,
-            chunk_dimensions,
-        )?;
-        chunks.extend(block_chunks);
+        // Advance even for undefined blocks so linear indices stay aligned.
         global_index += nelmts;
     }
 
-    // Remaining elements are in super blocks
-    let total_in_ib_and_direct: usize = n_inline + dblk_sizes.iter().sum::<usize>();
-    if total_elements <= total_in_ib_and_direct {
-        return Ok(chunks);
-    }
-    let remaining_elements = total_elements - total_in_ib_and_direct;
-
-    // Compute super block layout
-    let mut sb_addrs: Vec<u64> = Vec::new();
-    let mut sb_infos: Vec<(usize, usize)> = Vec::new();
-    {
-        let mut covered = 0usize;
-        let mut sb_level = sblk_min;
-        let mut nelmts_per_dblk = min_dblk;
-        for lev in 0..sblk_min {
-            if lev > 0 {
-                nelmts_per_dblk *= 2;
-            }
-        }
-
-        while covered < remaining_elements {
-            let ndblks = 1usize << sb_level;
-            nelmts_per_dblk *= 2;
-            let total_in_sb = ndblks * nelmts_per_dblk;
-            sb_infos.push((ndblks, nelmts_per_dblk));
-            covered += total_in_sb;
-            sb_level += 1;
-        }
-    }
-
-    // Read super block addresses from index block
-    for _ in 0..sb_infos.len() {
+    // 3. Super blocks: the remaining `geom.nsblk_addrs` index-block entries are
+    //    addresses of on-disk super blocks (`EASB`). Super-block pointer `j`
+    //    refers to super block `first_indirect_sblk + j`.
+    let mut sblk_addrs: Vec<u64> = Vec::with_capacity(geom.nsblk_addrs);
+    for _ in 0..geom.nsblk_addrs {
         if pos + os > file_data.len() {
             break;
         }
-        let addr = read_offset(file_data, pos, offset_size)?;
-        sb_addrs.push(addr);
+        sblk_addrs.push(read_offset(file_data, pos, offset_size)?);
         pos += os;
     }
-
-    // Process each super block
-    for (sb_idx, &sb_addr) in sb_addrs.iter().enumerate() {
-        let (ndblks, nelmts_per_dblk) = sb_infos[sb_idx];
-        if is_undefined_addr(sb_addr, offset_size) {
-            global_index += ndblks * nelmts_per_dblk;
-            continue;
+    for (j, &sb_addr) in sblk_addrs.iter().enumerate() {
+        if global_index >= total_elements {
+            break;
         }
-        let sb_chunks = read_super_block(
-            file_data,
-            sb_addr as usize,
-            ndblks,
-            nelmts_per_dblk,
-            header,
-            offset_size,
-            chunk_byte_size,
-            global_index,
-            &num_chunks_per_dim,
-            chunk_dimensions,
-        )?;
-        chunks.extend(sb_chunks);
-        global_index += ndblks * nelmts_per_dblk;
+        let sblk_idx = geom.first_indirect_sblk + j;
+        let (ndblks, dblk_nelmts) = geom.sblks[sblk_idx];
+        let total_in_sb = (ndblks * dblk_nelmts) as usize;
+        if !is_undefined_addr(sb_addr, offset_size) {
+            let sb_chunks = read_super_block(
+                file_data,
+                sb_addr as usize,
+                ndblks as usize,
+                dblk_nelmts as usize,
+                header,
+                offset_size,
+                chunk_byte_size,
+                global_index,
+                &num_chunks_per_dim,
+                chunk_dimensions,
+            )?;
+            chunks.extend(sb_chunks);
+        }
+        global_index += total_in_sb;
     }
 
     Ok(chunks)
@@ -595,7 +636,12 @@ fn read_super_block(
     let os = offset_size as usize;
 
     // AESB: signature(4) + version(1) + client_id(1) + header_address(offset_size)
-    let sb_header_size = 4 + 1 + 1 + os;
+    //       + block_offset(ceil(max_nelmts_bits/8))
+    //       + [page-init bitmap, if data blocks are paged]
+    //       + data block addresses
+    //       + checksum
+    let blk_off_size = (header.max_nelmts_bits as usize).div_ceil(8);
+    let sb_header_size = 4 + 1 + 1 + os + blk_off_size;
     if sb_offset + sb_header_size > file_data.len() {
         return Err(FormatError::UnexpectedEof {
             expected: sb_offset + sb_header_size,
@@ -611,7 +657,33 @@ fn read_super_block(
 
     let mut pos = sb_offset + sb_header_size;
 
-    // Read data block addresses
+    // A super block's data blocks are paged when their element count exceeds
+    // the page size. When paged, a page-init bitmap precedes the data block
+    // addresses. Its size is `ndblks * ceil(npages / 8)` bytes, and it is a
+    // contiguous bit stream indexed by `db_local_idx * npages + page`.
+    let page_nelmts = 1usize << header.max_dblk_nelmts_bits;
+    let is_paged = nelmts_per_dblk > page_nelmts;
+    let npages = if is_paged {
+        nelmts_per_dblk / page_nelmts
+    } else {
+        0
+    };
+    let page_bitmap: Vec<u8> = if is_paged {
+        let bitmap_size = ndblks * npages.div_ceil(8);
+        if pos + bitmap_size > file_data.len() {
+            return Err(FormatError::UnexpectedEof {
+                expected: pos + bitmap_size,
+                available: file_data.len(),
+            });
+        }
+        let bm = file_data[pos..pos + bitmap_size].to_vec();
+        pos += bitmap_size;
+        bm
+    } else {
+        Vec::new()
+    };
+
+    // Read data block addresses.
     let mut dblk_addrs: Vec<u64> = Vec::with_capacity(ndblks);
     for _ in 0..ndblks {
         if pos + os > file_data.len() {
@@ -628,23 +700,38 @@ fn read_super_block(
     let mut chunks = Vec::new();
     let mut global_idx = start_index;
 
-    for &addr in &dblk_addrs {
-        if is_undefined_addr(addr, offset_size) {
-            global_idx += nelmts_per_dblk;
-            continue;
+    for (db_local, &addr) in dblk_addrs.iter().enumerate() {
+        if !is_undefined_addr(addr, offset_size) {
+            let block_chunks = if is_paged {
+                read_paged_data_block(
+                    file_data,
+                    addr as usize,
+                    page_nelmts,
+                    npages,
+                    db_local,
+                    &page_bitmap,
+                    header,
+                    offset_size,
+                    chunk_byte_size,
+                    global_idx,
+                    num_chunks_per_dim,
+                    chunk_dimensions,
+                )?
+            } else {
+                read_data_block_elements(
+                    file_data,
+                    addr as usize,
+                    nelmts_per_dblk,
+                    header,
+                    offset_size,
+                    chunk_byte_size,
+                    global_idx,
+                    num_chunks_per_dim,
+                    chunk_dimensions,
+                )?
+            };
+            chunks.extend(block_chunks);
         }
-        let block_chunks = read_data_block_elements(
-            file_data,
-            addr as usize,
-            nelmts_per_dblk,
-            header,
-            offset_size,
-            chunk_byte_size,
-            global_idx,
-            num_chunks_per_dim,
-            chunk_dimensions,
-        )?;
-        chunks.extend(block_chunks);
         global_idx += nelmts_per_dblk;
     }
 

--- a/tests/extensible_array_crosscheck.rs
+++ b/tests/extensible_array_crosscheck.rs
@@ -1,0 +1,115 @@
+//! Cross-validation for Extensible-Array-indexed chunked datasets (one unlimited
+//! dimension), in both directions against the reference C HDF5 library.
+//!
+//! These guard the EA block-size geometry, super blocks, and paged data blocks.
+//! Sizes are chosen to span every structural range:
+//!   - 20      inline (4) + first direct data block (16)
+//!   - 300     all 6 direct data blocks + the first super block
+//!   - 2000    several super blocks
+//!   - 50000   deeper super-block nesting
+//!   - 140000  past 131060 chunks: paged data blocks
+//!
+//! Before the geometry fix, anything past 20 chunks silently corrupted on read.
+
+use hdf5::Extent;
+use hdf5::file::LibraryVersion;
+use hdf5_pure::{File, FileBuilder};
+use tempfile::tempdir;
+
+const SIZES: &[usize] = &[20, 300, 2000, 50000, 140000];
+
+/// Create a 1-D unlimited, chunked i32 dataset with the reference C library,
+/// using the latest format so the chunk index is an Extensible Array.
+fn write_with_c(path: &std::path::Path, n: usize) {
+    let file = hdf5::File::with_options()
+        .with_fapl(|p| p.libver_bounds(LibraryVersion::V110, LibraryVersion::latest()))
+        .create(path)
+        .unwrap();
+    let ds = file
+        .new_dataset::<i32>()
+        .chunk((1,))
+        .shape((Extent::resizable(n),))
+        .create("d")
+        .unwrap();
+    let data: Vec<i32> = (0..n as i32).collect();
+    ds.write(&data).unwrap();
+    file.close().unwrap();
+}
+
+/// Create the same dataset with hdf5-pure.
+fn write_with_pure(path: &std::path::Path, n: usize) {
+    let data: Vec<i32> = (0..n as i32).collect();
+    let mut b = FileBuilder::new();
+    b.create_dataset("d")
+        .with_i32_data(&data)
+        .with_shape(&[n as u64])
+        .with_maxshape(&[u64::MAX])
+        .with_chunks(&[1]);
+    b.write(path).unwrap();
+}
+
+/// Direction 1: hdf5-pure writes, the reference C library reads.
+#[test]
+fn pure_writes_c_reads() {
+    for &n in SIZES {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("ea.h5");
+        write_with_pure(&path, n);
+
+        let file = hdf5::File::open(&path).unwrap();
+        let ds = file.dataset("d").unwrap();
+        let values = ds.read_raw::<i32>().unwrap();
+        let expected: Vec<i32> = (0..n as i32).collect();
+        assert_eq!(values.len(), n, "C read wrong length for n={n}");
+        assert_eq!(values, expected, "C read wrong data for n={n}");
+    }
+}
+
+/// Direction 2: the reference C library writes, hdf5-pure reads.
+#[test]
+fn c_writes_pure_reads() {
+    for &n in SIZES {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("ea.h5");
+        write_with_c(&path, n);
+
+        let bytes = std::fs::read(&path).unwrap();
+        let file = File::from_bytes(bytes).unwrap();
+        let ds = file.dataset("d").unwrap();
+        let values = ds.read_i32().unwrap();
+        let expected: Vec<i32> = (0..n as i32).collect();
+        assert_eq!(values.len(), n, "hdf5-pure read wrong length for n={n}");
+        assert_eq!(values, expected, "hdf5-pure read wrong data for n={n}");
+    }
+}
+
+/// The EA header's six statistics fields must match the C library byte-for-byte
+/// (the C library recomputes and would reject inconsistent computed stats; the
+/// stored max_idx_set / nelmts must also agree). Compares the headers of the two
+/// files for identical datasets.
+#[test]
+fn eahd_stats_match_c() {
+    fn stats_of(path: &std::path::Path) -> Vec<u64> {
+        let b = std::fs::read(path).unwrap();
+        let h = (0..b.len() - 4).find(|&i| &b[i..i + 4] == b"EAHD").unwrap();
+        (0..6)
+            .map(|k| {
+                let p = h + 12 + k * 8;
+                u64::from_le_bytes(b[p..p + 8].try_into().unwrap())
+            })
+            .collect()
+    }
+
+    for &n in SIZES {
+        let dir = tempdir().unwrap();
+        let c_path = dir.path().join("c.h5");
+        let pure_path = dir.path().join("pure.h5");
+        write_with_c(&c_path, n);
+        write_with_pure(&pure_path, n);
+        assert_eq!(
+            stats_of(&pure_path),
+            stats_of(&c_path),
+            "EAHD stats differ from the C library at n={n}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

The Extensible Array chunk index (used for chunked datasets with one unlimited dimension) had a latent correctness bug: the reader and writer used two independent, divergent data-block size progressions that coincided only up to 20 chunks (4 inline elements + the first 16-element data block). Beyond that, reading any EA-indexed 1-D unlimited dataset (written by h5py, MATLAB, the reference C library, or this crate) silently returned wrong data, and writing more than 244 chunks silently dropped the excess because the writer never emitted super blocks or paged data blocks.

No existing test exercised unlimited dimensions, which is why this went unnoticed.

## Fix

Both sides now share a single block-size geometry (`EaGeometry`) derived from the array's creation parameters, matching the HDF5 format and the reference C library:

- **Reader**: correct direct-block / super-block size progression (`ndblks = 2^floor(i/2)`, `dblk_nelmts = 16 * 2^ceil(i/2)`), skips the super block's block-offset field, and reads paged data blocks using the page-init bitmap stored in the super block (sized `ndblks * ceil(npages/8)` as a global MSB-first bit stream).
- **Writer**: emits super blocks and, above 131056 chunks, paged data blocks; the EA header statistics now match the reference C library byte-for-byte.

## Verification

Verified against the reference C HDF5 library (hdf5-metno) in both directions — hdf5-pure writes / C reads, and C writes / hdf5-pure reads — across the inline, direct-block, super-block, and paged ranges (`tests/extensible_array_crosscheck.rs`), plus self-round-trip unit tests for the same ranges. Full test suite green; clippy clean.

Found while implementing SWMR support (#17); this fix is the self-contained prerequisite.
