### PR TITLE
Fix clippy lints in the zfp codec (range syntax)

### DIFF
--- a/src/zfp.rs
+++ b/src/zfp.rs
@@ -480,7 +480,7 @@ fn inv_cast_f64_slice(emax_biased: u64, coeffs: &[i64], out: &mut [f64]) {
 /// exceed the normal-range upper bound (up to ~2^1083).
 #[inline]
 fn pow2_f64_wide(exp: i32) -> f64 {
-    if exp >= -1022 && exp <= 1023 {
+    if (-1022..=1023).contains(&exp) {
         return pow2_f64(exp);
     }
     let mut remaining = exp;
@@ -504,7 +504,10 @@ fn pow2_f64_wide(exp: i32) -> f64 {
 /// not need a subnormal/overflow fallback path.
 #[inline]
 fn pow2_f64(exp: i32) -> f64 {
-    debug_assert!(exp >= -1022 && exp <= 1023, "pow2_f64 out of normal range");
+    debug_assert!(
+        (-1022..=1023).contains(&exp),
+        "pow2_f64 out of normal range"
+    );
     let biased = (exp + 1023) as u64;
     f64::from_bits(biased << 52)
 }

--- a/tests/zfp_crosscheck.rs
+++ b/tests/zfp_crosscheck.rs
@@ -83,7 +83,7 @@ fn read_bin(name: &str) -> Vec<u8> {
 /// far. All four types and 1D–4D are in scope after Step 5.
 fn is_supported(fix: &Fixture) -> bool {
     let dtype_ok = matches!(fix.dtype.as_str(), "f32" | "f64" | "i32" | "i64");
-    let rank_ok = matches!(fix.shape.len(), 1 | 2 | 3 | 4);
+    let rank_ok = matches!(fix.shape.len(), 1..=4);
     dtype_ok && rank_ok && fix.mode == "rate"
 }
 


### PR DESCRIPTION
Pre-existing clippy failures in the zfp codec, surfaced during review of #18. `cargo clippy --all-targets --all-features -- -D warnings` fails under newer clippy (1.96) on:

- `src/zfp.rs:483` and `:507` — `manual_range_contains` (the `pow2_f64` / `pow2_f64_wide` exponent-range checks, `exp >= -1022 && exp <= 1023`).
- `tests/zfp_crosscheck.rs:86` — `manual_range_patterns` (the rank check, `1 | 2 | 3 | 4`), which only the lib's two were visible until those were fixed.

Rewritten with range syntax (`(-1022..=1023).contains(&exp)`, `matches!(.., 1..=4)`); behavior is unchanged. The lint gate now passes with `--all-features --all-targets`, and the full zfp test suite is green.

Independent of the SWMR work (#18 / #19) — these files are untouched by those PRs; this just keeps the clippy gate green on newer toolchains and under `--all-features`.