### PR TITLE
Pin the ZFP fixture-regeneration toolchain

### DIFF
--- a/tests/fixtures/zfp/manifest.json
+++ b/tests/fixtures/zfp/manifest.json
@@ -248,6 +248,25 @@
       "notes": "length not a multiple of 4 -> partial block"
     },
     {
+      "name": "f32_1d_4_varied_rate24",
+      "dtype": "f32",
+      "shape": [
+        4
+      ],
+      "rate": 24.0,
+      "mode": "rate",
+      "filter_name": "H5Z-ZFP-1.1.1 (ZFP-1.0.1)",
+      "cd_values_u32": [
+        269504785,
+        91252346,
+        50,
+        99614720
+      ],
+      "raw_bytes_len": 16,
+      "compressed_bytes_len": 12,
+      "notes": "mixed-magnitude block that exposes a reference-diff at rate 24"
+    },
+    {
       "name": "i32_1d_16_ramp_rate16",
       "dtype": "i32",
       "shape": [
@@ -766,25 +785,6 @@
       "raw_bytes_len": 2048,
       "compressed_bytes_len": 512,
       "notes": ""
-    },
-    {
-      "name": "f32_1d_4_varied_rate24",
-      "dtype": "f32",
-      "shape": [
-        4
-      ],
-      "rate": 24.0,
-      "mode": "rate",
-      "filter_name": "H5Z-ZFP-1.1.1 (ZFP-1.0.1)",
-      "cd_values_u32": [
-        269504785,
-        91252346,
-        50,
-        99614720
-      ],
-      "raw_bytes_len": 16,
-      "compressed_bytes_len": 12,
-      "notes": "mixed-magnitude block that exposes a reference-diff at rate 24"
     }
   ]
 }

--- a/tests/fixtures/zfp/regen.py
+++ b/tests/fixtures/zfp/regen.py
@@ -1,4 +1,12 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = "==3.13.*"
+# dependencies = [
+#     "h5py==3.16.0",
+#     "hdf5plugin==6.0.0",
+#     "numpy==2.4.4",
+# ]
+# ///
 """Regenerate ZFP crosscheck fixtures from the reference H5Z-ZFP plugin.
 
 Produces a `manifest.json` plus three files per fixture:
@@ -6,7 +14,16 @@ Produces a `manifest.json` plus three files per fixture:
   <name>.compressed.bin   reference compressed chunk bytes (single chunk)
   <name>.cd.bin           cd_values as u32 little-endian tuple (informational)
 
-Run from repo root inside the project-local venv:
+The pinned versions above are the exact toolchain that produced the committed
+fixtures: hdf5plugin 6.0.0 bundles H5Z-ZFP 1.1.1 / ZFP 1.0.1, matching the
+`filter_name` recorded in `manifest.json`. Keep them in sync if you bump either.
+
+Run from the repo root with uv (resolves the pins above automatically):
+    uv run tests/fixtures/zfp/regen.py
+
+Or in a venv pinned from the sibling requirements file:
+    python -m venv tests/fixtures/zfp/.venv
+    tests/fixtures/zfp/.venv/bin/pip install -r tests/fixtures/zfp/requirements.txt
     tests/fixtures/zfp/.venv/bin/python tests/fixtures/zfp/regen.py
 """
 
@@ -124,6 +141,18 @@ def build_cases() -> list[Case]:
             data=np.arange(13, dtype=np.float64),
             rate=16.0,
             notes="length not a multiple of 4 -> partial block",
+        )
+    )
+    # edge: single partial block of mixed magnitudes at a high rate, which
+    # historically exposed a reference-diff in the decoder.
+    cases.append(
+        Case(
+            name="f32_1d_4_varied_rate24",
+            dtype="f32",
+            shape=(4,),
+            data=np.array([100.0, -50.5, 42.0, 80.0], dtype=np.float64),
+            rate=24.0,
+            notes="mixed-magnitude block that exposes a reference-diff at rate 24",
         )
     )
 

--- a/tests/fixtures/zfp/requirements.txt
+++ b/tests/fixtures/zfp/requirements.txt
@@ -1,0 +1,12 @@
+# Pinned toolchain for regenerating the ZFP crosscheck fixtures via regen.py.
+#
+# These are the exact versions that produced the committed fixtures:
+# hdf5plugin 6.0.0 bundles H5Z-ZFP 1.1.1 / ZFP 1.0.1, matching the
+# `filter_name` recorded in manifest.json. Bump deliberately, then regenerate
+# and commit the resulting fixtures + manifest together.
+#
+# Tested with Python 3.13.5. Prefer `uv run regen.py`, which reads the
+# equivalent PEP 723 pins embedded in regen.py and needs no venv.
+h5py==3.16.0
+hdf5plugin==6.0.0
+numpy==2.4.4

--- a/tests/swmr_concurrent.rs
+++ b/tests/swmr_concurrent.rs
@@ -2,7 +2,14 @@
 //! the superblock SWMR flag set) while h5py opens the same file with
 //! `swmr=True` and reads the appended data concurrently.
 //!
-//! Skipped automatically when python3 / h5py are unavailable.
+//! Skipped automatically when python3 / h5py are unavailable, so this is an
+//! optional interop probe rather than a hard dependency (CI does not install
+//! h5py). To run it deterministically, use the version the probe was validated
+//! against (h5py 3.16.0 on CPython 3.13):
+//!
+//!     uv run --with h5py==3.16.0 -- cargo test --test swmr_concurrent
+//!
+//! `uv run` puts a pinned python3 + h5py on PATH for the duration of the test.
 
 use hdf5_pure::{FileBuilder, SwmrWriter};
 use tempfile::tempdir;


### PR DESCRIPTION
Regenerating the committed ZFP crosscheck fixtures was not reproducible: `regen.py` shelled out to whatever `h5py` / `hdf5plugin` / `numpy` happened to be on `PATH`. This pins the exact toolchain that produced the committed fixtures, without changing how the test runs.

## Changes

- **Pin `regen.py`.** Add PEP 723 inline metadata (`h5py==3.16.0`, `hdf5plugin==6.0.0`, `numpy==2.4.4`; Python 3.13) so `uv run tests/fixtures/zfp/regen.py` resolves the pins with no venv, plus a `requirements.txt` for pip users. `hdf5plugin` 6.0.0 bundles H5Z-ZFP 1.1.1 / ZFP 1.0.1, matching the `filter_name` recorded in `manifest.json`.
- **Fix pre-existing generator drift.** The committed manifest and fixtures included `f32_1d_4_varied_rate24` ("mixed-magnitude block that exposes a reference-diff at rate 24"), but the generator no longer produced it, so a regeneration would have silently dropped that regression coverage. Restored the case to `regen.py`. The pinned toolchain reproduces every binary fixture byte-for-byte (identical `cd_values` and lengths); the only manifest changes are that entry moving into its logical f32-1D group and a trailing newline.
- **Document the SWMR interop probe.** Note the validated `h5py` version (3.16.0 / CPython 3.13) and a `uv run`-based invocation. The probe keeps its skip-if-absent behavior and remains optional (CI does not install h5py).

## Scope

The crosscheck test itself stays hermetic against the committed fixtures and needs no Python at runtime. These changes only make *regeneration* reproducible. Deliberately not containerizing the test run: the fixtures are already self-contained, so a container would add contributor friction without buying reproducibility we do not already have.

## Verification

- `cargo test --features zfp --test zfp_crosscheck` passes.
- Ran `regen.py` under the pinned venv: all `.bin` / `.h5` fixtures byte-identical to what is committed.