### PR TITLE
CI: add macOS and Windows to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,29 +10,39 @@ env:
 
 jobs:
   test:
-    name: Test (${{ matrix.name }})
-    runs-on: ubuntu-latest
+    name: Test (${{ matrix.os }} / ${{ matrix.config.name }})
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        include:
+        # `default` and `full` run on every platform so we exercise both the
+        # minimal and maximal feature sets on Linux, macOS, and Windows.
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        config:
           - name: default
             flags: ""
-          - name: serde
-            flags: --features serde
-          - name: zfp
-            flags: --features zfp
           # `matio-crosscheck` is intentionally excluded: it links against the
           # system libmatio and is meant for maintainer-local crosscheck runs.
           - name: full
             flags: --features "serde zfp fast-deflate fast-checksum provenance mmap parallel"
+        # The single-feature isolation configs only need to run on one platform;
+        # they are subsets of `full`, which already runs everywhere.
+        include:
+          - os: ubuntu-latest
+            config:
+              name: serde
+              flags: --features serde
+          - os: ubuntu-latest
+            config:
+              name: zfp
+              flags: --features zfp
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
-          key: ${{ matrix.name }}
-      - run: cargo test --locked ${{ matrix.flags }}
+          key: ${{ matrix.os }}-${{ matrix.config.name }}
+      - run: cargo test --locked ${{ matrix.config.flags }}
 
   no-std-check:
     name: Check (no_std)

--- a/src/chunked_write.rs
+++ b/src/chunked_write.rs
@@ -1943,10 +1943,14 @@ mod tests {
 
     // ---- h5py round-trip tests for chunked writes ----
 
+    // Runs `script` under python3, passing the HDF5 file path as `sys.argv[1]`
+    // so the script can open it without interpolating the path into the source.
+    // Interpolating a Windows path (with backslashes) into a Python string
+    // literal breaks the parser (e.g. `\U` triggers a unicode-escape error).
     #[cfg(feature = "std")]
-    fn h5py_run(script: &str) -> Option<String> {
+    fn h5py_run(path: &std::path::Path, script: &str) -> Option<String> {
         let o = std::process::Command::new("python3")
-            .args(["-c", script])
+            .args(["-c", script, &path.to_string_lossy()])
             .output()
             .ok()?;
         if !o.status.success() {
@@ -1977,11 +1981,10 @@ mod tests {
         let bytes = fw.finish().unwrap();
         let path = std::env::temp_dir().join("rustyhdf5_chunked_multi.h5");
         std::fs::write(&path, &bytes).unwrap();
-        let script = format!(
-            "import h5py,json; f=h5py.File('{}','r'); print(json.dumps({{'a':f['a'][:].tolist(),'b':f['b'][:].tolist()}}))",
-            path.display()
-        );
-        let Some(out) = h5py_run(&script) else { return };
+        let script = "import sys,h5py,json; f=h5py.File(sys.argv[1],'r'); print(json.dumps({'a':f['a'][:].tolist(),'b':f['b'][:].tolist()}))";
+        let Some(out) = h5py_run(&path, script) else {
+            return;
+        };
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
         let va: Vec<f64> = serde_json::from_value(v["a"].clone()).unwrap();
         let vb: Vec<f64> = serde_json::from_value(v["b"].clone()).unwrap();
@@ -2003,11 +2006,10 @@ mod tests {
         let bytes = fw.finish().unwrap();
         let path = std::env::temp_dir().join("rustyhdf5_chunked_attrs.h5");
         std::fs::write(&path, &bytes).unwrap();
-        let script = format!(
-            "import h5py,json; f=h5py.File('{}','r'); d=f['data']; print(json.dumps({{'values':d[:].tolist(),'units':d.attrs['units'].decode() if isinstance(d.attrs['units'],bytes) else str(d.attrs['units'])}}))",
-            path.display()
-        );
-        let Some(out) = h5py_run(&script) else { return };
+        let script = "import sys,h5py,json; f=h5py.File(sys.argv[1],'r'); d=f['data']; print(json.dumps({'values':d[:].tolist(),'units':d.attrs['units'].decode() if isinstance(d.attrs['units'],bytes) else str(d.attrs['units'])}))";
+        let Some(out) = h5py_run(&path, script) else {
+            return;
+        };
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
         let values: Vec<f64> = serde_json::from_value(v["values"].clone()).unwrap();
         assert_eq!(values, data);


### PR DESCRIPTION
Closes #23.

Adds macOS and Windows to the CI test matrix so the crate is exercised beyond Linux.

## Changes

The `test` job gains an `os` dimension:

- `default` and `full` (the minimal and maximal feature sets) now run on **ubuntu-latest**, **macos-latest**, and **windows-latest**.
- The single-feature isolation configs (`serde`, `zfp`) stay Linux-only via `include`, since they are strict subsets of `full`, which already runs everywhere.

This expands the job set to 8. The cache key now includes the OS so the three platforms do not collide, and `fail-fast: false` (already set) keeps a single-platform failure from masking the rest.

The `no-std`, `wasm`, and `lint` jobs remain Linux-only since they are platform-independent.

## Notes

- The crate itself has no `cfg(unix)`/`cfg(windows)` code, so the pure-Rust path is portable.
- Windows is the main unknown: the crosscheck tests pull in the `hdf5-metno` dev-dependency with the `static` feature, which builds the HDF5 C library from source (needs MSVC + CMake, both present on GitHub's Windows runners). If anything snags on first run it will most likely be there or in the SWMR file-locking tests.