### PR TITLE
Add ndarray N-dimensional array support (#24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           # `matio-crosscheck` is intentionally excluded: it links against the
           # system libmatio and is meant for maintainer-local crosscheck runs.
           - name: full
-            flags: --features "serde zfp fast-deflate fast-checksum provenance mmap parallel"
+            flags: --features "serde zfp fast-deflate fast-checksum provenance parallel ndarray"
         # The single-feature isolation configs only need to run on one platform;
         # they are subsets of `full`, which already runs everywhere.
         include:
@@ -36,6 +36,10 @@ jobs:
             config:
               name: zfp
               flags: --features zfp
+          - os: ubuntu-latest
+            config:
+              name: ndarray
+              flags: --features ndarray
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -85,4 +89,15 @@ jobs:
       - name: Rustfmt
         run: cargo fmt --all -- --check
       - name: Clippy
-        run: cargo clippy --locked --features serde --all-targets -- -D warnings
+        run: cargo clippy --locked --features "serde ndarray" --all-targets -- -D warnings
+
+  shear:
+    name: Unused dependencies (cargo-shear)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-shear
+      - run: cargo shear

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- N-dimensional array I/O via the optional `ndarray` feature ([#24](https://github.com/stephenberry/hdf5-pure/issues/24)). `DatasetBuilder::with_ndarray` writes any `ndarray` array or view, inferring the dataset shape and datatype from it, and `Dataset::read_array` / `Dataset::read_array_dyn` read a dataset back into a typed `ndarray::Array` (fixed rank) or `ArrayD` (runtime rank). Data is stored row-major (C order), so files are byte-compatible with the reference HDF5 library (verified by cross-check); non-standard-layout inputs (transposed, Fortran-order, or strided views) are repacked to row-major on write, and chunking/compression chain as usual. The feature is off by default and implies `std`, keeping the core build dependency-free and WASM/`no_std`-clean. The supported element types (`f32`, `f64`, and the signed and unsigned 8/16/32/64-bit integers) are described by the new sealed `H5Element` trait.
+
+### Changed
+
+- Writing a dataset whose shape disagrees with the supplied data now fails fast with `FormatError::ShapeDataMismatch` (the element count implied by the shape must match the data length) instead of silently producing a file that cannot be read back.
+
+### Removed
+
+- The `mmap` feature and its `memmap2` dependency, which were declared but never implemented — enabling `mmap` did nothing ([#24](https://github.com/stephenberry/hdf5-pure/issues/24)). Downstream code that named the feature should drop it.
+
 ## [0.7.0] - 2026-06-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,7 +245,7 @@ dependencies = [
  "hdf5-metno-sys",
  "hdf5-metno-types",
  "libc",
- "ndarray 0.17.2",
+ "ndarray",
  "paste",
 ]
 
@@ -310,8 +310,7 @@ dependencies = [
  "crc32fast",
  "flate2",
  "hdf5-metno",
- "memmap2",
- "ndarray 0.16.1",
+ "ndarray",
  "rayon",
  "serde",
  "serde_json",
@@ -431,15 +430,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
-name = "memmap2"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,21 +437,6 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
-]
-
-[[package]]
-name = "ndarray"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
-dependencies = [
- "matrixmultiply",
- "num-complex",
- "num-integer",
- "num-traits",
- "portable-atomic",
- "portable-atomic-util",
- "rawpointer",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,14 @@ fast-checksum = ["crc32fast"]
 deflate = ["flate2"]
 fast-deflate = ["flate2/zlib-ng"]
 provenance = ["sha2"]
-mmap = ["memmap2"]
 parallel = ["rayon"]
 # Pure-Rust ZFP fixed-rate compression filter (HDF5 filter ID 32013).
 # Supports f32/f64/i32/i64 datasets in 1D–4D.
 zfp = []
+# Ergonomic N-dimensional array I/O via the `ndarray` crate
+# (`DatasetBuilder::with_ndarray`, `Dataset::read_array`/`read_array_dyn`).
+# Requires `std` (it builds on the File/Dataset reader and writer APIs).
+ndarray = ["dep:ndarray", "std"]
 # Serde-based (de)serialization of MATLAB v7.3 .mat files.
 # Requires `std` (uses File/Group/Dataset reader APIs).
 serde = ["dep:serde", "std"]
@@ -40,15 +43,17 @@ flate2 = { version = "1", optional = true, default-features = false, features = 
 sha2 = { version = "0.10", optional = true, default-features = false }
 rayon = { version = "1", optional = true }
 crc32fast = { version = "1", optional = true }
-memmap2 = { version = "0.9", optional = true }
 serde = { version = "1", optional = true, default-features = false, features = ["derive", "alloc"] }
+# A permissive range (like `hdf5-metno`'s own `ndarray` requirement) so the
+# user's existing `ndarray` unifies with ours instead of compiling a second
+# copy. Only APIs stable across 0.16/0.17 are used.
+ndarray = { version = ">=0.16, <0.18", optional = true }
 
 [dev-dependencies]
 tempfile = "3"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 hdf5 = { package = "hdf5-metno", version = "0.12", features = ["static", "zlib"] }
-ndarray = "0.16"
 
 [[example]]
 name = "matlab_fixtures"

--- a/README.md
+++ b/README.md
@@ -65,6 +65,34 @@ builder.create_dataset("x").with_f64_data(&[1.0, 2.0]);
 let bytes: Vec<u8> = builder.finish().unwrap(); // no filesystem needed
 ```
 
+### N-dimensional arrays (`ndarray` feature)
+
+Enable the `ndarray` feature to write and read datasets of any rank as
+[`ndarray`](https://docs.rs/ndarray) arrays. Shape and datatype are taken from
+the array, and data is stored row-major (C order), matching HDF5:
+
+```rust
+use hdf5_pure::{File, FileBuilder};
+use ndarray::{array, Array2};
+
+let a: Array2<f64> = array![[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]];
+
+let mut fb = FileBuilder::new();
+fb.create_dataset("m").with_ndarray(&a);          // shape [2, 3], f64
+let bytes = fb.finish().unwrap();
+
+let file = File::from_bytes(bytes).unwrap();
+let back: Array2<f64> = file.dataset("m").unwrap().read_array().unwrap();
+assert_eq!(a, back);
+
+// When the rank is only known at runtime:
+let dynamic = file.dataset("m").unwrap().read_array_dyn::<f64>().unwrap(); // ArrayD<f64>
+```
+
+`with_ndarray` accepts owned arrays or views; non-standard layouts (transposed,
+Fortran-order, or strided) are repacked to row-major on write, and chunking and
+compression chain as usual (`.with_ndarray(&a).with_chunks(&[64, 64]).with_deflate(6)`).
+
 ## SWMR (single writer, multiple readers)
 
 A single process can append to an unlimited dataset in place while other processes read it concurrently. The writer appends chunks and flushes in dependency order so readers only ever observe a consistent prefix; readers re-read to pick up new data. This interoperates with the reference HDF5 C library and h5py in both directions.
@@ -332,7 +360,7 @@ Not supported in this release: non-unit enum variants, MATLAB objects (`classdef
 | `serde` | no | Serialize/deserialize MATLAB v7.3 `.mat` files via serde |
 | `fast-checksum` | no | Hardware-accelerated CRC32 via `crc32fast` |
 | `fast-deflate` | no | zlib-ng backend for deflate via `flate2/zlib-ng` |
-| `mmap` | no | Memory-mapped file reading via `memmap2` |
+| `ndarray` | no | N-dimensional array I/O via the [`ndarray`](https://docs.rs/ndarray) crate |
 | `parallel` | no | Parallel chunk processing via `rayon` |
 | `provenance` | no | SHA-256 data provenance tracking |
 | `zfp` | no | ZFP fixed-rate compression (HDF5 filter 32013), f32/f64/i32/i64 × 1D–4D |

--- a/src/error.rs
+++ b/src/error.rs
@@ -140,6 +140,14 @@ pub enum FormatError {
     DatasetMissingData,
     /// Dataset is missing shape.
     DatasetMissingShape,
+    /// The dataset's element count implied by its shape does not match the
+    /// amount of data supplied (`shape.product() * element_size != data.len()`).
+    ShapeDataMismatch {
+        /// Number of data bytes the shape requires (`product(shape) * element_size`).
+        expected: usize,
+        /// Number of data bytes actually supplied.
+        actual: usize,
+    },
     /// Invalid filter pipeline version.
     InvalidFilterPipelineVersion(u8),
     /// Unsupported filter ID.
@@ -344,6 +352,12 @@ impl fmt::Display for FormatError {
             FormatError::DatasetMissingShape => {
                 write!(f, "dataset is missing shape")
             }
+            FormatError::ShapeDataMismatch { expected, actual } => {
+                write!(
+                    f,
+                    "shape/data mismatch: shape requires {expected} bytes, got {actual} bytes"
+                )
+            }
             FormatError::InvalidFilterPipelineVersion(v) => {
                 write!(f, "invalid filter pipeline version: {v}")
             }
@@ -412,6 +426,11 @@ pub enum Error {
     MissingMessage(crate::message_type::MessageType),
     /// Alignment or size error for zero-copy typed access.
     AlignmentError(String),
+    /// An array shape error from the `ndarray` integration: either the flat
+    /// data could not be reshaped to the dataset's dimensions, or a requested
+    /// static rank (e.g. `read_array::<_, Ix2>`) did not match the dataset's
+    /// runtime rank. Only constructed when the `ndarray` feature is enabled.
+    Shape(String),
     /// A SWMR operation (e.g. [`crate::File::refresh`]) was requested on a file
     /// that was not opened for SWMR reading via `File::open_swmr`.
     SwmrUnsupported,
@@ -431,6 +450,7 @@ impl fmt::Display for Error {
             Error::NotADataset(path) => write!(f, "not a dataset: {path}"),
             Error::MissingMessage(mt) => write!(f, "missing required message: {mt:?}"),
             Error::AlignmentError(msg) => write!(f, "alignment error: {msg}"),
+            Error::Shape(msg) => write!(f, "array shape error: {msg}"),
             Error::SwmrUnsupported => write!(
                 f,
                 "refresh requires a file opened with File::open_swmr (live handle)"

--- a/src/file_writer.rs
+++ b/src/file_writer.rs
@@ -465,6 +465,22 @@ impl FileWriter {
             } else {
                 db.data.ok_or(FormatError::DatasetMissingData)?
             };
+            // Guard against a shape that disagrees with the supplied data. The
+            // reader enforces the same `num_elements * element_size` invariant
+            // (see `data_read::read_raw_data_full`), so without this check a
+            // mismatch (e.g. data for 3 elements with shape `[2, 2]`) would
+            // produce a file that fails to read back. `saturating_mul` keeps an
+            // absurd shape from overflowing into a false match.
+            let elem_size = dt.type_size() as u64;
+            if !is_empty && elem_size > 0 {
+                let expected = shape.iter().product::<u64>().saturating_mul(elem_size);
+                if raw.len() as u64 != expected {
+                    return Err(FormatError::ShapeDataMismatch {
+                        expected: expected as usize,
+                        actual: raw.len(),
+                    });
+                }
+            }
             let max_dimensions = db.maxshape.clone();
             let dspace = Dataspace {
                 space_type: if shape.is_empty() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,27 @@
 //! let ds = file.dataset("data").unwrap();
 //! let values = ds.read_f64().unwrap();
 //! ```
+//!
+//! # N-dimensional arrays (`ndarray` feature)
+//!
+//! With the `ndarray` feature, datasets can be written from and read back into
+//! [`ndarray`] arrays of any rank, in row-major (C) order:
+//!
+//! ```
+//! # #[cfg(feature = "ndarray")] {
+//! use hdf5_pure::{File, FileBuilder};
+//! use ndarray::{array, Array2};
+//!
+//! let a: Array2<f64> = array![[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]];
+//! let mut fb = FileBuilder::new();
+//! fb.create_dataset("m").with_ndarray(&a);
+//! let bytes = fb.finish().unwrap();
+//!
+//! let file = File::from_bytes(bytes).unwrap();
+//! let back: Array2<f64> = file.dataset("m").unwrap().read_array().unwrap();
+//! assert_eq!(a, back);
+//! # }
+//! ```
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
@@ -101,6 +122,9 @@ pub mod writer;
 #[cfg(feature = "std")]
 pub mod mat;
 
+#[cfg(feature = "ndarray")]
+pub mod ndarray_support;
+
 // ---------------------------------------------------------------------------
 // Public API re-exports
 // ---------------------------------------------------------------------------
@@ -120,6 +144,9 @@ pub use writer::FileBuilder;
 
 #[cfg(feature = "std")]
 pub use swmr_writer::SwmrWriter;
+
+#[cfg(feature = "ndarray")]
+pub use ndarray_support::H5Element;
 
 pub use scaleoffset::ScaleOffset;
 

--- a/src/ndarray_support.rs
+++ b/src/ndarray_support.rs
@@ -1,0 +1,157 @@
+//! Ergonomic N-dimensional array I/O via the [`ndarray`] crate.
+//!
+//! Enabled by the `ndarray` feature. This module adds:
+//!
+//! * [`DatasetBuilder::with_ndarray`](crate::writer::FileBuilder) — write any
+//!   [`ndarray`] array (owned or a view) of a supported scalar type, inferring
+//!   both the dataset shape and datatype from the array.
+//! * [`Dataset::read_array`](crate::Dataset::read_array) /
+//!   [`Dataset::read_array_dyn`](crate::Dataset::read_array_dyn) — read a
+//!   dataset back into a typed [`ndarray::Array`] (fixed rank) or
+//!   [`ndarray::ArrayD`] (runtime rank).
+//!
+//! # Memory order
+//!
+//! HDF5 stores dataset elements in row-major (C) order, which is also
+//! `ndarray`'s default layout, so reads and writes are a flat copy with no
+//! transpose. On write, non-standard-layout inputs (Fortran-order, transposed,
+//! or strided views) are repacked into row-major order via
+//! [`ndarray::ArrayBase::as_standard_layout`]; arrays that are already standard
+//! layout are borrowed without copying.
+//!
+//! # Example
+//!
+//! ```
+//! use hdf5_pure::{File, FileBuilder};
+//! use ndarray::{array, Array2};
+//!
+//! let a: Array2<f64> = array![[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]];
+//!
+//! let mut fb = FileBuilder::new();
+//! fb.create_dataset("m").with_ndarray(&a);
+//! let bytes = fb.finish().unwrap();
+//!
+//! let file = File::from_bytes(bytes).unwrap();
+//! let back: Array2<f64> = file.dataset("m").unwrap().read_array().unwrap();
+//! assert_eq!(a, back);
+//! ```
+
+use ndarray::{Array, ArrayBase, ArrayD, Data, Dimension, IxDyn};
+
+use crate::error::Error;
+use crate::reader::Dataset;
+use crate::type_builders::DatasetBuilder;
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// A Rust scalar type that can be stored as an HDF5 dataset element.
+///
+/// This trait is sealed: it is implemented for the fixed set of scalar types
+/// the crate's reader and writer support (`f32`, `f64`, the signed integers
+/// `i8`/`i16`/`i32`/`i64`, and the unsigned integers `u8`/`u16`/`u32`/`u64`)
+/// and cannot be implemented for other types. It is the element bound for the
+/// [`ndarray`] read/write helpers and dispatches to the existing per-type
+/// reader/writer methods, so an `ndarray` read or write has exactly the same
+/// datatype, endianness, and conversion behavior as the corresponding
+/// [`Dataset::read_f64`](crate::Dataset::read_f64) /
+/// [`DatasetBuilder::with_f64_data`] family.
+pub trait H5Element: sealed::Sealed + Copy {
+    /// Read every element of `ds` as `Self`, in row-major order.
+    #[doc(hidden)]
+    fn read_from(ds: &Dataset<'_>) -> Result<Vec<Self>, Error>;
+
+    /// Set `builder`'s data and datatype from a flat row-major slice.
+    #[doc(hidden)]
+    fn write_into(builder: &mut DatasetBuilder, data: &[Self]);
+}
+
+macro_rules! impl_h5_element {
+    ($ty:ty, $read:ident, $write:ident) => {
+        impl sealed::Sealed for $ty {}
+        impl H5Element for $ty {
+            fn read_from(ds: &Dataset<'_>) -> Result<Vec<Self>, Error> {
+                ds.$read()
+            }
+            fn write_into(builder: &mut DatasetBuilder, data: &[Self]) {
+                builder.$write(data);
+            }
+        }
+    };
+}
+
+impl_h5_element!(f32, read_f32, with_f32_data);
+impl_h5_element!(f64, read_f64, with_f64_data);
+impl_h5_element!(i8, read_i8, with_i8_data);
+impl_h5_element!(i16, read_i16, with_i16_data);
+impl_h5_element!(i32, read_i32, with_i32_data);
+impl_h5_element!(i64, read_i64, with_i64_data);
+impl_h5_element!(u8, read_u8, with_u8_data);
+impl_h5_element!(u16, read_u16, with_u16_data);
+impl_h5_element!(u32, read_u32, with_u32_data);
+impl_h5_element!(u64, read_u64, with_u64_data);
+
+impl Dataset<'_> {
+    /// Read the dataset into a statically-ranked [`ndarray::Array`].
+    ///
+    /// The dimensionality `D` (e.g. [`ndarray::Ix2`]) is usually inferred from
+    /// the binding, so a call site reads as `let m: Array2<f64> =
+    /// ds.read_array()?;`. The element type `T` follows the same numeric
+    /// conversion rules as [`Dataset::read_f64`](crate::Dataset::read_f64) and
+    /// friends.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Shape`] if the dataset's runtime rank does not match
+    /// `D`. Use [`read_array_dyn`](Self::read_array_dyn) when the rank is not
+    /// known at compile time.
+    pub fn read_array<T: H5Element, D: Dimension>(&self) -> Result<Array<T, D>, Error> {
+        self.read_array_dyn::<T>()?
+            .into_dimensionality::<D>()
+            .map_err(|e| Error::Shape(e.to_string()))
+    }
+
+    /// Read the dataset into a dynamically-ranked [`ndarray::ArrayD`].
+    ///
+    /// The array's shape is taken from the dataset's dataspace, so this works
+    /// for any rank without naming it at compile time.
+    pub fn read_array_dyn<T: H5Element>(&self) -> Result<ArrayD<T>, Error> {
+        let shape: Vec<usize> = self.shape()?.iter().map(|&d| d as usize).collect();
+        let data = T::read_from(self)?;
+        ArrayD::from_shape_vec(IxDyn(&shape), data).map_err(|e| Error::Shape(e.to_string()))
+    }
+}
+
+impl DatasetBuilder {
+    /// Set the dataset's data, datatype, and shape from an [`ndarray`] array.
+    ///
+    /// Accepts any owned array or view of a supported scalar type by reference
+    /// (e.g. `&Array2<f64>`, `&arr.view()`). The dataset's shape is taken from
+    /// the array's shape and its datatype from the element type, so this is the
+    /// N-dimensional counterpart of the flat `with_*_data` methods.
+    ///
+    /// Data is written in row-major (C) order. Inputs that are not already in
+    /// standard layout (transposed, Fortran-order, or strided views) are
+    /// repacked once into row-major order; standard-layout inputs are used
+    /// without copying. The builder is returned so chunking and compression
+    /// can be chained, e.g. `b.with_ndarray(&a).with_chunks(&[64, 64])`.
+    pub fn with_ndarray<T, S, D>(&mut self, arr: &ArrayBase<S, D>) -> &mut Self
+    where
+        T: H5Element,
+        S: Data<Elem = T>,
+        D: Dimension,
+    {
+        let shape: Vec<u64> = arr.shape().iter().map(|&d| d as u64).collect();
+        // `as_standard_layout` borrows when `arr` is already row-major
+        // contiguous and copies into a fresh row-major buffer otherwise, so the
+        // resulting slice is always the C-order data HDF5 expects.
+        let standard = arr.as_standard_layout();
+        let flat = standard
+            .as_slice()
+            .expect("as_standard_layout yields a contiguous standard-layout array");
+        T::write_into(self, flat);
+        self.shape = Some(shape);
+        self
+    }
+}

--- a/tests/ndarray_roundtrip.rs
+++ b/tests/ndarray_roundtrip.rs
@@ -1,0 +1,209 @@
+//! Tests for the `ndarray` integration: round-trips through `hdf5-pure` itself
+//! and byte-level cross-validation against the reference HDF5 library
+//! (`hdf5-metno`). Only built with the `ndarray` feature.
+#![cfg(feature = "ndarray")]
+
+use hdf5_pure::{Error, File, FileBuilder};
+use ndarray::{Array1, Array2, Array3, ArrayD, ShapeBuilder, array};
+use tempfile::tempdir;
+
+/// Build a one-dataset file from an ndarray and reopen it in memory.
+fn write_then_open(name: &str, build: impl FnOnce(&mut FileBuilder)) -> File {
+    let mut fb = FileBuilder::new();
+    build(&mut fb);
+    let bytes = fb.finish().unwrap();
+    let file = File::from_bytes(bytes).unwrap();
+    // Sanity: the dataset exists.
+    file.dataset(name).unwrap();
+    file
+}
+
+// ---------------------------------------------------------------------------
+// Round-trips through hdf5-pure across ranks and element types
+// ---------------------------------------------------------------------------
+
+#[test]
+fn roundtrip_1d_f32() {
+    let a: Array1<f32> = array![1.5, 2.5, 3.5, 4.5];
+    let file = write_then_open("v", |fb| {
+        fb.create_dataset("v").with_ndarray(&a);
+    });
+    let ds = file.dataset("v").unwrap();
+    assert_eq!(ds.shape().unwrap(), vec![4]);
+    let back: Array1<f32> = ds.read_array().unwrap();
+    assert_eq!(back, a);
+}
+
+#[test]
+fn roundtrip_2d_f64() {
+    let a: Array2<f64> = array![[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]];
+    let file = write_then_open("m", |fb| {
+        fb.create_dataset("m").with_ndarray(&a);
+    });
+    let ds = file.dataset("m").unwrap();
+    assert_eq!(ds.shape().unwrap(), vec![2, 3]);
+    let back: Array2<f64> = ds.read_array().unwrap();
+    assert_eq!(back, a);
+}
+
+#[test]
+fn roundtrip_3d_i32() {
+    // 2 x 2 x 3 cube of distinct values.
+    let a: Array3<i32> = Array3::from_shape_vec((2, 2, 3), (0..12).collect()).unwrap();
+    let file = write_then_open("cube", |fb| {
+        fb.create_dataset("cube").with_ndarray(&a);
+    });
+    let ds = file.dataset("cube").unwrap();
+    assert_eq!(ds.shape().unwrap(), vec![2, 2, 3]);
+    let back: Array3<i32> = ds.read_array().unwrap();
+    assert_eq!(back, a);
+}
+
+#[test]
+fn roundtrip_2d_i64_and_u32() {
+    let a: Array2<i64> = array![[-1, -2], [-3, -4], [-5, -6]];
+    let b: Array2<u32> = array![[10, 20, 30], [40, 50, 60]];
+    let mut fb = FileBuilder::new();
+    fb.create_dataset("a").with_ndarray(&a);
+    fb.create_dataset("b").with_ndarray(&b);
+    let file = File::from_bytes(fb.finish().unwrap()).unwrap();
+    assert_eq!(
+        file.dataset("a").unwrap().read_array::<i64, _>().unwrap(),
+        a
+    );
+    assert_eq!(
+        file.dataset("b").unwrap().read_array::<u32, _>().unwrap(),
+        b
+    );
+}
+
+#[test]
+fn read_array_dyn_reports_runtime_rank() {
+    let a: Array3<f64> = Array3::from_shape_vec((3, 1, 2), vec![1., 2., 3., 4., 5., 6.]).unwrap();
+    let file = write_then_open("d", |fb| {
+        fb.create_dataset("d").with_ndarray(&a);
+    });
+    let dynamic: ArrayD<f64> = file.dataset("d").unwrap().read_array_dyn().unwrap();
+    assert_eq!(dynamic.ndim(), 3);
+    assert_eq!(dynamic.shape(), &[3, 1, 2]);
+    assert_eq!(dynamic, a.into_dyn());
+}
+
+// ---------------------------------------------------------------------------
+// Non-standard memory layouts must be repacked into row-major on write
+// ---------------------------------------------------------------------------
+
+#[test]
+fn transposed_view_is_written_row_major() {
+    let a: Array2<f64> = array![[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]];
+    let transposed = a.t(); // 3x2 view, NOT standard layout
+    assert!(!transposed.is_standard_layout());
+
+    let file = write_then_open("t", |fb| {
+        fb.create_dataset("t").with_ndarray(&transposed);
+    });
+    let ds = file.dataset("t").unwrap();
+    assert_eq!(ds.shape().unwrap(), vec![3, 2]);
+    let back: Array2<f64> = ds.read_array().unwrap();
+    // Logical values must match the transpose, regardless of source layout.
+    assert_eq!(back, transposed);
+    assert_eq!(back, array![[1.0, 4.0], [2.0, 5.0], [3.0, 6.0]]);
+}
+
+#[test]
+fn fortran_order_array_is_written_row_major() {
+    // Same logical 2x3 matrix, but stored column-major (Fortran order).
+    let f: Array2<f64> =
+        Array2::from_shape_vec((2, 3).f(), vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0]).unwrap();
+    assert!(!f.is_standard_layout());
+    let expected: Array2<f64> = array![[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]];
+    assert_eq!(f, expected);
+
+    let file = write_then_open("f", |fb| {
+        fb.create_dataset("f").with_ndarray(&f);
+    });
+    let back: Array2<f64> = file.dataset("f").unwrap().read_array().unwrap();
+    assert_eq!(back, expected);
+}
+
+// ---------------------------------------------------------------------------
+// Error handling
+// ---------------------------------------------------------------------------
+
+#[test]
+fn read_array_wrong_rank_errors() {
+    let a: Array3<f64> =
+        Array3::from_shape_vec((2, 2, 2), (0..8).map(|x| x as f64).collect()).unwrap();
+    let file = write_then_open("cube", |fb| {
+        fb.create_dataset("cube").with_ndarray(&a);
+    });
+    let ds = file.dataset("cube").unwrap();
+    // Requesting a 2-D array from a 3-D dataset must fail, not panic.
+    let err = ds.read_array::<f64, ndarray::Ix2>().unwrap_err();
+    assert!(matches!(err, Error::Shape(_)), "got {err:?}");
+    // But read_array_dyn still works.
+    assert_eq!(ds.read_array_dyn::<f64>().unwrap(), a.into_dyn());
+}
+
+// ---------------------------------------------------------------------------
+// Cross-validation against the reference HDF5 library (hdf5-metno)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn crosscheck_2d_with_reference_library() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("nd2.h5");
+
+    let a: Array2<f64> = array![[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]];
+    let mut fb = FileBuilder::new();
+    fb.create_dataset("m").with_ndarray(&a);
+    fb.write(&path).unwrap();
+
+    // The reference library must see the same shape and row-major values.
+    let file = hdf5::File::open(&path).unwrap();
+    let ds = file.dataset("m").unwrap();
+    assert_eq!(ds.shape(), vec![2, 3]);
+    let read: Array2<f64> = ds.read_2d::<f64>().unwrap();
+    assert_eq!(read, a);
+}
+
+#[test]
+fn crosscheck_3d_with_reference_library() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("nd3.h5");
+
+    let a: Array3<i32> = Array3::from_shape_vec((2, 3, 4), (0..24).collect()).unwrap();
+    let mut fb = FileBuilder::new();
+    fb.create_dataset("cube").with_ndarray(&a);
+    fb.write(&path).unwrap();
+
+    let file = hdf5::File::open(&path).unwrap();
+    let ds = file.dataset("cube").unwrap();
+    assert_eq!(ds.shape(), vec![2, 3, 4]);
+    let read: ArrayD<i32> = ds.read_dyn::<i32>().unwrap();
+    assert_eq!(read, a.into_dyn());
+}
+
+#[test]
+fn crosscheck_chunked_compressed_ndarray() {
+    // ndarray write composes with the existing chunking/compression builders.
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("nd_chunked.h5");
+
+    let a: Array2<f64> = Array2::from_shape_fn((8, 8), |(i, j)| (i * 8 + j) as f64 * 0.25);
+    let mut fb = FileBuilder::new();
+    fb.create_dataset("m")
+        .with_ndarray(&a)
+        .with_chunks(&[4, 4])
+        .with_deflate(6);
+    fb.write(&path).unwrap();
+
+    let file = hdf5::File::open(&path).unwrap();
+    let read: Array2<f64> = file.dataset("m").unwrap().read_2d::<f64>().unwrap();
+    assert_eq!(read, a);
+
+    // And it round-trips back through hdf5-pure too.
+    let ours = File::open(&path).unwrap();
+    let back: Array2<f64> = ours.dataset("m").unwrap().read_array().unwrap();
+    assert_eq!(back, a);
+}

--- a/tests/write_read_roundtrip.rs
+++ b/tests/write_read_roundtrip.rs
@@ -831,3 +831,37 @@ fn roundtrip_scale_offset_integer_then_deflate() {
     let ds = file.dataset("data").unwrap();
     assert_eq!(ds.read_i32().unwrap(), data);
 }
+
+#[test]
+fn shape_data_mismatch_is_rejected() {
+    use hdf5_pure::{Error, FormatError};
+
+    // 3 elements supplied but a 2x2 (=4 element) shape requested.
+    let mut builder = FileBuilder::new();
+    builder
+        .create_dataset("bad")
+        .with_f64_data(&[1.0, 2.0, 3.0])
+        .with_shape(&[2, 2]);
+    let err = builder.finish().unwrap_err();
+    match err {
+        Error::Format(FormatError::ShapeDataMismatch { expected, actual }) => {
+            assert_eq!(expected, 4 * 8); // shape needs 4 f64 = 32 bytes
+            assert_eq!(actual, 3 * 8); // only 3 f64 = 24 bytes supplied
+        }
+        other => panic!("expected ShapeDataMismatch, got {other:?}"),
+    }
+}
+
+#[test]
+fn matching_shape_and_data_is_accepted() {
+    // Regression guard: a correct 2x3 shape must still write/read cleanly.
+    let mut builder = FileBuilder::new();
+    builder
+        .create_dataset("ok")
+        .with_f64_data(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+        .with_shape(&[2, 3]);
+    let file = File::from_bytes(builder.finish().unwrap()).unwrap();
+    let ds = file.dataset("ok").unwrap();
+    assert_eq!(ds.shape().unwrap(), vec![2, 3]);
+    assert_eq!(ds.read_f64().unwrap(), vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+}


### PR DESCRIPTION
## Summary

Implements the N-dimensional array support requested in #24, and resolves the unused-dependency concerns it raised.

The HDF5 format layer in this crate is already fully N-dimensional and row-major (C-order) end to end, which is exactly `ndarray`'s default layout. So this is a thin, safe ergonomic layer over the existing reader/writer: reads and writes are a flat copy with no transpose.

## N-dimensional array API (`ndarray` feature)

New optional `ndarray` feature, off by default and implying `std`, so the core build stays dependency-free and WASM/`no_std`-clean.

- `DatasetBuilder::with_ndarray(&arr)` writes any `ndarray` array or view, inferring the dataset shape and datatype from it. Non-standard-layout inputs (transposed, Fortran-order, or strided views) are repacked to row-major on write; standard-layout inputs are used without copying. It returns `&mut Self`, so chunking/compression chain as usual: `b.with_ndarray(&a).with_chunks(&[64, 64]).with_deflate(6)`.
- `Dataset::read_array::<T, D>()` reads into a statically-ranked `Array<T, D>` (e.g. `let m: Array2<f64> = ds.read_array()?;`), and `Dataset::read_array_dyn::<T>()` reads into an `ArrayD<T>` when the rank is only known at runtime.
- A sealed `H5Element` trait describes the supported element types (`f32`, `f64`, and the signed/unsigned 8/16/32/64-bit integers) and dispatches to the existing per-type `read_f64`/`with_f64_data` family, so an ndarray read/write has identical datatype, endianness, and conversion behavior.

## Issue #24, part 1: unused dependencies

- `ndarray` was a dead dev-dependency (never referenced). It is now a real, used optional dependency.
- Added a `cargo-shear` CI job to catch unused dependencies going forward. It immediately surfaced a second dead dependency: the advertised-but-never-implemented `mmap` feature and its `memmap2` dependency. Both are removed (enabling `mmap` previously did nothing — a no-op breaking change for anyone who named the feature).

## Correctness: write-time shape validation

Writing a dataset whose shape disagrees with the supplied data now fails fast with `FormatError::ShapeDataMismatch` instead of silently producing a file that cannot be read back (the reader enforces the same `num_elements * element_size` invariant). For example, `with_f64_data(&[1.0, 2.0, 3.0]).with_shape(&[2, 2])` is now rejected.

## Notes for reviewers

`ndarray` is required with a permissive `>=0.16, <0.18` range (the same approach `hdf5-metno` itself uses) so a downstream user's existing `ndarray` unifies with ours rather than compiling a second copy. `Cargo.lock` is collapsed to a single `ndarray` version, because the `hdf5-metno` dev-dependency otherwise drags in a second one and the cross-check tests would fail to compile. Only `ndarray` APIs stable across 0.16/0.17 are used.

## Testing

- `cargo test` (default) and the full feature set including `ndarray` pass with zero failures.
- 11 new tests in `tests/ndarray_roundtrip.rs`: round-trips across ranks/types, transposed-view and Fortran-order writes, rank-mismatch error handling, and **reference-library cross-checks** — 2-D, 3-D, and chunked+compressed arrays written via `with_ndarray` are read back identically by `hdf5-metno`, proving byte-level row-major compatibility.
- New validation tests in `tests/write_read_roundtrip.rs` for `ShapeDataMismatch` and the matching-shape regression guard.
- `clippy -D warnings` (serde + ndarray, all targets), `fmt --check`, `cargo shear`, the `no_std` check, and both `wasm32-unknown-unknown` builds are all clean.

Closes #24.
