### PR TITLE
Report element counts in ShapeDataMismatch; clarify read_array docs

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -147,6 +147,9 @@ pub enum FormatError {
         expected: usize,
         /// Number of data bytes actually supplied.
         actual: usize,
+        /// Size in bytes of one element (the dataset's datatype size). Always
+        /// non-zero; used to report the mismatch in elements as well as bytes.
+        element_size: usize,
     },
     /// Invalid filter pipeline version.
     InvalidFilterPipelineVersion(u8),
@@ -352,10 +355,19 @@ impl fmt::Display for FormatError {
             FormatError::DatasetMissingShape => {
                 write!(f, "dataset is missing shape")
             }
-            FormatError::ShapeDataMismatch { expected, actual } => {
+            FormatError::ShapeDataMismatch {
+                expected,
+                actual,
+                element_size,
+            } => {
+                // `element_size` is guaranteed non-zero at construction, so the
+                // element counts below are well defined.
                 write!(
                     f,
-                    "shape/data mismatch: shape requires {expected} bytes, got {actual} bytes"
+                    "shape/data mismatch: shape requires {} elements ({expected} bytes), \
+                     but {} elements ({actual} bytes) were supplied",
+                    expected / element_size,
+                    actual / element_size,
                 )
             }
             FormatError::InvalidFilterPipelineVersion(v) => {

--- a/src/file_writer.rs
+++ b/src/file_writer.rs
@@ -478,6 +478,7 @@ impl FileWriter {
                     return Err(FormatError::ShapeDataMismatch {
                         expected: expected as usize,
                         actual: raw.len(),
+                        element_size: elem_size as usize,
                     });
                 }
             }

--- a/src/ndarray_support.rs
+++ b/src/ndarray_support.rs
@@ -97,9 +97,15 @@ impl Dataset<'_> {
     ///
     /// The dimensionality `D` (e.g. [`ndarray::Ix2`]) is usually inferred from
     /// the binding, so a call site reads as `let m: Array2<f64> =
-    /// ds.read_array()?;`. The element type `T` follows the same numeric
-    /// conversion rules as [`Dataset::read_f64`](crate::Dataset::read_f64) and
-    /// friends.
+    /// ds.read_array()?;`.
+    ///
+    /// `T` is the type you want the elements *delivered as*, not an assertion
+    /// about the dataset's stored type. The stored bytes are coerced into `T`
+    /// using the same rules as [`Dataset::read_f64`](crate::Dataset::read_f64)
+    /// and its siblings, so the conversion can be lossy: reading an `f64`
+    /// dataset as `i32` truncates, and reading an `i32` dataset as `f64`
+    /// widens. There is no check that `T` matches the on-disk datatype, so pick
+    /// `T` to match the stored type when you need an exact, lossless read.
     ///
     /// # Errors
     ///
@@ -115,7 +121,11 @@ impl Dataset<'_> {
     /// Read the dataset into a dynamically-ranked [`ndarray::ArrayD`].
     ///
     /// The array's shape is taken from the dataset's dataspace, so this works
-    /// for any rank without naming it at compile time.
+    /// for any rank without naming it at compile time. As with
+    /// [`read_array`](Self::read_array), `T` is the requested element type and
+    /// the stored bytes are coerced into it (possibly lossily) following the
+    /// [`Dataset::read_f64`](crate::Dataset::read_f64) conversion rules, with
+    /// no check that `T` matches the on-disk datatype.
     pub fn read_array_dyn<T: H5Element>(&self) -> Result<ArrayD<T>, Error> {
         let shape: Vec<usize> = self.shape()?.iter().map(|&d| d as usize).collect();
         let data = T::read_from(self)?;

--- a/tests/write_read_roundtrip.rs
+++ b/tests/write_read_roundtrip.rs
@@ -844,9 +844,14 @@ fn shape_data_mismatch_is_rejected() {
         .with_shape(&[2, 2]);
     let err = builder.finish().unwrap_err();
     match err {
-        Error::Format(FormatError::ShapeDataMismatch { expected, actual }) => {
+        Error::Format(FormatError::ShapeDataMismatch {
+            expected,
+            actual,
+            element_size,
+        }) => {
             assert_eq!(expected, 4 * 8); // shape needs 4 f64 = 32 bytes
             assert_eq!(actual, 3 * 8); // only 3 f64 = 24 bytes supplied
+            assert_eq!(element_size, 8); // f64
         }
         other => panic!("expected ShapeDataMismatch, got {other:?}"),
     }


### PR DESCRIPTION
Follow-up polish that missed the squash merge of #24 (landed via #28).

Adds an `element_size` field to `FormatError::ShapeDataMismatch` and rewrites the message to report the mismatch in elements as well as raw bytes, e.g. "shape requires 4 elements (32 bytes), but 3 elements (24 bytes) were supplied" instead of the bytes-only diagnostic. The field is populated at the writer construction site (`file_writer.rs`) and asserted in the roundtrip test.

Also clarifies the `read_array`/`read_array_dyn` docs: `T` is the type elements are delivered as, not an assertion about the stored datatype, and the coercion can be lossy.

Verified locally: `cargo fmt --check`, `cargo clippy --features ndarray --all-targets -- -D warnings`, and the `shape_data_mismatch_is_rejected` test all pass.