### PR TITLE
Edit multi-chunk object headers in place (issue #32 follow-on)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- `EditSession` now edits objects whose headers span multiple chunks ([#32](https://github.com/stephenberry/hdf5-pure/issues/32)). The reference C library lays a group or dataset object header out across continuation blocks once it holds enough messages (several attributes are enough); previously the in-place editor refused such a header. It now gathers the messages from every chunk and re-emits them as a single chunk on rewrite, so files written by the C library — in both the 1.8 (version 2 superblock) and 1.10+ (version 3 superblock) formats — are editable in place, verified by a round-trip crosscheck against the C library. The default earliest format (version 0 superblock with symbol-table groups) is still refused cleanly.
+
 ## [0.11.0] - 2026-06-09
 
 ### Added

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -35,9 +35,11 @@
 //! - The file uses a latest-format (version 2/3) superblock with 8-byte
 //!   offsets/lengths and **no** userblock (base address 0).
 //! - Every group on an edited path stores its links compactly (not in a dense
-//!   fractal heap), has a single-chunk object header, and does not track message
-//!   creation order. Files written by this crate's
-//!   [`FileBuilder`](crate::FileBuilder) satisfy this.
+//!   fractal heap) and does not track message creation order. Object headers
+//!   split across continuation chunks (as the reference C library often writes)
+//!   are collapsed into a single chunk when rewritten. Files written by this
+//!   crate's [`FileBuilder`](crate::FileBuilder) and by the C library satisfy
+//!   this.
 //! - Added datasets are contiguous and unfiltered (no chunking, compression,
 //!   shuffle, scale-offset, or extensible dimensions), have a fixed-size
 //!   datatype with a non-empty shape, and carry only fixed-size (non
@@ -73,6 +75,11 @@ const MAX_COMPACT_ATTRS: usize = 8;
 /// pathological or cyclic hard-link graph (HDF5 hard links can form cycles).
 /// Far deeper than any real group hierarchy.
 const MAX_COPY_DEPTH: u32 = 1000;
+
+/// Maximum number of object-header chunks to follow when gathering a header that
+/// spans continuation blocks, guarding against a cyclic continuation chain.
+/// Matches the reader's continuation-depth cap.
+const MAX_OH_CHUNKS: usize = 256;
 
 /// A path identified by its components (no leading/trailing empties); the root
 /// group is the empty vector.
@@ -343,7 +350,7 @@ impl EditSession {
                     .map_err(|_| Error::EditUnsupported("group address exceeds this platform"))?;
                 let info = self.inspect_group(addr)?;
                 let node = nodes.get_mut(key).unwrap();
-                node.base_region = self.data[info.region_start..info.region_end].to_vec();
+                node.base_region = info.region;
                 node.existing_links = info.link_names;
             }
         }
@@ -511,24 +518,75 @@ impl EditSession {
         Ok((region_start, region_end))
     }
 
-    /// Parse and validate a group's object header, returning the byte range
-    /// `[start, end)` of its chunk-0 message region (the bytes to copy when
-    /// rewriting the header) and the names of its existing links.
-    fn inspect_group(&self, addr: usize) -> Result<GroupInfo, Error> {
+    /// Collect every message of the object header at `addr` into one contiguous
+    /// region, following continuation blocks across chunks and dropping the
+    /// `Continuation` messages themselves. Re-emitting the result through
+    /// [`build_v2_object_header`] collapses a multi-chunk header (as the
+    /// reference C library often writes) into a single chunk, which is how this
+    /// editor rebuilds headers. The chunk-0 prefix is validated by
+    /// [`oh_region`]; each continuation block must be a well-formed `OCHK` block
+    /// within the file.
+    fn gather_oh_messages(&self, addr: usize) -> Result<Vec<u8>, Error> {
+        let (rs, re) = self.oh_region(addr)?;
         let d = &self.data;
-        let (region_start, region_end) = self.oh_region(addr)?;
+        let mut out = Vec::new();
+        // Worklist of (message-region start, end) per chunk, chunk 0 first.
+        let mut chunks: Vec<(usize, usize)> = vec![(rs, re)];
+        let mut i = 0;
+        while i < chunks.len() {
+            if chunks.len() > MAX_OH_CHUNKS {
+                return Err(Error::EditUnsupported(
+                    "object header has too many continuation chunks",
+                ));
+            }
+            let (cs, ce) = chunks[i];
+            i += 1;
+            let region = &d[..ce];
+            let mut p = cs;
+            while let Some((msg_type, body, body_end)) = next_message(region, p)? {
+                if msg_type == MessageType::ObjectHeaderContinuation {
+                    // Body: block offset (offset_size) + block length (length_size).
+                    if body_end - body < (OFFSET_SIZE + LENGTH_SIZE) as usize {
+                        return Err(Error::EditUnsupported("malformed continuation message"));
+                    }
+                    let off = u64::from_le_bytes(d[body..body + 8].try_into().unwrap());
+                    let len = u64::from_le_bytes(d[body + 8..body + 16].try_into().unwrap());
+                    let off = usize::try_from(off).map_err(|_| {
+                        Error::EditUnsupported("continuation address exceeds this platform")
+                    })?;
+                    let len = usize::try_from(len).map_err(|_| {
+                        Error::EditUnsupported("continuation length exceeds this platform")
+                    })?;
+                    // An OCHK block is signature(4) + messages + checksum(4).
+                    let blk_end = off
+                        .checked_add(len)
+                        .filter(|&e| e <= d.len() && len >= 8)
+                        .ok_or(Error::EditUnsupported("continuation block out of bounds"))?;
+                    if &d[off..off + 4] != b"OCHK" {
+                        return Err(Error::EditUnsupported(
+                            "invalid continuation block signature",
+                        ));
+                    }
+                    chunks.push((off + 4, blk_end - 4));
+                } else {
+                    out.extend_from_slice(&region[p..body_end]);
+                }
+                p = body_end;
+            }
+        }
+        Ok(out)
+    }
 
-        let region = &d[..region_end];
-        let mut p = region_start;
+    /// Parse and validate a group's object header (collapsing any continuation
+    /// chunks), returning its unified message region — the bytes to copy when
+    /// rewriting the header — and the names of its existing links.
+    fn inspect_group(&self, addr: usize) -> Result<GroupInfo, Error> {
+        let region = self.gather_oh_messages(addr)?;
+        let mut p = 0;
         let mut has_link_info = false;
         let mut link_names = Vec::new();
-        while let Some((msg_type, body, body_end)) = next_message(region, p)? {
+        while let Some((msg_type, body, body_end)) = next_message(&region, p)? {
             match msg_type {
-                MessageType::ObjectHeaderContinuation => {
-                    return Err(Error::EditUnsupported(
-                        "a target group's object header spans multiple chunks (not supported in place yet)",
-                    ));
-                }
                 MessageType::LinkInfo => {
                     has_link_info = true;
                     // LinkInfo: version(1) flags(1) [max_creation_index(8) if
@@ -537,11 +595,11 @@ impl EditSession {
                     // message's own body, not just the region, so a short or
                     // malformed LinkInfo can't make us read the next message.
                     let mut q = body + 2;
-                    if body_end - body >= 2 && d[body + 1] & 0x01 != 0 {
+                    if body_end - body >= 2 && region[body + 1] & 0x01 != 0 {
                         q += 8;
                     }
                     if q + 8 <= body_end {
-                        let heap_addr = u64::from_le_bytes(d[q..q + 8].try_into().unwrap());
+                        let heap_addr = u64::from_le_bytes(region[q..q + 8].try_into().unwrap());
                         if heap_addr != u64::MAX {
                             return Err(Error::EditUnsupported(
                                 "a target group uses dense (fractal-heap) link storage (not supported in place yet)",
@@ -550,7 +608,7 @@ impl EditSession {
                     }
                 }
                 MessageType::Link => {
-                    if let Ok(link) = LinkMessage::parse(&d[body..body_end], OFFSET_SIZE) {
+                    if let Ok(link) = LinkMessage::parse(&region[body..body_end], OFFSET_SIZE) {
                         link_names.push(link.name);
                     }
                 }
@@ -568,11 +626,7 @@ impl EditSession {
                 "a target group's object header has no link-info message",
             ));
         }
-        Ok(GroupInfo {
-            region_start,
-            region_end,
-            link_names,
-        })
+        Ok(GroupInfo { region, link_names })
     }
 
     /// Parse the object header at `addr` into a copyable model, validating that
@@ -582,23 +636,16 @@ impl EditSession {
     /// soft/external links, chunked/old-version data layouts, and headers that
     /// are neither a dataset nor a group.
     fn read_object(&self, addr: usize) -> Result<ObjModel, Error> {
-        let (rs, re) = self.oh_region(addr)?;
-        let d = &self.data;
+        let region = self.gather_oh_messages(addr)?;
 
         let mut layout: Option<(usize, usize)> = None; // (body offset, size)
         let mut has_link_info = false;
         let mut children: Vec<(String, u64)> = Vec::new();
         let mut non_link: Vec<u8> = Vec::new();
 
-        let region = &d[..re];
-        let mut p = rs;
-        while let Some((msg_type, body, body_end)) = next_message(region, p)? {
+        let mut p = 0;
+        while let Some((msg_type, body, body_end)) = next_message(&region, p)? {
             match msg_type {
-                MessageType::ObjectHeaderContinuation => {
-                    return Err(Error::EditUnsupported(
-                        "an object's header spans multiple chunks (not supported in place yet)",
-                    ));
-                }
                 MessageType::AttributeInfo => {
                     return Err(Error::EditUnsupported(
                         "an object uses dense (fractal-heap) attribute storage (not supported in place yet)",
@@ -607,11 +654,11 @@ impl EditSession {
                 MessageType::LinkInfo => {
                     has_link_info = true;
                     let mut q = body + 2;
-                    if body_end - body >= 2 && d[body + 1] & 0x01 != 0 {
+                    if body_end - body >= 2 && region[body + 1] & 0x01 != 0 {
                         q += 8;
                     }
                     if q + 8 <= body_end {
-                        let heap_addr = u64::from_le_bytes(d[q..q + 8].try_into().unwrap());
+                        let heap_addr = u64::from_le_bytes(region[q..q + 8].try_into().unwrap());
                         if heap_addr != u64::MAX {
                             return Err(Error::EditUnsupported(
                                 "a group uses dense (fractal-heap) link storage (not supported in place yet)",
@@ -619,7 +666,8 @@ impl EditSession {
                         }
                     }
                 }
-                MessageType::Link => match LinkMessage::parse(&d[body..body_end], OFFSET_SIZE) {
+                MessageType::Link => match LinkMessage::parse(&region[body..body_end], OFFSET_SIZE)
+                {
                     Ok(LinkMessage {
                         name,
                         link_target:
@@ -638,33 +686,32 @@ impl EditSession {
                 _ => {}
             }
             if msg_type != MessageType::Link {
-                non_link.extend_from_slice(&d[p..body_end]);
+                non_link.extend_from_slice(&region[p..body_end]);
             }
             p = body_end;
         }
 
         if let Some((lbody, lsize)) = layout {
-            let version = d[lbody];
+            let version = region[lbody];
             if !(version == 3 || version == 4) || lsize < 2 {
                 return Err(Error::EditUnsupported(
                     "an unsupported data-layout version cannot be copied in place yet",
                 ));
             }
-            match d[lbody + 1] {
-                0 => Ok(ObjModel::DatasetVerbatim {
-                    region: d[rs..re].to_vec(),
-                }),
+            let class = region[lbody + 1];
+            match class {
+                0 => Ok(ObjModel::DatasetVerbatim { region }),
                 1 => {
-                    if lbody + 18 > re {
+                    if lbody + 18 > region.len() {
                         return Err(Error::EditUnsupported("malformed contiguous data layout"));
                     }
                     let data_addr =
-                        u64::from_le_bytes(d[lbody + 2..lbody + 10].try_into().unwrap());
+                        u64::from_le_bytes(region[lbody + 2..lbody + 10].try_into().unwrap());
                     let data_size =
-                        u64::from_le_bytes(d[lbody + 10..lbody + 18].try_into().unwrap());
+                        u64::from_le_bytes(region[lbody + 10..lbody + 18].try_into().unwrap());
                     Ok(ObjModel::DatasetContiguous {
-                        region: d[rs..re].to_vec(),
-                        addr_off: (lbody + 2) - rs,
+                        region,
+                        addr_off: lbody + 2,
                         data_addr,
                         data_size,
                     })
@@ -816,10 +863,10 @@ enum ObjModel {
     },
 }
 
-/// The validated message region and existing link names of a group header.
+/// The validated, chunk-collapsed message region and existing link names of a
+/// group header.
 struct GroupInfo {
-    region_start: usize,
-    region_end: usize,
+    region: Vec<u8>,
     link_names: Vec<String>,
 }
 

--- a/tests/edit_crosscheck.rs
+++ b/tests/edit_crosscheck.rs
@@ -3,16 +3,16 @@
 // suite can run under `cross test --target i686-...`.
 #![cfg(not(target_pointer_width = "32"))]
 //! Cross-validation for in-place editing against the reference C library
-//! (PR #38 / issue #32): files the C library *writes* are edited in place by
+//! (issue #32): files the C library *writes* are edited in place by
 //! `EditSession`, and the result is read back by both `hdf5-pure` and the C
 //! library. This proves the editor works on files it did not itself produce, in
-//! both the HDF5 1.8 (v2 superblock) and 1.10+ (v3 superblock) formats.
+//! both the HDF5 1.8 (v2 superblock) and 1.10+ (v3 superblock) formats, and
+//! including headers the C library splits across multiple chunks (which the
+//! editor collapses into a single chunk on rewrite).
 //!
 //! Boundary recorded here too: the default earliest format (version 0
 //! superblock with symbol-table groups) is refused cleanly, leaving the file
-//! untouched. (A separate, content-dependent limit not asserted here: the C
-//! library sometimes lays a group header out across multiple chunks, which the
-//! editor does not yet rebuild — see `src/edit.rs`.)
+//! untouched.
 
 use hdf5::file::LibraryVersion;
 use hdf5_pure::{EditSession, File, FileBuilder};
@@ -158,6 +158,71 @@ fn c_written_v3_file_edited_in_place() {
     session.commit().unwrap();
 
     assert_edits_applied(&path);
+}
+
+#[test]
+fn c_multichunk_group_header_is_collapsed_and_edited() {
+    // The C library lays a group header out across multiple chunks once it holds
+    // enough messages; several root attributes reliably force that. The editor
+    // must collapse the continuation chunks into one header on rewrite, preserve
+    // the existing messages (the attributes), and apply the edit.
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("c_multichunk.h5");
+    {
+        let file = hdf5::File::with_options()
+            .with_fapl(|p| p.libver_bounds(LibraryVersion::V110, LibraryVersion::latest()))
+            .create(&path)
+            .unwrap();
+        file.new_dataset::<f64>()
+            .shape((3,))
+            .create("alpha")
+            .unwrap()
+            .write(&[1.0f64, 2.0, 3.0])
+            .unwrap();
+        file.new_dataset::<i32>()
+            .shape((2,))
+            .create("doomed")
+            .unwrap()
+            .write(&[7i32, 8])
+            .unwrap();
+        let grp = file.create_group("grp").unwrap();
+        grp.new_dataset::<i32>()
+            .shape((4,))
+            .create("beta")
+            .unwrap()
+            .write(&[10i32, 20, 30, 40])
+            .unwrap();
+        // Several root-group attributes push the root header past one chunk.
+        for i in 0..6 {
+            let a = file
+                .new_attr::<i64>()
+                .shape(())
+                .create(format!("meta{i}").as_str())
+                .unwrap();
+            a.write_scalar(&(i as i64 * 100)).unwrap();
+        }
+        file.close().unwrap();
+    }
+
+    {
+        let mut session = EditSession::open(&path).unwrap();
+        stage_edits(&mut session);
+        session.commit().unwrap();
+    }
+
+    assert_edits_applied(&path);
+
+    // The C-written root attributes survived the multi-chunk -> single-chunk
+    // rewrite of the root header (verified by the C library).
+    let c = hdf5::File::open(&path).unwrap();
+    for i in 0..6 {
+        let v: i64 = c.attr(&format!("meta{i}")).unwrap().read_scalar().unwrap();
+        assert_eq!(
+            v,
+            i as i64 * 100,
+            "root attribute meta{i} lost or corrupted"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Stacked on #39. Lets `EditSession` edit objects whose headers span **multiple chunks** — which is what makes it able to edit arbitrary C-library files.

The interop crosscheck in #39 found the real boundary: `EditSession` edits C-library files in both modern formats, *except* when the C library lays a group or dataset header out across continuation blocks (it does so once the header holds enough messages — a handful of attributes is enough). This PR closes that gap.

## How

`gather_oh_messages(addr)` collects every message of an object header into one contiguous region, following the `Continuation` messages to their `OCHK` blocks and dropping the continuation messages themselves. Re-emitting that region through the existing `build_v2_object_header` **collapses a multi-chunk header into a single chunk** on rewrite. `inspect_group` and `read_object` now operate on this unified region instead of a chunk-0-only slice. A `MAX_OH_CHUNKS` cap guards against a cyclic continuation chain (mirrors the reader).

Single-chunk headers are unaffected — `gather` returns the same bytes the old chunk-0 walk did, so all existing edit tests pass unchanged.

## Testing

- `tests/edit_crosscheck.rs` adds `c_multichunk_group_header_is_collapsed_and_edited`: forces the C library to write a multi-chunk root group header (six root attributes), edits it (add/delete/copy), and confirms via the C library that the edit applied **and every original attribute survived** the multi-chunk → single-chunk rewrite.
- During development I instrumented `gather` to confirm the fixture is genuinely multi-chunk (it reported two chunks for the root header), so the test isn't vacuous.
- `fmt`, `clippy -D warnings`, `no_std`, and the full suite pass.

After this, the remaining gap for editing *any* C-library / h5py file is the version 0 / symbol-table format (default h5py, and the C library's earliest libver bound), which is refused cleanly today.

Refs #32.