### PR TITLE
Name repeated B-tree v1 layout sizes (issue #26)

### DIFF
--- a/src/btree_v1.rs
+++ b/src/btree_v1.rs
@@ -6,6 +6,21 @@ use alloc::vec::Vec;
 use crate::convert::TryToUsize;
 use crate::error::FormatError;
 
+/// Size of the size-of-offsets-independent prefix of a version 1 B-tree node:
+/// `signature(4) + node_type(1) + node_level(1) + entries_used(2)`. The two
+/// sibling addresses that follow are each `offset_size` bytes wide; see
+/// [`btree_v1_node_header_size`]. (HDF5 format spec, "Disk Format: Level 1A1 —
+/// Version 1 B-trees".)
+pub(crate) const BTREE_V1_NODE_PREFIX_LEN: usize = 8;
+
+/// Total size of a version 1 B-tree node header for a file whose size-of-offsets
+/// is `offset_size`: the fixed [`BTREE_V1_NODE_PREFIX_LEN`] prefix plus the left
+/// and right sibling addresses (`offset_size` bytes each). This is the offset
+/// from the start of a node to its first key.
+pub(crate) const fn btree_v1_node_header_size(offset_size: u8) -> usize {
+    BTREE_V1_NODE_PREFIX_LEN + (offset_size as usize) * 2
+}
+
 /// A parsed B-tree v1 node.
 ///
 /// Some fields are decoded from the on-disk node for completeness but are not
@@ -67,10 +82,10 @@ impl BTreeV1Node {
         offset_size: u8,
         _length_size: u8,
     ) -> Result<BTreeV1Node, FormatError> {
-        // signature(4) + node_type(1) + node_level(1) + entries_used(2) = 8
-        // + left_sibling(offset_size) + right_sibling(offset_size)
+        // signature(4) + node_type(1) + node_level(1) + entries_used(2),
+        // then left_sibling(offset_size) + right_sibling(offset_size).
         let os = offset_size as usize;
-        let header_size = 8 + os * 2;
+        let header_size = btree_v1_node_header_size(offset_size);
         if offset + header_size > file_data.len() {
             return Err(FormatError::UnexpectedEof {
                 expected: offset + header_size,
@@ -86,7 +101,7 @@ impl BTreeV1Node {
         let node_level = file_data[offset + 5];
         let entries_used = u16::from_le_bytes([file_data[offset + 6], file_data[offset + 7]]);
 
-        let mut pos = offset + 8;
+        let mut pos = offset + BTREE_V1_NODE_PREFIX_LEN;
         let left_sibling = if is_undefined(file_data, pos, offset_size) {
             None
         } else {

--- a/src/chunked_read.rs
+++ b/src/chunked_read.rs
@@ -6,6 +6,7 @@ extern crate alloc;
 #[cfg(not(feature = "std"))]
 use alloc::{format, vec, vec::Vec};
 
+use crate::btree_v1::btree_v1_node_header_size;
 use crate::chunk_cache::{CacheAlignedBuffer, ChunkCache};
 use crate::convert::{TryToUsize, slice_range, u32_from};
 use crate::data_layout::DataLayout;
@@ -136,6 +137,15 @@ fn read_offset(data: &[u8], pos: usize, size: u8) -> Result<u64, FormatError> {
     })
 }
 
+/// Size of a single key in a version 1 B-tree of type 1 (raw data chunks):
+/// `chunk_size(4) + filter_mask(4) + ndims * offset_size`. The `ndims` trailing
+/// offsets are the per-dimension scaled chunk coordinates (rank + 1 values, the
+/// extra one being the element-offset dimension). (HDF5 format spec, "Disk
+/// Format: Level 1A1 — Version 1 B-trees", type 1 key.)
+const fn chunk_record_key_size(ndims: usize, offset_size: usize) -> usize {
+    4 + 4 + ndims * offset_size
+}
+
 /// Traverse B-tree v1 type 1 to collect all chunk locations.
 ///
 /// `ndims` is the number of offset dimensions in each key, which equals
@@ -151,7 +161,7 @@ pub fn collect_chunk_info(
     let os = offset_size as usize;
 
     // Parse B-tree v1 header
-    let header_size = 8 + os * 2;
+    let header_size = btree_v1_node_header_size(offset_size);
     if offset + header_size > file_data.len() {
         return Err(FormatError::UnexpectedEof {
             expected: offset + header_size,
@@ -171,10 +181,9 @@ pub fn collect_chunk_info(
     let node_level = file_data[offset + 5];
     let entries_used = u16::from_le_bytes([file_data[offset + 6], file_data[offset + 7]]) as usize;
 
-    let mut pos = offset + 8 + os * 2; // skip left/right sibling
+    let mut pos = offset + header_size; // first key, past signature/siblings
 
-    // Key size: chunk_size(4) + filter_mask(4) + ndims * offset_size
-    let key_size = 4 + 4 + ndims * os;
+    let key_size = chunk_record_key_size(ndims, os);
 
     if node_level == 0 {
         // Leaf node: keys and children interleaved
@@ -265,7 +274,7 @@ pub fn collect_chunk_info_from_source<S: FileSource + ?Sized>(
     _length_size: u8,
 ) -> Result<Vec<ChunkInfo>, FormatError> {
     let os = offset_size as usize;
-    let header_size = 8 + os * 2;
+    let header_size = btree_v1_node_header_size(offset_size);
 
     // Node header: signature(4) + type(1) + level(1) + entries_used(2) + 2 siblings.
     let header = source.read_exact_at(btree_address, header_size)?;
@@ -280,7 +289,7 @@ pub fn collect_chunk_info_from_source<S: FileSource + ?Sized>(
     let entries_used = u16::from_le_bytes([header[6], header[7]]) as usize;
 
     // Key/child region begins right after the header (siblings already included).
-    let key_size = 4 + 4 + ndims * os;
+    let key_size = chunk_record_key_size(ndims, os);
     let needed = entries_used * (key_size + os) + key_size;
     let body_addr =
         btree_address

--- a/src/group_v1.rs
+++ b/src/group_v1.rs
@@ -122,7 +122,7 @@ mod tests {
         } else {
             heap_data_size as u64
         };
-        let btree_header_size = 8 + os * 2; // sig + type + level + entries + siblings
+        let btree_header_size = crate::btree_v1::btree_v1_node_header_size(offset_size);
         let btree_keys_children = os + os + os; // key[0] + child[0] + key[1]
         let total_size = btree_offset + btree_header_size + btree_keys_children + 64;
 


### PR DESCRIPTION
Addresses the concrete example in #26: the version 1 B-tree node header size, previously written as `8 + os * 2` in five places, plus the duplicated chunk-record key size `4 + 4 + ndims * offset_size`.

## What changed

- Add `btree_v1_node_header_size(offset_size)` and `BTREE_V1_NODE_PREFIX_LEN` in `btree_v1.rs`, documented against the HDF5 format spec. The prefix constant (`signature + node_type + node_level + entries_used`) is the size-of-offsets independent part; the helper adds the two sibling addresses.
- Add `chunk_record_key_size(ndims, offset_size)` in `chunked_read.rs` for the type 1 (raw data chunk) key.
- Replace the five `8 + os * 2` sites (`btree_v1.rs`, `chunked_read.rs` x3, `group_v1.rs`) and both `4 + 4 + ndims * os` sites with the named helpers.

## Scope

Deliberately limited to the genuinely repeated/derived numeric quantities the issue called out. The 4-byte spec signatures (`b"TREE"`, `b"SNOD"`, ...) are left as literals: they read directly as the format tokens and naming them adds indirection without aiding spec correspondence.

No behavior change. `cargo fmt`, `clippy -D warnings`, and the full test suite pass locally.

A separate PR will add a miri CI job (the other suggestion in #26).