### PR TITLE
CI: add Miri undefined-behavior job (issue #26)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,3 +247,33 @@ jobs:
         with:
           key: thumbv7em
       - run: cargo build --locked --no-default-features --target thumbv7em-none-eabi
+
+  # ===========================================================================
+  # Undefined-behavior sanitizing with Miri (issue #26).
+  #
+  # The library is almost entirely safe Rust; the unsafe that exists is the
+  # cache-line-aligned chunk buffer in `chunk_cache` (manual global-allocator
+  # `alloc_zeroed`/`dealloc`, `slice::from_raw_parts[_mut]`, and `unsafe impl
+  # Send`/`Sync` for `CacheAlignedBuffer`). Miri interprets that allocation and
+  # the surrounding pointer arithmetic under Stacked Borrows + strict provenance,
+  # catching aliasing / out-of-bounds / leak UB that the normal test run cannot
+  # observe.
+  #
+  # Scoped to the `chunk_cache` unit tests on purpose: most other tests touch the
+  # filesystem and the crosscheck tests call into the libhdf5 C library, neither
+  # of which Miri can execute. Widen the `--lib` test filter as more
+  # pure-in-memory unsafe lands (the single-threaded `nosync::Mutex` is the next
+  # candidate, once the crate's no_std unit-test harness compiles).
+  miri:
+    name: Miri (undefined behavior)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@miri
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: miri
+      - name: Miri test (chunk_cache unsafe)
+        run: cargo miri test --locked --lib chunk_cache
+        env:
+          MIRIFLAGS: -Zmiri-strict-provenance

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,6 +274,10 @@ jobs:
         with:
           key: miri
       - name: Miri test (chunk_cache unsafe)
-        run: cargo miri test --locked --lib chunk_cache
+        # `--no-default-features --features std` keeps the interpreted build
+        # minimal: the `chunk_cache` tests are pure in-memory, so there is no
+        # need to compile the `deflate` (flate2/miniz_oxide) or `checksum` code
+        # that Miri never executes. Smaller, more deterministic surface.
+        run: cargo miri test --locked --no-default-features --features std --lib chunk_cache
         env:
           MIRIFLAGS: -Zmiri-strict-provenance


### PR DESCRIPTION
Adds the second suggestion from #26: a Miri job that sanitizes the crate's `unsafe` for undefined behavior.

## What changed

A `miri` CI job running `cargo miri test --locked --lib chunk_cache` under `-Zmiri-strict-provenance` (Stacked Borrows + strict provenance).

## Why `chunk_cache` specifically

The library is almost entirely safe Rust. The unsafe that matters is `CacheAlignedBuffer` in `chunk_cache`: manual global-allocator `alloc_zeroed`/`dealloc`, `slice::from_raw_parts[_mut]`, and `unsafe impl Send`/`Sync`. That manual allocation + pointer arithmetic + the hand-written `Drop` is exactly the class of code Miri's aliasing model catches and that normal tests cannot observe. Its 16 unit tests pass clean under Miri locally.

## Why it's scoped, not whole-suite

Miri interprets MIR and cannot run real filesystem I/O or FFI. Most of the suite writes temp files, and the crosscheck tests call into the libhdf5 C library (`hdf5-metno`), so a blanket `cargo miri test` would fail on those. The `--lib chunk_cache` filter targets the unsafe that Miri can actually validate. The job comment notes the next candidate (the single-threaded `nosync::Mutex`), which needs the crate's no_std unit-test harness to compile first.

Stacked separately from the magic-number cleanup (the other half of #26) as requested.