### PR TITLE
Add property tests for roundtrip and parser robustness (issue #26)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,6 +205,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,13 +228,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -310,6 +343,7 @@ dependencies = [
  "flate2",
  "hdf5-metno",
  "ndarray",
+ "proptest",
  "rayon",
  "serde",
  "serde_json",
@@ -537,6 +571,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -586,6 +629,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,9 +664,53 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "rawpointer"
@@ -675,6 +787,18 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -779,7 +903,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -822,6 +946,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -844,6 +974,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "wasip2"
@@ -1091,6 +1230,26 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,9 @@ ndarray = { version = ">=0.16, <0.18", optional = true }
 tempfile = "3"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
+# Property-based testing for the write/read roundtrip and parser-robustness
+# invariants (issue #26).
+proptest = "1"
 
 # The reference HDF5 C library, used only by the byte-level crosscheck tests.
 # Its `static` feature compiles libhdf5 from source via CMake, which does not

--- a/tests/proptest_roundtrip.rs
+++ b/tests/proptest_roundtrip.rs
@@ -13,6 +13,11 @@
 //!    reader must return `Ok`/`Err` but never panic, index out of bounds, or
 //!    overflow. proptest *shrinks* any offending input to its minimal form,
 //!    which is exactly what makes parser bugs tractable to debug.
+//!
+//! When a property fails, proptest records the minimal reproducer under
+//! `tests/proptest-regressions/` and replays it on every subsequent run. Those
+//! files are deterministic seeds, not build artifacts: commit them so the
+//! reproducer travels with the fix.
 
 use hdf5_pure::{DType, File, FileBuilder, Group};
 use proptest::prelude::*;

--- a/tests/proptest_roundtrip.rs
+++ b/tests/proptest_roundtrip.rs
@@ -1,0 +1,261 @@
+//! Property-based tests (issue #26).
+//!
+//! Two invariants that example-based tests can only spot-check but that
+//! property testing exercises across a generated input space:
+//!
+//! 1. **Roundtrip identity.** For any in-range data and shape, writing a
+//!    dataset and reading it back yields the original values, bit-exact (so
+//!    `NaN`/`Inf` floats must roundtrip too), with the original shape and
+//!    dtype. Covered for every numeric type the builder/reader support, in
+//!    both contiguous and chunked+deflate layouts.
+//!
+//! 2. **Parser robustness.** Feeding arbitrary or corrupted bytes to the
+//!    reader must return `Ok`/`Err` but never panic, index out of bounds, or
+//!    overflow. proptest *shrinks* any offending input to its minimal form,
+//!    which is exactly what makes parser bugs tractable to debug.
+
+use hdf5_pure::{DType, File, FileBuilder, Group};
+use proptest::prelude::*;
+
+/// The 8-byte HDF5 magic signature. Mirrored here (rather than imported from
+/// the crate-internal `signature` module) so the robustness tests can force the
+/// reader past signature detection and into superblock/header parsing, where
+/// the interesting failure modes live.
+const HDF5_SIGNATURE: [u8; 8] = [0x89, b'H', b'D', b'F', b'\r', b'\n', 0x1A, b'\n'];
+
+// ---------------------------------------------------------------------------
+// Roundtrip identity
+// ---------------------------------------------------------------------------
+
+/// Strategy: a shape of 1..=3 dimensions, each extent 1..=6, paired with
+/// exactly `product(shape)` elements drawn from `$elem`.
+macro_rules! shaped {
+    ($elem:expr) => {
+        prop::collection::vec(1u64..=6, 1..=3).prop_flat_map(|shape| {
+            let n = shape.iter().product::<u64>() as usize;
+            (Just(shape), prop::collection::vec($elem, n..=n))
+        })
+    };
+}
+
+/// Generate a roundtrip property test for one numeric type. `$eq` compares the
+/// readback against the input (plain `==` for integers, bit-exact for floats).
+macro_rules! roundtrip_test {
+    ($name:ident, $ty:ty, $with:ident, $read:ident, $dtype:expr, $eq:expr) => {
+        proptest! {
+            #[test]
+            fn $name((shape, data) in shaped!(any::<$ty>())) {
+                let mut b = FileBuilder::new();
+                b.create_dataset("d").$with(&data).with_shape(&shape);
+                let bytes = b.finish().expect("write");
+                let file = File::from_bytes(bytes).expect("parse");
+                let ds = file.dataset("d").expect("dataset");
+
+                prop_assert_eq!(ds.shape().expect("shape"), shape);
+                prop_assert_eq!(ds.dtype().expect("dtype"), $dtype);
+                let got = ds.$read().expect("read");
+                prop_assert!($eq(&got, &data), "roundtrip mismatch");
+            }
+        }
+    };
+}
+
+fn int_eq<T: PartialEq>(a: &[T], b: &[T]) -> bool {
+    a == b
+}
+fn f32_eq(a: &[f32], b: &[f32]) -> bool {
+    a.len() == b.len() && a.iter().zip(b).all(|(x, y)| x.to_bits() == y.to_bits())
+}
+fn f64_eq(a: &[f64], b: &[f64]) -> bool {
+    a.len() == b.len() && a.iter().zip(b).all(|(x, y)| x.to_bits() == y.to_bits())
+}
+
+roundtrip_test!(
+    roundtrip_f64,
+    f64,
+    with_f64_data,
+    read_f64,
+    DType::F64,
+    f64_eq
+);
+roundtrip_test!(
+    roundtrip_f32,
+    f32,
+    with_f32_data,
+    read_f32,
+    DType::F32,
+    f32_eq
+);
+roundtrip_test!(roundtrip_i8, i8, with_i8_data, read_i8, DType::I8, int_eq);
+roundtrip_test!(
+    roundtrip_i16,
+    i16,
+    with_i16_data,
+    read_i16,
+    DType::I16,
+    int_eq
+);
+roundtrip_test!(
+    roundtrip_i32,
+    i32,
+    with_i32_data,
+    read_i32,
+    DType::I32,
+    int_eq
+);
+roundtrip_test!(
+    roundtrip_i64,
+    i64,
+    with_i64_data,
+    read_i64,
+    DType::I64,
+    int_eq
+);
+roundtrip_test!(roundtrip_u8, u8, with_u8_data, read_u8, DType::U8, int_eq);
+roundtrip_test!(
+    roundtrip_u16,
+    u16,
+    with_u16_data,
+    read_u16,
+    DType::U16,
+    int_eq
+);
+roundtrip_test!(
+    roundtrip_u32,
+    u32,
+    with_u32_data,
+    read_u32,
+    DType::U32,
+    int_eq
+);
+roundtrip_test!(
+    roundtrip_u64,
+    u64,
+    with_u64_data,
+    read_u64,
+    DType::U64,
+    int_eq
+);
+
+proptest! {
+    /// Chunked + deflate layout roundtrip (lossless integer path). Exercises
+    /// the B-tree v1 chunk index and the filter pipeline, not just contiguous
+    /// storage. Chunk dims are clamped to the shape so the request is valid.
+    #[test]
+    fn roundtrip_i32_chunked_deflate(
+        (shape, chunk, data) in prop::collection::vec(1u64..=6, 1..=3).prop_flat_map(|shape| {
+            let k = shape.len();
+            let n = shape.iter().product::<u64>() as usize;
+            (Just(shape), prop::collection::vec(1u64..=6, k..=k), prop::collection::vec(any::<i32>(), n..=n))
+        }).prop_map(|(shape, seeds, data)| {
+            let chunk = shape.iter().zip(&seeds).map(|(&d, &s)| s.min(d)).collect::<Vec<u64>>();
+            (shape, chunk, data)
+        })
+    ) {
+        let mut b = FileBuilder::new();
+        b.create_dataset("d")
+            .with_i32_data(&data)
+            .with_shape(&shape)
+            .with_chunks(&chunk)
+            .with_deflate(6);
+        let bytes = b.finish().expect("write");
+        let file = File::from_bytes(bytes).expect("parse");
+        let ds = file.dataset("d").expect("dataset");
+
+        prop_assert_eq!(ds.shape().expect("shape"), shape);
+        prop_assert_eq!(ds.read_i32().expect("read"), data);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Parser robustness
+// ---------------------------------------------------------------------------
+
+/// Drive parsing one level deep without unwrapping: every call may legitimately
+/// fail on a corrupt file, but none may panic. Deliberately shallow (no
+/// recursion into nested groups) so a maliciously cyclic structure cannot hang
+/// the test; the goal here is "parsing primitives never panic", not exhaustive
+/// traversal.
+fn exercise(file: &File) {
+    let root: Group<'_> = file.root();
+    if let Ok(names) = root.datasets() {
+        for name in names.iter().take(16) {
+            if let Ok(ds) = root.dataset(name) {
+                let _ = ds.shape();
+                let _ = ds.dtype();
+                let _ = ds.read_f64();
+                let _ = ds.read_i64();
+                let _ = ds.read_u8();
+                let _ = ds.read_string();
+            }
+        }
+    }
+    if let Ok(groups) = root.groups() {
+        for name in groups.iter().take(16) {
+            let _ = root.group(name);
+        }
+    }
+}
+
+/// A small but structurally complete valid file: root attribute, a contiguous
+/// dataset, and a group containing a chunked+deflate dataset. Corrupting copies
+/// of this drives far more of the parser than random bytes can.
+fn valid_sample_file() -> Vec<u8> {
+    let mut b = FileBuilder::new();
+    b.set_attr("version", hdf5_pure::AttrValue::I64(2));
+    b.create_dataset("contig")
+        .with_f64_data(&[1.0, 2.0, 3.0, 4.0])
+        .with_shape(&[2, 2]);
+    let mut grp = b.create_group("g");
+    grp.create_dataset("chunked")
+        .with_i32_data(&[1, 2, 3, 4, 5, 6])
+        .with_shape(&[6])
+        .with_chunks(&[3])
+        .with_deflate(4);
+    let finished = grp.finish();
+    b.add_group(finished);
+    b.finish().expect("sample file must build")
+}
+
+proptest! {
+    /// Arbitrary bytes: the common case returns `SignatureNotFound`, but the
+    /// reader must never panic regardless.
+    #[test]
+    fn open_arbitrary_bytes_never_panics(bytes in prop::collection::vec(any::<u8>(), 0..4096)) {
+        if let Ok(file) = File::from_bytes(bytes) {
+            exercise(&file);
+        }
+    }
+
+    /// Arbitrary bytes behind a valid signature: forces the reader past
+    /// signature detection into superblock and object-header parsing, where the
+    /// interesting out-of-bounds/overflow paths are.
+    #[test]
+    fn open_signature_prefixed_bytes_never_panics(tail in prop::collection::vec(any::<u8>(), 0..4096)) {
+        let mut bytes = HDF5_SIGNATURE.to_vec();
+        bytes.extend_from_slice(&tail);
+        if let Ok(file) = File::from_bytes(bytes) {
+            exercise(&file);
+        }
+    }
+
+    /// Corrupted valid file: flip random bytes and/or truncate a real file.
+    /// This keeps the byte stream "shaped like" HDF5 so mutations land inside
+    /// superblock fields, message headers, B-tree nodes, and chunk offsets,
+    /// the regions where a careless parser over-reads.
+    #[test]
+    fn corrupted_valid_file_never_panics(
+        muts in prop::collection::vec((any::<usize>(), any::<u8>()), 0..48),
+        truncate in 0usize..=96,
+    ) {
+        let mut bytes = valid_sample_file();
+        let len = bytes.len();
+        for (idx, val) in muts {
+            bytes[idx % len] = val;
+        }
+        bytes.truncate(len.saturating_sub(truncate));
+        if let Ok(file) = File::from_bytes(bytes) {
+            exercise(&file);
+        }
+    }
+}


### PR DESCRIPTION
Adds the property-based testing suggested in #26, with `proptest` as a dev-dependency. Two invariants that example-based tests can only spot-check by enumeration.

## 1. Roundtrip identity

For a generated shape (1-3 dims, each extent 1-6) and matching data, writing a dataset and reading it back must yield the original values, **bit-exact** (so `NaN`/`Inf` floats roundtrip too, compared via `to_bits()`), with the original shape and dtype.

Covered for every numeric type the builder/reader expose: `f32`, `f64`, `i8`/`i16`/`i32`/`i64`, `u8`/`u16`/`u32`/`u64`, generated through a small macro. Plus a chunked+deflate case that drives the B-tree v1 chunk index and the filter pipeline rather than just contiguous storage.

## 2. Parser robustness

Feeding bytes to `File::from_bytes` must return `Ok`/`Err` but never panic, index out of bounds, or overflow. Three generators, increasing in depth:

- **arbitrary bytes** (mostly `SignatureNotFound`, but must not panic),
- **arbitrary bytes behind a valid HDF5 signature**, forcing the reader past signature detection into superblock and object-header parsing where the over-read paths live,
- **a corrupted/truncated copy of a real file** (root attr + contiguous dataset + group with a chunked+deflate dataset), so mutations land inside genuine superblock fields, message headers, B-tree nodes, and chunk offsets.

When a property fails, proptest shrinks the input to a minimal reproducer and records it under `tests/proptest-regressions/` for replay.

## Validation

Stressed locally well beyond CI defaults: **20,000 cases per robustness test** and **5,000 per roundtrip type**, no failures. The parser handled every corrupted/truncated input gracefully.

Runs inside the existing `cargo test --locked` job on all platforms, so no workflow change is needed. Third of the #26 follow-ups, alongside the magic-number cleanup (#42) and the Miri job (#43).