### PR TITLE
Add safe compound tuple I/O and explicit field offsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,10 +184,34 @@ Supported subset: one unlimited dimension, chunked, unfiltered (no compression o
 | `with_complex32_data` | Compound `{real: f32, imag: f32}` |
 | `with_complex64_data` | Compound `{real: f64, imag: f64}` |
 | `with_compound_data` | Arbitrary compound types |
+| `with_compound_values` | Safely encoded numeric tuples |
 | `with_enum_i32_data` / `with_enum_u8_data` | Enumeration types |
 | `with_array_data` | Fixed-size array types |
 | `with_path_references` | Object references (resolved by path) |
 | `with_dtype` + `with_shape` | Empty/zero-dimension datasets |
+
+### Compound types
+
+Numeric tuples are encoded field by field, without relying on Rust tuple layout:
+
+```rust
+use hdf5_pure::{File, FileBuilder};
+
+let values = [(1i8, 20u64, 3.5f32), (2, 30, 4.5)];
+let mut builder = FileBuilder::new();
+builder.create_dataset("records")
+    .with_compound_values(&values)
+    .unwrap();
+let bytes = builder.finish().unwrap();
+
+let file = File::from_bytes(bytes).unwrap();
+let records = file.dataset("records").unwrap()
+    .read_compound::<(i8, u64, f32)>()
+    .unwrap();
+assert_eq!(records, values);
+```
+
+Use `CompoundTypeBuilder::with_size` for an `H5Tinsert`-style layout with explicit offsets and padding. `Dataset::datatype` exposes the exact field offsets from existing files, while `Dataset::read_raw` returns their complete unfiltered record bytes.
 
 ### Attributes
 

--- a/src/compound.rs
+++ b/src/compound.rs
@@ -1,7 +1,7 @@
 //! Safe field-wise encoding and decoding for HDF5 compound datatypes.
 
 #[cfg(not(feature = "std"))]
-use alloc::{string::ToString, vec::Vec};
+use alloc::{format, string::ToString, vec::Vec};
 
 use crate::convert::{TryToUsize, u32_from};
 use crate::datatype::{CompoundMember, Datatype, DatatypeByteOrder};
@@ -236,8 +236,13 @@ fn decode_named<T: CompoundField>(
                 compound_size: reported_compound_size(bytes),
             })?;
     T::decode_field(&member.datatype, field_bytes).map_err(|error| match error {
-        FormatError::CompoundFieldTypeMismatch(_) => {
-            FormatError::CompoundFieldTypeMismatch(name.to_string())
+        FormatError::CompoundFieldTypeMismatch(inner) => {
+            let path = if inner.is_empty() {
+                name.to_string()
+            } else {
+                format!("{}.{}", name, inner)
+            };
+            FormatError::CompoundFieldTypeMismatch(path)
         }
         other => other,
     })

--- a/src/compound.rs
+++ b/src/compound.rs
@@ -1,0 +1,303 @@
+//! Safe field-wise encoding and decoding for HDF5 compound datatypes.
+
+#[cfg(not(feature = "std"))]
+use alloc::{string::ToString, vec::Vec};
+
+use crate::datatype::{CompoundMember, Datatype, DatatypeByteOrder};
+use crate::error::FormatError;
+use crate::type_builders::{
+    make_f32_type, make_f64_type, make_i8_type, make_i16_type, make_i32_type, make_i64_type,
+    make_u8_type, make_u16_type, make_u32_type, make_u64_type,
+};
+
+/// A type that can occupy one field of an HDF5 compound value.
+///
+/// Implementations encode and decode the field explicitly. They must not copy
+/// padding bytes or rely on the Rust memory layout of `Self`.
+pub trait CompoundField: Sized {
+    /// Canonical datatype used when writing this field.
+    fn datatype() -> Datatype;
+
+    /// Append this field's canonical byte representation to `output`.
+    fn encode_field(&self, output: &mut Vec<u8>);
+
+    /// Decode this field from bytes described by `datatype`.
+    fn decode_field(datatype: &Datatype, bytes: &[u8]) -> Result<Self, FormatError>;
+}
+
+/// A safely encoded HDF5 compound element.
+///
+/// The built-in implementations cover tuples of one through twelve numeric
+/// fields. Tuple fields are named `"0"`, `"1"`, and so on in the file. The
+/// tuple's Rust memory representation is never inspected.
+///
+/// User-defined structs can implement this trait by encoding each field
+/// explicitly and decoding fields according to the offsets in the supplied
+/// [`Datatype`].
+pub trait CompoundType: Sized {
+    /// Canonical datatype used when creating a dataset for this type.
+    fn datatype() -> Datatype;
+
+    /// Append one canonical compound element to `output`.
+    fn encode(&self, output: &mut Vec<u8>);
+
+    /// Decode one element from `bytes` using its exact on-disk datatype.
+    fn decode(datatype: &Datatype, bytes: &[u8]) -> Result<Self, FormatError>;
+}
+
+fn require_bytes(bytes: &[u8], size: usize) -> Result<&[u8], FormatError> {
+    if bytes.len() != size {
+        return Err(FormatError::DataSizeMismatch {
+            expected: size,
+            actual: bytes.len(),
+        });
+    }
+    Ok(bytes)
+}
+
+fn integer_order(
+    datatype: &Datatype,
+    size: u32,
+    signed: bool,
+    name: &str,
+) -> Result<DatatypeByteOrder, FormatError> {
+    match datatype {
+        Datatype::FixedPoint {
+            size: actual_size,
+            byte_order,
+            signed: actual_signed,
+            bit_offset: 0,
+            bit_precision,
+        } if *actual_size == size
+            && *actual_signed == signed
+            && u32::from(*bit_precision) == size * 8 =>
+        {
+            Ok(byte_order.clone())
+        }
+        _ => Err(FormatError::CompoundFieldTypeMismatch(name.to_string())),
+    }
+}
+
+fn float_order(
+    datatype: &Datatype,
+    size: u32,
+    name: &str,
+) -> Result<DatatypeByteOrder, FormatError> {
+    let standard = match (datatype, size) {
+        (
+            Datatype::FloatingPoint {
+                size: 4,
+                byte_order,
+                bit_offset: 0,
+                bit_precision: 32,
+                exponent_location: 23,
+                exponent_size: 8,
+                mantissa_location: 0,
+                mantissa_size: 23,
+                exponent_bias: 127,
+            },
+            4,
+        ) => Some(byte_order.clone()),
+        (
+            Datatype::FloatingPoint {
+                size: 8,
+                byte_order,
+                bit_offset: 0,
+                bit_precision: 64,
+                exponent_location: 52,
+                exponent_size: 11,
+                mantissa_location: 0,
+                mantissa_size: 52,
+                exponent_bias: 1023,
+            },
+            8,
+        ) => Some(byte_order.clone()),
+        _ => None,
+    };
+    standard.ok_or_else(|| FormatError::CompoundFieldTypeMismatch(name.to_string()))
+}
+
+fn ordered<const N: usize>(bytes: &[u8], order: DatatypeByteOrder) -> Result<[u8; N], FormatError> {
+    let bytes = require_bytes(bytes, N)?;
+    let mut array = [0u8; N];
+    array.copy_from_slice(bytes);
+    match order {
+        DatatypeByteOrder::LittleEndian => Ok(array),
+        DatatypeByteOrder::BigEndian => {
+            array.reverse();
+            Ok(array)
+        }
+        DatatypeByteOrder::Vax => Err(FormatError::InvalidByteOrder(2)),
+    }
+}
+
+macro_rules! impl_integer_field {
+    ($ty:ty, $make:ident, $signed:expr) => {
+        impl CompoundField for $ty {
+            fn datatype() -> Datatype {
+                $make()
+            }
+
+            fn encode_field(&self, output: &mut Vec<u8>) {
+                output.extend_from_slice(&self.to_le_bytes());
+            }
+
+            fn decode_field(datatype: &Datatype, bytes: &[u8]) -> Result<Self, FormatError> {
+                let order =
+                    integer_order(datatype, core::mem::size_of::<Self>() as u32, $signed, "")?;
+                Ok(<$ty>::from_le_bytes(ordered(bytes, order)?))
+            }
+        }
+    };
+}
+
+impl_integer_field!(i8, make_i8_type, true);
+impl_integer_field!(i16, make_i16_type, true);
+impl_integer_field!(i32, make_i32_type, true);
+impl_integer_field!(i64, make_i64_type, true);
+impl_integer_field!(u8, make_u8_type, false);
+impl_integer_field!(u16, make_u16_type, false);
+impl_integer_field!(u32, make_u32_type, false);
+impl_integer_field!(u64, make_u64_type, false);
+
+macro_rules! impl_float_field {
+    ($ty:ty, $make:ident) => {
+        impl CompoundField for $ty {
+            fn datatype() -> Datatype {
+                $make()
+            }
+
+            fn encode_field(&self, output: &mut Vec<u8>) {
+                output.extend_from_slice(&self.to_le_bytes());
+            }
+
+            fn decode_field(datatype: &Datatype, bytes: &[u8]) -> Result<Self, FormatError> {
+                let order = float_order(datatype, core::mem::size_of::<Self>() as u32, "")?;
+                Ok(<$ty>::from_le_bytes(ordered(bytes, order)?))
+            }
+        }
+    };
+}
+
+impl_float_field!(f32, make_f32_type);
+impl_float_field!(f64, make_f64_type);
+
+fn compound_parts<'a>(
+    datatype: &'a Datatype,
+    bytes: &[u8],
+) -> Result<(&'a [CompoundMember], u32), FormatError> {
+    match datatype {
+        Datatype::Compound { size, members } => {
+            require_bytes(bytes, *size as usize)?;
+            Ok((members, *size))
+        }
+        _ => Err(FormatError::TypeMismatch {
+            expected: "Compound",
+            actual: "non-Compound",
+        }),
+    }
+}
+
+fn decode_named<T: CompoundField>(
+    members: &[CompoundMember],
+    bytes: &[u8],
+    name: &str,
+) -> Result<T, FormatError> {
+    let member = members
+        .iter()
+        .find(|member| member.name == name)
+        .ok_or_else(|| FormatError::CompoundFieldMissing(name.to_string()))?;
+    let start =
+        usize::try_from(member.byte_offset).map_err(|_| FormatError::CompoundFieldOutOfBounds {
+            name: name.to_string(),
+            offset: member.byte_offset,
+            field_size: member.datatype.type_size(),
+            compound_size: bytes.len() as u32,
+        })?;
+    let end = start
+        .checked_add(member.datatype.type_size() as usize)
+        .ok_or_else(|| FormatError::CompoundFieldOutOfBounds {
+            name: name.to_string(),
+            offset: member.byte_offset,
+            field_size: member.datatype.type_size(),
+            compound_size: bytes.len() as u32,
+        })?;
+    let field_bytes =
+        bytes
+            .get(start..end)
+            .ok_or_else(|| FormatError::CompoundFieldOutOfBounds {
+                name: name.to_string(),
+                offset: member.byte_offset,
+                field_size: member.datatype.type_size(),
+                compound_size: bytes.len() as u32,
+            })?;
+    T::decode_field(&member.datatype, field_bytes).map_err(|error| match error {
+        FormatError::CompoundFieldTypeMismatch(_) => {
+            FormatError::CompoundFieldTypeMismatch(name.to_string())
+        }
+        other => other,
+    })
+}
+
+macro_rules! impl_compound_tuple {
+    ($($type:ident:$index:tt),+) => {
+        impl<$($type: CompoundField),+> CompoundType for ($($type,)+) {
+            fn datatype() -> Datatype {
+                let mut offset = 0u64;
+                let mut members = Vec::new();
+                $(
+                    let datatype = $type::datatype();
+                    members.push(CompoundMember {
+                        name: stringify!($index).to_string(),
+                        byte_offset: offset,
+                        datatype: datatype.clone(),
+                    });
+                    offset += u64::from(datatype.type_size());
+                )+
+                Datatype::Compound {
+                    size: offset as u32,
+                    members,
+                }
+            }
+
+            fn encode(&self, output: &mut Vec<u8>) {
+                $(self.$index.encode_field(output);)+
+            }
+
+            fn decode(datatype: &Datatype, bytes: &[u8]) -> Result<Self, FormatError> {
+                let (members, _) = compound_parts(datatype, bytes)?;
+                Ok(($(decode_named::<$type>(members, bytes, stringify!($index))?,)+))
+            }
+        }
+
+        impl<$($type: CompoundField),+> CompoundField for ($($type,)+) {
+            fn datatype() -> Datatype {
+                <Self as CompoundType>::datatype()
+            }
+
+            fn encode_field(&self, output: &mut Vec<u8>) {
+                <Self as CompoundType>::encode(self, output);
+            }
+
+            fn decode_field(
+                datatype: &Datatype,
+                bytes: &[u8],
+            ) -> Result<Self, FormatError> {
+                <Self as CompoundType>::decode(datatype, bytes)
+            }
+        }
+    };
+}
+
+impl_compound_tuple!(A:0);
+impl_compound_tuple!(A:0, B:1);
+impl_compound_tuple!(A:0, B:1, C:2);
+impl_compound_tuple!(A:0, B:1, C:2, D:3);
+impl_compound_tuple!(A:0, B:1, C:2, D:3, E:4);
+impl_compound_tuple!(A:0, B:1, C:2, D:3, E:4, F:5);
+impl_compound_tuple!(A:0, B:1, C:2, D:3, E:4, F:5, G:6);
+impl_compound_tuple!(A:0, B:1, C:2, D:3, E:4, F:5, G:6, H:7);
+impl_compound_tuple!(A:0, B:1, C:2, D:3, E:4, F:5, G:6, H:7, I:8);
+impl_compound_tuple!(A:0, B:1, C:2, D:3, E:4, F:5, G:6, H:7, I:8, J:9);
+impl_compound_tuple!(A:0, B:1, C:2, D:3, E:4, F:5, G:6, H:7, I:8, J:9, K:10);
+impl_compound_tuple!(A:0, B:1, C:2, D:3, E:4, F:5, G:6, H:7, I:8, J:9, K:10, L:11);

--- a/src/compound.rs
+++ b/src/compound.rs
@@ -3,6 +3,7 @@
 #[cfg(not(feature = "std"))]
 use alloc::{string::ToString, vec::Vec};
 
+use crate::convert::{TryToUsize, u32_from};
 use crate::datatype::{CompoundMember, Datatype, DatatypeByteOrder};
 use crate::error::FormatError;
 use crate::type_builders::{
@@ -16,7 +17,7 @@ use crate::type_builders::{
 /// padding bytes or rely on the Rust memory layout of `Self`.
 pub trait CompoundField: Sized {
     /// Canonical datatype used when writing this field.
-    fn datatype() -> Datatype;
+    fn datatype() -> Result<Datatype, FormatError>;
 
     /// Append this field's canonical byte representation to `output`.
     fn encode_field(&self, output: &mut Vec<u8>);
@@ -36,7 +37,7 @@ pub trait CompoundField: Sized {
 /// [`Datatype`].
 pub trait CompoundType: Sized {
     /// Canonical datatype used when creating a dataset for this type.
-    fn datatype() -> Datatype;
+    fn datatype() -> Result<Datatype, FormatError>;
 
     /// Append one canonical compound element to `output`.
     fn encode(&self, output: &mut Vec<u8>);
@@ -132,10 +133,10 @@ fn ordered<const N: usize>(bytes: &[u8], order: DatatypeByteOrder) -> Result<[u8
 }
 
 macro_rules! impl_integer_field {
-    ($ty:ty, $make:ident, $signed:expr) => {
+    ($ty:ty, $make:ident, $size:expr, $signed:expr) => {
         impl CompoundField for $ty {
-            fn datatype() -> Datatype {
-                $make()
+            fn datatype() -> Result<Datatype, FormatError> {
+                Ok($make())
             }
 
             fn encode_field(&self, output: &mut Vec<u8>) {
@@ -143,28 +144,27 @@ macro_rules! impl_integer_field {
             }
 
             fn decode_field(datatype: &Datatype, bytes: &[u8]) -> Result<Self, FormatError> {
-                let order =
-                    integer_order(datatype, core::mem::size_of::<Self>() as u32, $signed, "")?;
+                let order = integer_order(datatype, $size, $signed, "")?;
                 Ok(<$ty>::from_le_bytes(ordered(bytes, order)?))
             }
         }
     };
 }
 
-impl_integer_field!(i8, make_i8_type, true);
-impl_integer_field!(i16, make_i16_type, true);
-impl_integer_field!(i32, make_i32_type, true);
-impl_integer_field!(i64, make_i64_type, true);
-impl_integer_field!(u8, make_u8_type, false);
-impl_integer_field!(u16, make_u16_type, false);
-impl_integer_field!(u32, make_u32_type, false);
-impl_integer_field!(u64, make_u64_type, false);
+impl_integer_field!(i8, make_i8_type, 1, true);
+impl_integer_field!(i16, make_i16_type, 2, true);
+impl_integer_field!(i32, make_i32_type, 4, true);
+impl_integer_field!(i64, make_i64_type, 8, true);
+impl_integer_field!(u8, make_u8_type, 1, false);
+impl_integer_field!(u16, make_u16_type, 2, false);
+impl_integer_field!(u32, make_u32_type, 4, false);
+impl_integer_field!(u64, make_u64_type, 8, false);
 
 macro_rules! impl_float_field {
-    ($ty:ty, $make:ident) => {
+    ($ty:ty, $make:ident, $size:expr) => {
         impl CompoundField for $ty {
-            fn datatype() -> Datatype {
-                $make()
+            fn datatype() -> Result<Datatype, FormatError> {
+                Ok($make())
             }
 
             fn encode_field(&self, output: &mut Vec<u8>) {
@@ -172,15 +172,15 @@ macro_rules! impl_float_field {
             }
 
             fn decode_field(datatype: &Datatype, bytes: &[u8]) -> Result<Self, FormatError> {
-                let order = float_order(datatype, core::mem::size_of::<Self>() as u32, "")?;
+                let order = float_order(datatype, $size, "")?;
                 Ok(<$ty>::from_le_bytes(ordered(bytes, order)?))
             }
         }
     };
 }
 
-impl_float_field!(f32, make_f32_type);
-impl_float_field!(f64, make_f64_type);
+impl_float_field!(f32, make_f32_type, 4);
+impl_float_field!(f64, make_f64_type, 8);
 
 fn compound_parts<'a>(
     datatype: &'a Datatype,
@@ -188,7 +188,7 @@ fn compound_parts<'a>(
 ) -> Result<(&'a [CompoundMember], u32), FormatError> {
     match datatype {
         Datatype::Compound { size, members } => {
-            require_bytes(bytes, *size as usize)?;
+            require_bytes(bytes, size.to_usize()?)?;
             Ok((members, *size))
         }
         _ => Err(FormatError::TypeMismatch {
@@ -196,6 +196,10 @@ fn compound_parts<'a>(
             actual: "non-Compound",
         }),
     }
+}
+
+fn reported_compound_size(bytes: &[u8]) -> u32 {
+    u32::try_from(bytes.len()).unwrap_or(u32::MAX)
 }
 
 fn decode_named<T: CompoundField>(
@@ -212,15 +216,15 @@ fn decode_named<T: CompoundField>(
             name: name.to_string(),
             offset: member.byte_offset,
             field_size: member.datatype.type_size(),
-            compound_size: bytes.len() as u32,
+            compound_size: reported_compound_size(bytes),
         })?;
     let end = start
-        .checked_add(member.datatype.type_size() as usize)
+        .checked_add(member.datatype.type_size().to_usize()?)
         .ok_or_else(|| FormatError::CompoundFieldOutOfBounds {
             name: name.to_string(),
             offset: member.byte_offset,
             field_size: member.datatype.type_size(),
-            compound_size: bytes.len() as u32,
+            compound_size: reported_compound_size(bytes),
         })?;
     let field_bytes =
         bytes
@@ -229,7 +233,7 @@ fn decode_named<T: CompoundField>(
                 name: name.to_string(),
                 offset: member.byte_offset,
                 field_size: member.datatype.type_size(),
-                compound_size: bytes.len() as u32,
+                compound_size: reported_compound_size(bytes),
             })?;
     T::decode_field(&member.datatype, field_bytes).map_err(|error| match error {
         FormatError::CompoundFieldTypeMismatch(_) => {
@@ -242,11 +246,11 @@ fn decode_named<T: CompoundField>(
 macro_rules! impl_compound_tuple {
     ($($type:ident:$index:tt),+) => {
         impl<$($type: CompoundField),+> CompoundType for ($($type,)+) {
-            fn datatype() -> Datatype {
+            fn datatype() -> Result<Datatype, FormatError> {
                 let mut offset = 0u64;
                 let mut members = Vec::new();
                 $(
-                    let datatype = $type::datatype();
+                    let datatype = $type::datatype()?;
                     members.push(CompoundMember {
                         name: stringify!($index).to_string(),
                         byte_offset: offset,
@@ -254,10 +258,10 @@ macro_rules! impl_compound_tuple {
                     });
                     offset += u64::from(datatype.type_size());
                 )+
-                Datatype::Compound {
-                    size: offset as u32,
+                Ok(Datatype::Compound {
+                    size: u32_from(offset)?,
                     members,
-                }
+                })
             }
 
             fn encode(&self, output: &mut Vec<u8>) {
@@ -271,7 +275,7 @@ macro_rules! impl_compound_tuple {
         }
 
         impl<$($type: CompoundField),+> CompoundField for ($($type,)+) {
-            fn datatype() -> Datatype {
+            fn datatype() -> Result<Datatype, FormatError> {
                 <Self as CompoundType>::datatype()
             }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -53,6 +53,34 @@ pub enum FormatError {
     InvalidByteOrder(u8),
     /// Invalid reference type.
     InvalidReferenceType(u8),
+    /// A compound datatype has a zero total size.
+    InvalidCompoundSize,
+    /// A compound datatype contains no fields.
+    EmptyCompoundType,
+    /// A compound datatype contains the same field name more than once.
+    DuplicateCompoundField(String),
+    /// A compound field extends past the declared compound size.
+    CompoundFieldOutOfBounds {
+        /// Field name.
+        name: String,
+        /// Field byte offset.
+        offset: u64,
+        /// Field size in bytes.
+        field_size: u32,
+        /// Declared compound size in bytes.
+        compound_size: u32,
+    },
+    /// Two compound fields overlap.
+    CompoundFieldOverlap {
+        /// Earlier field in byte order.
+        first: String,
+        /// Later field in byte order.
+        second: String,
+    },
+    /// A named compound field was not present.
+    CompoundFieldMissing(String),
+    /// A compound field has an incompatible datatype.
+    CompoundFieldTypeMismatch(String),
     /// Invalid dataspace version.
     InvalidDataspaceVersion(u8),
     /// Invalid dataspace type.
@@ -271,6 +299,36 @@ impl fmt::Display for FormatError {
             }
             FormatError::InvalidReferenceType(r) => {
                 write!(f, "invalid reference type: {r}")
+            }
+            FormatError::InvalidCompoundSize => {
+                write!(f, "compound datatype size must be greater than zero")
+            }
+            FormatError::EmptyCompoundType => {
+                write!(f, "compound datatype must contain at least one field")
+            }
+            FormatError::DuplicateCompoundField(name) => {
+                write!(f, "duplicate compound field name: {name}")
+            }
+            FormatError::CompoundFieldOutOfBounds {
+                name,
+                offset,
+                field_size,
+                compound_size,
+            } => {
+                write!(
+                    f,
+                    "compound field {name:?} at offset {offset} with size {field_size} \
+                     exceeds compound size {compound_size}"
+                )
+            }
+            FormatError::CompoundFieldOverlap { first, second } => {
+                write!(f, "compound fields {first:?} and {second:?} overlap")
+            }
+            FormatError::CompoundFieldMissing(name) => {
+                write!(f, "compound field {name:?} is missing")
+            }
+            FormatError::CompoundFieldTypeMismatch(name) => {
+                write!(f, "compound field {name:?} has an incompatible datatype")
             }
             FormatError::InvalidDataspaceVersion(v) => {
                 write!(f, "invalid dataspace version: {v}")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,7 @@ pub(crate) mod checksum;
 pub(crate) mod chunk_cache;
 pub(crate) mod chunked_read;
 pub(crate) mod chunked_write;
+pub(crate) mod compound;
 pub(crate) mod convert;
 pub(crate) mod data_layout;
 pub(crate) mod data_read;
@@ -210,10 +211,14 @@ pub use scaleoffset::ScaleOffset;
 
 // The HDF5 datatype handle returned by the `make_*_type` constructors and
 // accepted by the compound/enum builders and `DatasetBuilder::with_dtype`.
-pub use datatype::Datatype;
+pub use compound::{CompoundField, CompoundType};
+pub use datatype::{
+    CharacterSet, CompoundMember, Datatype, DatatypeByteOrder, EnumMember, ReferenceType,
+    StringPadding,
+};
 
 pub use type_builders::{
-    CompoundTypeBuilder, DatasetBuilder, EnumTypeBuilder, FinishedGroup, GroupBuilder,
-    make_f32_type, make_f64_type, make_i8_type, make_i16_type, make_i32_type, make_i64_type,
-    make_u8_type, make_u16_type, make_u32_type, make_u64_type,
+    CompoundTypeBuilder, DatasetBuilder, EnumTypeBuilder, ExplicitCompoundTypeBuilder,
+    FinishedGroup, GroupBuilder, make_f32_type, make_f64_type, make_i8_type, make_i16_type,
+    make_i32_type, make_i64_type, make_u8_type, make_u16_type, make_u32_type, make_u64_type,
 };

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -688,7 +688,7 @@ impl<'f> Dataset<'f> {
     /// memory layout, so padded compound records are supported safely.
     pub fn read_compound<T: CompoundType>(&self) -> Result<Vec<T>, Error> {
         let datatype = self.datatype()?;
-        let element_size = datatype.type_size() as usize;
+        let element_size = datatype.type_size().to_usize()?;
         if !matches!(datatype, Datatype::Compound { .. }) {
             return Err(FormatError::TypeMismatch {
                 expected: "Compound",

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -5,6 +5,7 @@ use std::io::{Read, Seek, SeekFrom};
 
 use crate::attribute::extract_attributes_full;
 use crate::chunk_cache::ChunkCache;
+use crate::compound::CompoundType;
 use crate::convert::TryToUsize;
 use crate::data_layout::DataLayout;
 use crate::data_read;
@@ -627,7 +628,9 @@ impl<'f> Dataset<'f> {
         self.file.attrs_of(&self.header)
     }
 
-    fn datatype(&self) -> Result<Datatype, Error> {
+    /// Returns the exact HDF5 datatype, including compound field offsets and
+    /// total record size.
+    pub fn datatype(&self) -> Result<Datatype, Error> {
         let msg = find_message(&self.header, MessageType::Datatype)?;
         let (dt, _) = Datatype::parse(&msg.data)?;
         Ok(dt)
@@ -655,7 +658,11 @@ impl<'f> Dataset<'f> {
             .and_then(|msg| FilterPipeline::parse(&msg.data).ok())
     }
 
-    fn read_raw(&self) -> Result<Vec<u8>, Error> {
+    /// Read the dataset's exact unfiltered element bytes.
+    ///
+    /// For compound datasets this preserves all file padding and uses the
+    /// offsets reported by [`datatype`](Self::datatype).
+    pub fn read_raw(&self) -> Result<Vec<u8>, Error> {
         let dt = self.datatype()?;
         let ds = self.dataspace()?;
         let mut dl = self.data_layout()?;
@@ -672,6 +679,34 @@ impl<'f> Dataset<'f> {
         Ok(self
             .file
             .read_dataset_raw(&dl, &ds, &dt, pipeline.as_ref(), &self.chunk_cache)?)
+    }
+
+    /// Decode all elements of a compound dataset field by field.
+    ///
+    /// Built-in implementations support numeric tuples with one through twelve
+    /// fields. Decoding uses the file's field offsets rather than Rust's tuple
+    /// memory layout, so padded compound records are supported safely.
+    pub fn read_compound<T: CompoundType>(&self) -> Result<Vec<T>, Error> {
+        let datatype = self.datatype()?;
+        let element_size = datatype.type_size() as usize;
+        if !matches!(datatype, Datatype::Compound { .. }) {
+            return Err(FormatError::TypeMismatch {
+                expected: "Compound",
+                actual: "non-Compound",
+            }
+            .into());
+        }
+        let raw = self.read_raw()?;
+        if element_size == 0 || !raw.len().is_multiple_of(element_size) {
+            return Err(FormatError::DataSizeMismatch {
+                expected: element_size,
+                actual: raw.len(),
+            }
+            .into());
+        }
+        raw.chunks_exact(element_size)
+            .map(|bytes| T::decode(&datatype, bytes).map_err(Error::from))
+            .collect()
     }
 
     /// Verify this dataset against its stored provenance hash.

--- a/src/type_builders.rs
+++ b/src/type_builders.rs
@@ -7,6 +7,7 @@ use alloc::{boxed::Box, string::String, string::ToString, vec, vec::Vec};
 
 use crate::attribute::AttributeMessage;
 use crate::chunked_write::ChunkOptions;
+use crate::compound::CompoundType;
 use crate::dataspace::{Dataspace, DataspaceType};
 use crate::datatype::{
     CharacterSet, CompoundMember, Datatype, DatatypeByteOrder, EnumMember, StringPadding,
@@ -212,6 +213,135 @@ impl CompoundTypeBuilder {
 impl Default for CompoundTypeBuilder {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Builder for an HDF5 compound datatype with explicit field offsets and size.
+///
+/// This is the pure-Rust equivalent of creating an `H5T_COMPOUND` type and
+/// inserting fields with `H5Tinsert`. [`build`](Self::build) validates field
+/// names, bounds, and overlap before returning a datatype.
+pub struct ExplicitCompoundTypeBuilder {
+    size: u32,
+    fields: Vec<CompoundMember>,
+}
+
+impl ExplicitCompoundTypeBuilder {
+    /// Add a field at an explicit byte offset.
+    pub fn field(mut self, name: &str, byte_offset: u64, datatype: Datatype) -> Self {
+        self.fields.push(CompoundMember {
+            name: name.to_string(),
+            byte_offset,
+            datatype,
+        });
+        self
+    }
+
+    /// Add an f64 field at an explicit byte offset.
+    pub fn f64_field(self, name: &str, byte_offset: u64) -> Self {
+        self.field(name, byte_offset, make_f64_type())
+    }
+
+    /// Add an f32 field at an explicit byte offset.
+    pub fn f32_field(self, name: &str, byte_offset: u64) -> Self {
+        self.field(name, byte_offset, make_f32_type())
+    }
+
+    /// Add an i32 field at an explicit byte offset.
+    pub fn i32_field(self, name: &str, byte_offset: u64) -> Self {
+        self.field(name, byte_offset, make_i32_type())
+    }
+
+    /// Add an i64 field at an explicit byte offset.
+    pub fn i64_field(self, name: &str, byte_offset: u64) -> Self {
+        self.field(name, byte_offset, make_i64_type())
+    }
+
+    /// Add a u8 field at an explicit byte offset.
+    pub fn u8_field(self, name: &str, byte_offset: u64) -> Self {
+        self.field(name, byte_offset, make_u8_type())
+    }
+
+    /// Add an i8 field at an explicit byte offset.
+    pub fn i8_field(self, name: &str, byte_offset: u64) -> Self {
+        self.field(name, byte_offset, make_i8_type())
+    }
+
+    /// Add an i16 field at an explicit byte offset.
+    pub fn i16_field(self, name: &str, byte_offset: u64) -> Self {
+        self.field(name, byte_offset, make_i16_type())
+    }
+
+    /// Add a u16 field at an explicit byte offset.
+    pub fn u16_field(self, name: &str, byte_offset: u64) -> Self {
+        self.field(name, byte_offset, make_u16_type())
+    }
+
+    /// Add a u32 field at an explicit byte offset.
+    pub fn u32_field(self, name: &str, byte_offset: u64) -> Self {
+        self.field(name, byte_offset, make_u32_type())
+    }
+
+    /// Add a u64 field at an explicit byte offset.
+    pub fn u64_field(self, name: &str, byte_offset: u64) -> Self {
+        self.field(name, byte_offset, make_u64_type())
+    }
+
+    /// Validate and build the compound datatype.
+    pub fn build(mut self) -> Result<Datatype, crate::error::FormatError> {
+        use crate::error::FormatError;
+
+        if self.size == 0 {
+            return Err(FormatError::InvalidCompoundSize);
+        }
+        if self.fields.is_empty() {
+            return Err(FormatError::EmptyCompoundType);
+        }
+
+        for (index, field) in self.fields.iter().enumerate() {
+            if self.fields[..index]
+                .iter()
+                .any(|earlier| earlier.name == field.name)
+            {
+                return Err(FormatError::DuplicateCompoundField(field.name.clone()));
+            }
+            let field_size = field.datatype.type_size();
+            let end = field.byte_offset.checked_add(u64::from(field_size));
+            if field_size == 0 || end.is_none_or(|end| end > u64::from(self.size)) {
+                return Err(FormatError::CompoundFieldOutOfBounds {
+                    name: field.name.clone(),
+                    offset: field.byte_offset,
+                    field_size,
+                    compound_size: self.size,
+                });
+            }
+        }
+
+        self.fields.sort_by_key(|field| field.byte_offset);
+        for fields in self.fields.windows(2) {
+            let first_end = fields[0].byte_offset + u64::from(fields[0].datatype.type_size());
+            if first_end > fields[1].byte_offset {
+                return Err(FormatError::CompoundFieldOverlap {
+                    first: fields[0].name.clone(),
+                    second: fields[1].name.clone(),
+                });
+            }
+        }
+
+        Ok(Datatype::Compound {
+            size: self.size,
+            members: self.fields,
+        })
+    }
+}
+
+impl CompoundTypeBuilder {
+    /// Create a compound builder with an explicit total size and field offsets.
+    pub fn with_size(size: u32) -> ExplicitCompoundTypeBuilder {
+        ExplicitCompoundTypeBuilder {
+            size,
+            fields: Vec::new(),
+        }
     }
 }
 
@@ -774,6 +904,40 @@ impl DatasetBuilder {
             self.shape = Some(vec![num_elements]);
         }
         self
+    }
+
+    /// Safely encode a slice of compound values field by field.
+    ///
+    /// Built-in implementations support numeric tuples with one through twelve
+    /// fields. No Rust struct or tuple padding is copied into the file.
+    pub fn with_compound_values<T: CompoundType>(
+        &mut self,
+        values: &[T],
+    ) -> Result<&mut Self, crate::error::FormatError> {
+        let datatype = T::datatype();
+        if !matches!(datatype, Datatype::Compound { .. }) {
+            return Err(crate::error::FormatError::TypeMismatch {
+                expected: "Compound",
+                actual: "non-Compound",
+            });
+        }
+        let element_size = datatype.type_size() as usize;
+        if element_size == 0 {
+            return Err(crate::error::FormatError::InvalidCompoundSize);
+        }
+        let mut raw = Vec::with_capacity(values.len().saturating_mul(element_size));
+        for value in values {
+            let start = raw.len();
+            value.encode(&mut raw);
+            let actual = raw.len() - start;
+            if actual != element_size {
+                return Err(crate::error::FormatError::DataSizeMismatch {
+                    expected: element_size,
+                    actual,
+                });
+            }
+        }
+        Ok(self.with_compound_data(datatype, raw, values.len() as u64))
     }
 
     /// Write an enum dataset with i32 values.

--- a/src/type_builders.rs
+++ b/src/type_builders.rs
@@ -8,6 +8,7 @@ use alloc::{boxed::Box, string::String, string::ToString, vec, vec::Vec};
 use crate::attribute::AttributeMessage;
 use crate::chunked_write::ChunkOptions;
 use crate::compound::CompoundType;
+use crate::convert::TryToUsize;
 use crate::dataspace::{Dataspace, DataspaceType};
 use crate::datatype::{
     CharacterSet, CompoundMember, Datatype, DatatypeByteOrder, EnumMember, StringPadding,
@@ -914,14 +915,14 @@ impl DatasetBuilder {
         &mut self,
         values: &[T],
     ) -> Result<&mut Self, crate::error::FormatError> {
-        let datatype = T::datatype();
+        let datatype = T::datatype()?;
         if !matches!(datatype, Datatype::Compound { .. }) {
             return Err(crate::error::FormatError::TypeMismatch {
                 expected: "Compound",
                 actual: "non-Compound",
             });
         }
-        let element_size = datatype.type_size() as usize;
+        let element_size = datatype.type_size().to_usize()?;
         if element_size == 0 {
             return Err(crate::error::FormatError::InvalidCompoundSize);
         }

--- a/tests/hdf5_crosscheck.rs
+++ b/tests/hdf5_crosscheck.rs
@@ -7,7 +7,7 @@
 //! These tests verify that files produced by hdf5-pure are valid HDF5 files
 //! readable by the reference C implementation.
 
-use hdf5_pure::{AttrValue, CompoundTypeBuilder, FileBuilder, make_f64_type};
+use hdf5_pure::{AttrValue, CompoundTypeBuilder, Datatype, File, FileBuilder, make_f64_type};
 use tempfile::tempdir;
 
 /// Read a MATLAB-style variable-length ASCII attribute from an `hdf5::Attribute`.
@@ -719,6 +719,125 @@ fn crosscheck_compound_f64_pairs() {
     let file = hdf5::File::open(&path).unwrap();
     let ds = file.dataset("complex").unwrap();
     assert_eq!(ds.shape(), vec![3]);
+}
+
+#[repr(C)]
+#[derive(hdf5::H5Type, Clone, Copy, Debug, PartialEq)]
+struct PaddedTuple(
+    #[hdf5(rename = "0")] i8,
+    #[hdf5(rename = "1")] u64,
+    #[hdf5(rename = "2")] f32,
+);
+
+#[test]
+fn c_library_reads_explicit_offset_compound() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("padded_compound.h5");
+
+    let datatype = CompoundTypeBuilder::with_size(24)
+        .i8_field("0", 0)
+        .u64_field("1", 8)
+        .f32_field("2", 16)
+        .build()
+        .unwrap();
+    let expected = [PaddedTuple(-4, 17, 2.5), PaddedTuple(8, u64::MAX, -1.25)];
+    let mut raw = vec![0u8; expected.len() * 24];
+    for (index, value) in expected.iter().enumerate() {
+        let record = &mut raw[index * 24..(index + 1) * 24];
+        record[0] = value.0 as u8;
+        record[8..16].copy_from_slice(&value.1.to_le_bytes());
+        record[16..20].copy_from_slice(&value.2.to_le_bytes());
+    }
+
+    let mut builder = FileBuilder::new();
+    builder
+        .create_dataset("padded")
+        .with_compound_data(datatype, raw, expected.len() as u64);
+    builder.write(&path).unwrap();
+
+    let file = hdf5::File::open(&path).unwrap();
+    let actual: Vec<PaddedTuple> = file.dataset("padded").unwrap().read_raw().unwrap();
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn pure_reader_decodes_c_written_padded_compound() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("c_padded_compound.h5");
+    let expected = [PaddedTuple(-9, 23, 4.5), PaddedTuple(3, 77, -6.25)];
+
+    let file = hdf5::File::create(&path).unwrap();
+    file.new_dataset_builder()
+        .with_data(&expected)
+        .create("padded")
+        .unwrap();
+    drop(file);
+
+    let file = File::open(&path).unwrap();
+    let ds = file.dataset("padded").unwrap();
+    assert_eq!(
+        ds.read_compound::<(i8, u64, f32)>().unwrap(),
+        expected.map(|value| (value.0, value.1, value.2))
+    );
+    match ds.datatype().unwrap() {
+        Datatype::Compound { size, members } => {
+            assert_eq!(size as usize, core::mem::size_of::<PaddedTuple>());
+            assert_eq!(
+                members
+                    .iter()
+                    .map(|member| (member.name.as_str(), member.byte_offset))
+                    .collect::<Vec<_>>(),
+                vec![("0", 0), ("1", 8), ("2", 16)]
+            );
+        }
+        other => panic!("expected compound, got {other:?}"),
+    }
+}
+
+#[repr(C)]
+#[derive(hdf5::H5Type, Clone, Copy, Debug, PartialEq)]
+struct NestedInner(#[hdf5(rename = "0")] i8, #[hdf5(rename = "1")] u64);
+
+#[repr(C)]
+#[derive(hdf5::H5Type, Clone, Copy, Debug, PartialEq)]
+struct NestedOuter(#[hdf5(rename = "0")] NestedInner, #[hdf5(rename = "1")] f32);
+
+#[test]
+fn c_library_reads_nested_explicit_compound() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("nested_compound.h5");
+
+    let inner = CompoundTypeBuilder::with_size(16)
+        .i8_field("0", 0)
+        .u64_field("1", 8)
+        .build()
+        .unwrap();
+    let outer = CompoundTypeBuilder::with_size(24)
+        .field("0", 0, inner)
+        .f32_field("1", 16)
+        .build()
+        .unwrap();
+    let expected = [
+        NestedOuter(NestedInner(-1, 100), 2.0),
+        NestedOuter(NestedInner(6, 200), -3.0),
+    ];
+    let mut raw = vec![0u8; expected.len() * 24];
+    for (index, value) in expected.iter().enumerate() {
+        let record = &mut raw[index * 24..(index + 1) * 24];
+        record[0] = value.0.0 as u8;
+        record[8..16].copy_from_slice(&value.0.1.to_le_bytes());
+        record[16..20].copy_from_slice(&value.1.to_le_bytes());
+    }
+
+    let mut builder = FileBuilder::new();
+    builder
+        .create_dataset("nested")
+        .with_compound_data(outer, raw, expected.len() as u64);
+    builder.write(&path).unwrap();
+
+    let file = hdf5::File::open(&path).unwrap();
+    let actual: Vec<NestedOuter> = file.dataset("nested").unwrap().read_raw().unwrap();
+    assert_eq!(actual, expected);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/write_read_roundtrip.rs
+++ b/tests/write_read_roundtrip.rs
@@ -372,7 +372,10 @@ fn nested_compound_type_mismatch_shows_hierarchical_path() {
         hdf5_pure::Error::Format(FormatError::CompoundFieldTypeMismatch(ref path)) => {
             assert_eq!(path, "0.1");
         }
-        other => panic!("expected CompoundFieldTypeMismatch(\"0.1\"), got {:?}", other),
+        other => panic!(
+            "expected CompoundFieldTypeMismatch(\"0.1\"), got {:?}",
+            other
+        ),
     }
 }
 

--- a/tests/write_read_roundtrip.rs
+++ b/tests/write_read_roundtrip.rs
@@ -344,6 +344,39 @@ fn explicit_compound_builder_rejects_invalid_layouts() {
 }
 
 #[test]
+fn nested_compound_type_mismatch_shows_hierarchical_path() {
+    let inner_mismatched = CompoundTypeBuilder::with_size(16)
+        .i8_field("0", 0)
+        .f64_field("1", 8) // mismatch: expected u64, got f64
+        .build()
+        .unwrap();
+
+    let outer = CompoundTypeBuilder::with_size(24)
+        .field("0", 0, inner_mismatched)
+        .f32_field("1", 16)
+        .build()
+        .unwrap();
+
+    let raw = vec![0u8; 24];
+    let mut builder = FileBuilder::new();
+    builder
+        .create_dataset("nested_mismatched")
+        .with_compound_data(outer, raw, 1);
+    let bytes = builder.finish().unwrap();
+
+    let file = File::from_bytes(bytes).unwrap();
+    let ds = file.dataset("nested_mismatched").unwrap();
+
+    let err = ds.read_compound::<((i8, u64), f32)>().unwrap_err();
+    match err {
+        hdf5_pure::Error::Format(FormatError::CompoundFieldTypeMismatch(ref path)) => {
+            assert_eq!(path, "0.1");
+        }
+        other => panic!("expected CompoundFieldTypeMismatch(\"0.1\"), got {:?}", other),
+    }
+}
+
+#[test]
 fn roundtrip_userblock_512() {
     let mut builder = FileBuilder::new();
     builder.with_userblock(512);

--- a/tests/write_read_roundtrip.rs
+++ b/tests/write_read_roundtrip.rs
@@ -1,4 +1,6 @@
-use hdf5_pure::{AttrValue, CompoundTypeBuilder, DType, File, FileBuilder, make_f64_type};
+use hdf5_pure::{
+    AttrValue, CompoundTypeBuilder, DType, Datatype, File, FileBuilder, FormatError, make_f64_type,
+};
 
 #[test]
 fn roundtrip_f64_dataset() {
@@ -229,6 +231,116 @@ fn roundtrip_compound_complex64() {
         }
         other => panic!("expected compound, got {other}"),
     }
+}
+
+#[test]
+fn roundtrip_compound_tuple_field_wise() {
+    let values = [(-5i8, 10u64, 1.25f32), (7i8, u64::MAX, -3.5f32)];
+
+    let mut builder = FileBuilder::new();
+    builder
+        .create_dataset("tuples")
+        .with_compound_values(&values)
+        .unwrap();
+    let bytes = builder.finish().unwrap();
+
+    let file = File::from_bytes(bytes).unwrap();
+    let ds = file.dataset("tuples").unwrap();
+    assert_eq!(ds.read_compound::<(i8, u64, f32)>().unwrap(), values);
+    assert_eq!(ds.read_raw().unwrap().len(), values.len() * 13);
+
+    match ds.datatype().unwrap() {
+        Datatype::Compound { size, members } => {
+            assert_eq!(size, 13);
+            assert_eq!(
+                members
+                    .iter()
+                    .map(|member| (member.name.as_str(), member.byte_offset))
+                    .collect::<Vec<_>>(),
+                vec![("0", 0), ("1", 1), ("2", 9)]
+            );
+        }
+        other => panic!("expected compound, got {other:?}"),
+    }
+}
+
+#[test]
+fn padded_compound_decodes_without_using_tuple_layout() {
+    let datatype = CompoundTypeBuilder::with_size(24)
+        .i8_field("0", 0)
+        .u64_field("1", 8)
+        .f32_field("2", 16)
+        .build()
+        .unwrap();
+
+    let values = [(-3i8, 42u64, 1.5f32), (9, u64::MAX, -2.25)];
+    let mut raw = vec![0u8; values.len() * 24];
+    for (index, (a, b, c)) in values.iter().copied().enumerate() {
+        let record = &mut raw[index * 24..(index + 1) * 24];
+        record[0] = a as u8;
+        record[8..16].copy_from_slice(&b.to_le_bytes());
+        record[16..20].copy_from_slice(&c.to_le_bytes());
+    }
+
+    let mut builder = FileBuilder::new();
+    builder
+        .create_dataset("padded")
+        .with_compound_data(datatype, raw.clone(), values.len() as u64);
+    let bytes = builder.finish().unwrap();
+
+    let file = File::from_bytes(bytes).unwrap();
+    let ds = file.dataset("padded").unwrap();
+    assert_eq!(ds.read_raw().unwrap(), raw);
+    assert_eq!(ds.read_compound::<(i8, u64, f32)>().unwrap(), values);
+}
+
+#[test]
+fn nested_compound_tuple_roundtrip() {
+    let values = [((-2i8, 99u64), 3.25f32), ((7, 11), -0.5)];
+
+    let mut builder = FileBuilder::new();
+    builder
+        .create_dataset("nested")
+        .with_compound_values(&values)
+        .unwrap();
+    let bytes = builder.finish().unwrap();
+
+    let file = File::from_bytes(bytes).unwrap();
+    let ds = file.dataset("nested").unwrap();
+    assert_eq!(ds.read_compound::<((i8, u64), f32)>().unwrap(), values);
+}
+
+#[test]
+fn explicit_compound_builder_rejects_invalid_layouts() {
+    let err = CompoundTypeBuilder::with_size(8)
+        .u64_field("a", 0)
+        .u32_field("b", 6)
+        .build()
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        FormatError::CompoundFieldOutOfBounds { ref name, .. } if name == "b"
+    ));
+
+    let err = CompoundTypeBuilder::with_size(16)
+        .u64_field("a", 0)
+        .u64_field("b", 4)
+        .build()
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        FormatError::CompoundFieldOverlap {
+            ref first,
+            ref second
+        } if first == "a" && second == "b"
+    ));
+
+    let err = CompoundTypeBuilder::with_size(16)
+        .u64_field("a", 0)
+        .u64_field("a", 8)
+        .build()
+        .unwrap_err();
+    assert_eq!(err, FormatError::DuplicateCompoundField("a".into()));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add an `H5Tinsert`-style compound builder with explicit total size and validated field offsets
- expose exact dataset datatypes and raw logical bytes for padded/custom compound records
- add safe field-wise compound encoding and decoding for numeric tuples of one through twelve fields, including nested tuples
- preserve compatibility with padded records without inspecting or transmuting Rust tuple memory layouts

## Safety

Tuple fields are serialized individually into a canonical packed file layout. Reads use the field names and byte offsets stored in the HDF5 datatype, so the implementation does not depend on Rust tuple layout and does not construct references from synthetic pointers.

## Validation

- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check --no-default-features`
- reference HDF5 C-library crosschecks for padded, nested, and C-written compound records

Closes #49