### PR TITLE
Add bounded reads for variable-length strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,30 @@ assert_eq!(records, values);
 
 Use `CompoundTypeBuilder::with_size` for an `H5Tinsert`-style layout with explicit offsets and padding. `Dataset::datatype` exposes the exact field offsets from existing files, while `Dataset::read_raw` returns their complete unfiltered record bytes.
 
+### Variable-length string reads
+
+`Dataset::read_string` reads both fixed-length and variable-length HDF5 string datasets. VL reads can be bounded before payload allocation, or consumed one string at a time:
+
+```rust
+use hdf5_pure::{File, VlenStringReadOptions};
+
+let file = File::open_streaming("strings.h5").unwrap();
+let dataset = file.dataset("names").unwrap();
+
+let payload_bytes = dataset.vlen_string_payload_size().unwrap();
+let options = VlenStringReadOptions::new()
+    .with_max_elements(100_000)
+    .with_max_payload_bytes(64 * 1024 * 1024);
+
+dataset.visit_vlen_strings(options, |value| {
+    println!("{value}");
+}).unwrap();
+
+println!("{payload_bytes} bytes of string payload");
+```
+
+The payload limit covers bytes referenced by VL elements and excludes Rust container metadata. Shared global heap collections are indexed once per read, and only the referenced object payloads are fetched. This works with both `File::open` and `File::open_streaming`.
+
 ### Attributes
 
 | Variant | HDF5 encoding |

--- a/src/error.rs
+++ b/src/error.rs
@@ -154,6 +154,20 @@ pub enum FormatError {
     },
     /// Variable-length data error.
     VlDataError(String),
+    /// A variable-length read exceeded its configured element limit.
+    VariableLengthElementLimitExceeded {
+        /// Maximum number of elements permitted by the caller.
+        limit: usize,
+        /// Number of elements present in the selected data.
+        actual: u64,
+    },
+    /// A variable-length read exceeded its configured payload-byte limit.
+    VariableLengthByteLimitExceeded {
+        /// Maximum number of payload bytes permitted by the caller.
+        limit: usize,
+        /// Number of payload bytes required by the selected data.
+        required: u64,
+    },
     /// Serialization error.
     SerializationError(String),
     /// Dataset is missing data.
@@ -425,6 +439,19 @@ impl fmt::Display for FormatError {
             }
             FormatError::VlDataError(msg) => {
                 write!(f, "variable-length data error: {msg}")
+            }
+            FormatError::VariableLengthElementLimitExceeded { limit, actual } => {
+                write!(
+                    f,
+                    "variable-length element limit exceeded: limit is {limit}, data contains {actual}"
+                )
+            }
+            FormatError::VariableLengthByteLimitExceeded { limit, required } => {
+                write!(
+                    f,
+                    "variable-length payload limit exceeded: limit is {limit} bytes, \
+                     data requires {required} bytes"
+                )
             }
             FormatError::SerializationError(msg) => {
                 write!(f, "serialization error: {msg}")

--- a/src/global_heap.rs
+++ b/src/global_heap.rs
@@ -5,32 +5,31 @@ use alloc::vec::Vec;
 
 use crate::convert::TryToUsize;
 use crate::error::FormatError;
+use crate::source::FileSource;
 
 /// Magic signature for global heap collections.
 const GCOL_SIGNATURE: [u8; 4] = [b'G', b'C', b'O', b'L'];
 
-/// A parsed global heap collection.
+/// Metadata index for a global heap collection.
+///
+/// This stores object locations rather than copying every object payload. VL
+/// readers can parse a shared collection once and fetch only the referenced
+/// object bytes.
 #[derive(Debug, Clone)]
-pub struct GlobalHeapCollection {
-    /// Total size of this collection including header. Parsed from the GCOL
-    /// header for completeness; the reader uses object offsets directly.
-    #[allow(dead_code)]
-    pub collection_size: u64,
-    /// Objects within this collection.
-    pub objects: Vec<GlobalHeapObject>,
+pub struct GlobalHeapIndex {
+    /// Object locations within this collection.
+    pub objects: Vec<GlobalHeapObjectInfo>,
 }
 
-/// A single object within a global heap collection.
+/// Location and size of one object in a global heap collection.
 #[derive(Debug, Clone)]
-pub struct GlobalHeapObject {
+pub struct GlobalHeapObjectInfo {
     /// Object index (1-based; 0 is the free space marker).
     pub index: u16,
-    /// Reference count. Parsed from the heap object for completeness; not used
-    /// by the reader.
-    #[allow(dead_code)]
-    pub reference_count: u16,
-    /// Object data.
-    pub data: Vec<u8>,
+    /// Absolute address of the object payload.
+    pub data_address: u64,
+    /// Object payload size in bytes.
+    pub size: u64,
 }
 
 fn ensure_len(data: &[u8], offset: usize, needed: usize) -> Result<(), FormatError> {
@@ -58,88 +57,136 @@ fn read_length(data: &[u8], offset: usize, length_size: u8) -> Result<u64, Forma
 }
 
 /// Round up to next multiple of 8.
+#[cfg(test)]
 fn pad8(x: usize) -> usize {
     (x + 7) & !7
 }
 
-impl GlobalHeapCollection {
-    /// Parse a global heap collection at the given offset in the file data.
-    pub fn parse(
-        file_data: &[u8],
-        offset: usize,
-        length_size: u8,
-    ) -> Result<GlobalHeapCollection, FormatError> {
-        // signature(4) + version(1) + reserved(3) + collection_size(length_size)
-        let header_size = 8 + length_size as usize;
-        ensure_len(file_data, offset, header_size)?;
+fn pad8_u64(x: u64) -> Result<u64, FormatError> {
+    x.checked_add(7)
+        .map(|value| value & !7)
+        .ok_or(FormatError::OffsetOverflow {
+            offset: x,
+            length: 7,
+        })
+}
 
-        if file_data[offset..offset + 4] != GCOL_SIGNATURE {
+impl GlobalHeapIndex {
+    /// Parse collection metadata from a random-access source without copying
+    /// object payloads.
+    pub fn parse<S: FileSource + ?Sized>(
+        source: &S,
+        offset: u64,
+        length_size: u8,
+    ) -> Result<Self, FormatError> {
+        let header_size = 8 + length_size as usize;
+        let header = source.read_exact_at(offset, header_size)?;
+
+        if header[..4] != GCOL_SIGNATURE {
             return Err(FormatError::InvalidGlobalHeapSignature);
         }
-
-        let version = file_data[offset + 4];
+        let version = header[4];
         if version != 1 {
             return Err(FormatError::InvalidGlobalHeapVersion(version));
         }
 
-        let collection_size = read_length(file_data, offset + 8, length_size)?;
+        let collection_size = read_length(&header, 8, length_size)?;
+        if collection_size < header_size as u64 {
+            return Err(FormatError::VlDataError(
+                "global heap collection is smaller than its header".into(),
+            ));
+        }
         let collection_end =
             offset
-                .checked_add(collection_size.to_usize()?)
+                .checked_add(collection_size)
                 .ok_or(FormatError::OffsetOverflow {
-                    offset: offset as u64,
+                    offset,
                     length: collection_size,
                 })?;
+        if collection_end > source.len() {
+            return Err(FormatError::UnexpectedEof {
+                expected: collection_end.to_usize().unwrap_or(usize::MAX),
+                available: source.len().to_usize().unwrap_or(usize::MAX),
+            });
+        }
 
-        let mut pos = offset + header_size;
+        let object_header_size = 8 + length_size as usize;
+        let mut pos =
+            offset
+                .checked_add(header_size as u64)
+                .ok_or(FormatError::OffsetOverflow {
+                    offset,
+                    length: header_size as u64,
+                })?;
         let mut objects = Vec::new();
 
-        // Parse objects until we hit index 0 (free space) or run out of space
-        while pos + 2 <= collection_end {
-            ensure_len(file_data, pos, 2)?;
-            let object_index = u16::from_le_bytes([file_data[pos], file_data[pos + 1]]);
-
+        while pos
+            .checked_add(2)
+            .is_some_and(|index_end| index_end <= collection_end)
+        {
+            let index_bytes = source.read_exact_at(pos, 2)?;
+            let object_index = u16::from_le_bytes([index_bytes[0], index_bytes[1]]);
             if object_index == 0 {
-                // Free space marker — done
                 break;
             }
 
-            // object_index(2) + reference_count(2) + reserved(4) + object_size(length_size)
-            let obj_header_size = 8 + length_size as usize;
-            ensure_len(file_data, pos, obj_header_size)?;
+            let object_header_end =
+                pos.checked_add(object_header_size as u64)
+                    .ok_or(FormatError::OffsetOverflow {
+                        offset: pos,
+                        length: object_header_size as u64,
+                    })?;
+            if object_header_end > collection_end {
+                return Err(FormatError::UnexpectedEof {
+                    expected: object_header_end.to_usize().unwrap_or(usize::MAX),
+                    available: collection_end.to_usize().unwrap_or(usize::MAX),
+                });
+            }
+            let object_header = source.read_exact_at(pos, object_header_size)?;
+            let object_size = read_length(&object_header, 8, length_size)?;
+            let data_address = object_header_end;
+            let data_end =
+                data_address
+                    .checked_add(object_size)
+                    .ok_or(FormatError::OffsetOverflow {
+                        offset: data_address,
+                        length: object_size,
+                    })?;
+            if data_end > collection_end {
+                return Err(FormatError::UnexpectedEof {
+                    expected: data_end.to_usize().unwrap_or(usize::MAX),
+                    available: collection_end.to_usize().unwrap_or(usize::MAX),
+                });
+            }
 
-            let reference_count = u16::from_le_bytes([file_data[pos + 2], file_data[pos + 3]]);
-            let object_size = read_length(file_data, pos + 8, length_size)?.to_usize()?;
-
-            pos += obj_header_size;
-            ensure_len(file_data, pos, object_size)?;
-            let data = file_data[pos..pos + object_size].to_vec();
-
-            objects.push(GlobalHeapObject {
+            objects.push(GlobalHeapObjectInfo {
                 index: object_index,
-                reference_count,
-                data,
+                data_address,
+                size: object_size,
             });
 
-            // Advance past data + padding to 8-byte boundary
-            pos += pad8(object_size);
+            let padded_size = pad8_u64(object_size)?;
+            pos = data_address
+                .checked_add(padded_size)
+                .ok_or(FormatError::OffsetOverflow {
+                    offset: data_address,
+                    length: padded_size,
+                })?;
         }
 
-        Ok(GlobalHeapCollection {
-            collection_size,
-            objects,
-        })
+        Ok(Self { objects })
     }
 
-    /// Get an object by its index.
-    pub fn get_object(&self, index: u16) -> Option<&GlobalHeapObject> {
-        self.objects.iter().find(|o| o.index == index)
+    /// Get object metadata by its collection-local index.
+    pub fn get_object(&self, index: u16) -> Option<&GlobalHeapObjectInfo> {
+        self.objects.iter().find(|object| object.index == index)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::source::BytesSource;
 
     /// Build a global heap collection with given objects.
     fn build_collection(
@@ -198,21 +245,37 @@ mod tests {
     #[test]
     fn parse_collection_two_objects() {
         let data = build_collection(&[(1, 1, b"hello"), (2, 1, b"world!!!")], 8);
-        let coll = GlobalHeapCollection::parse(&data, 0, 8).unwrap();
+        let source = BytesSource::new(&data);
+        let coll = GlobalHeapIndex::parse(&source, 0, 8).unwrap();
         assert_eq!(coll.objects.len(), 2);
         assert_eq!(coll.objects[0].index, 1);
-        assert_eq!(coll.objects[0].data, b"hello");
+        assert_eq!(
+            source
+                .read_exact_at(coll.objects[0].data_address, coll.objects[0].size as usize)
+                .unwrap(),
+            b"hello"
+        );
         assert_eq!(coll.objects[1].index, 2);
-        assert_eq!(coll.objects[1].data, b"world!!!");
+        assert_eq!(
+            source
+                .read_exact_at(coll.objects[1].data_address, coll.objects[1].size as usize)
+                .unwrap(),
+            b"world!!!"
+        );
     }
 
     #[test]
     fn get_object_by_index() {
         let data = build_collection(&[(1, 1, b"aaa"), (3, 2, b"bbb")], 8);
-        let coll = GlobalHeapCollection::parse(&data, 0, 8).unwrap();
+        let source = BytesSource::new(&data);
+        let coll = GlobalHeapIndex::parse(&source, 0, 8).unwrap();
         let obj = coll.get_object(3).unwrap();
-        assert_eq!(obj.data, b"bbb");
-        assert_eq!(obj.reference_count, 2);
+        assert_eq!(
+            source
+                .read_exact_at(obj.data_address, obj.size as usize)
+                .unwrap(),
+            b"bbb"
+        );
         assert!(coll.get_object(99).is_none());
     }
 
@@ -227,7 +290,7 @@ mod tests {
         data.extend_from_slice(&size.to_le_bytes());
         data.extend_from_slice(&0u16.to_le_bytes()); // free space
 
-        let coll = GlobalHeapCollection::parse(&data, 0, 8).unwrap();
+        let coll = GlobalHeapIndex::parse(&BytesSource::new(&data), 0, 8).unwrap();
         assert_eq!(coll.objects.len(), 0);
     }
 
@@ -235,7 +298,7 @@ mod tests {
     fn invalid_signature_error() {
         let mut data = build_collection(&[(1, 1, b"x")], 8);
         data[0] = b'X'; // corrupt
-        let err = GlobalHeapCollection::parse(&data, 0, 8).unwrap_err();
+        let err = GlobalHeapIndex::parse(&BytesSource::new(&data), 0, 8).unwrap_err();
         assert_eq!(err, FormatError::InvalidGlobalHeapSignature);
     }
 
@@ -243,15 +306,32 @@ mod tests {
     fn invalid_version_error() {
         let mut data = build_collection(&[(1, 1, b"x")], 8);
         data[4] = 2; // wrong version
-        let err = GlobalHeapCollection::parse(&data, 0, 8).unwrap_err();
+        let err = GlobalHeapIndex::parse(&BytesSource::new(&data), 0, 8).unwrap_err();
         assert_eq!(err, FormatError::InvalidGlobalHeapVersion(2));
+    }
+
+    #[test]
+    fn object_header_cannot_cross_collection_boundary() {
+        let mut data = build_collection(&[(1, 1, b"x")], 8);
+        let truncated_collection_size = 8u64 + 8 + 2;
+        data[8..16].copy_from_slice(&truncated_collection_size.to_le_bytes());
+
+        let err = GlobalHeapIndex::parse(&BytesSource::new(&data), 0, 8).unwrap_err();
+        assert!(matches!(err, FormatError::UnexpectedEof { .. }));
     }
 
     #[test]
     fn parse_with_4byte_length() {
         let data = build_collection(&[(1, 1, b"test")], 4);
-        let coll = GlobalHeapCollection::parse(&data, 0, 4).unwrap();
+        let source = BytesSource::new(&data);
+        let coll = GlobalHeapIndex::parse(&source, 0, 4).unwrap();
         assert_eq!(coll.objects.len(), 1);
-        assert_eq!(coll.objects[0].data, b"test");
+        let object = &coll.objects[0];
+        assert_eq!(
+            source
+                .read_exact_at(object.data_address, object.size as usize)
+                .unwrap(),
+            b"test"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,6 +187,9 @@ pub use error::FormatError;
 #[cfg(feature = "std")]
 pub use reader::{Dataset, File, Group, is_hdf5, is_hdf5_bytes};
 
+#[cfg(feature = "std")]
+pub use vl_data::VlenStringReadOptions;
+
 pub use libver::LibVer;
 
 #[cfg(all(feature = "std", feature = "provenance"))]

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -21,6 +21,7 @@ use crate::object_header::ObjectHeader;
 use crate::signature;
 use crate::source::{BytesSource, FileSource, ReadSeekSource};
 use crate::superblock::Superblock;
+use crate::vl_data::{self, VlenStringReadOptions};
 
 use crate::types::{AttrValue, DType, attrs_to_map, classify_datatype};
 
@@ -617,10 +618,93 @@ impl<'f> Dataset<'f> {
     }
 
     /// Read all data as `String` values.
+    ///
+    /// Fixed-length and variable-length HDF5 string datasets are both
+    /// supported. Use [`read_vlen_strings`](Self::read_vlen_strings) when
+    /// variable-length allocation limits are required.
     pub fn read_string(&self) -> Result<Vec<String>, Error> {
-        let raw = self.read_raw()?;
         let dt = self.datatype()?;
-        Ok(data_read::read_as_strings(&raw, &dt)?)
+        if vl_data::is_vlen_string_datatype(&dt) {
+            self.read_vlen_strings(VlenStringReadOptions::default())
+        } else {
+            let raw = self.read_raw()?;
+            Ok(data_read::read_as_strings(&raw, &dt)?)
+        }
+    }
+
+    /// Return the total bytes referenced by this VL string dataset.
+    ///
+    /// This is the payload equivalent of HDF5's `H5Dvlen_get_buf_size`: it
+    /// excludes `Vec<String>` and `String` allocation metadata.
+    pub fn vlen_string_payload_size(&self) -> Result<u64, Error> {
+        let datatype = self.datatype()?;
+        if !vl_data::is_vlen_string_datatype(&datatype) {
+            return Err(FormatError::TypeMismatch {
+                expected: "VariableLength string",
+                actual: "non-VariableLength string",
+            }
+            .into());
+        }
+        let dataspace = self.dataspace()?;
+        let raw = self.read_raw()?;
+        Ok(vl_data::vlen_string_payload_size(
+            &raw,
+            dataspace.num_elements(),
+            self.file.offset_size(),
+        )?)
+    }
+
+    /// Read a VL string dataset with explicit allocation limits.
+    ///
+    /// Both limits are checked before any string payload is materialized.
+    pub fn read_vlen_strings(&self, options: VlenStringReadOptions) -> Result<Vec<String>, Error> {
+        let mut strings = Vec::new();
+        self.visit_vlen_strings(options, |string| strings.push(string.to_owned()))?;
+        Ok(strings)
+    }
+
+    /// Visit a VL string dataset one element at a time.
+    ///
+    /// The string slice passed to `visitor` is valid only for the duration of
+    /// that callback. This avoids retaining all decoded string payloads at once.
+    pub fn visit_vlen_strings<F>(
+        &self,
+        options: VlenStringReadOptions,
+        visitor: F,
+    ) -> Result<(), Error>
+    where
+        F: FnMut(&str),
+    {
+        let datatype = self.datatype()?;
+        if !vl_data::is_vlen_string_datatype(&datatype) {
+            return Err(FormatError::TypeMismatch {
+                expected: "VariableLength string",
+                actual: "non-VariableLength string",
+            }
+            .into());
+        }
+        let dataspace = self.dataspace()?;
+        if let Some(limit) = options.max_elements()
+            && dataspace.num_elements() > limit as u64
+        {
+            return Err(FormatError::VariableLengthElementLimitExceeded {
+                limit,
+                actual: dataspace.num_elements(),
+            }
+            .into());
+        }
+        let raw = self.read_raw()?;
+        let source = self.file.source();
+        Ok(vl_data::visit_vl_strings_from_source(
+            &source,
+            &raw,
+            dataspace.num_elements(),
+            self.file.offset_size(),
+            self.file.length_size(),
+            self.file.addr_offset,
+            options,
+            visitor,
+        )?)
     }
 
     /// Read all attributes of this dataset.

--- a/src/vl_data.rs
+++ b/src/vl_data.rs
@@ -8,8 +8,53 @@
 use alloc::{format, string::String, vec::Vec};
 
 use crate::convert::TryToUsize;
+use crate::datatype::{CharacterSet, Datatype};
 use crate::error::FormatError;
-use crate::global_heap::GlobalHeapCollection;
+use crate::global_heap::GlobalHeapIndex;
+use crate::source::{BytesSource, FileSource};
+
+/// Allocation limits for reading variable-length strings.
+///
+/// Limits are checked before any string payload is materialized. The payload
+/// byte limit covers the bytes referenced by the VL elements; it excludes the
+/// `Vec<String>` and `String` allocation metadata.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct VlenStringReadOptions {
+    max_elements: Option<usize>,
+    max_payload_bytes: Option<usize>,
+}
+
+impl VlenStringReadOptions {
+    /// Create options with no limits.
+    pub const fn new() -> Self {
+        Self {
+            max_elements: None,
+            max_payload_bytes: None,
+        }
+    }
+
+    /// Set the maximum number of VL elements that may be read.
+    pub const fn with_max_elements(mut self, max_elements: usize) -> Self {
+        self.max_elements = Some(max_elements);
+        self
+    }
+
+    /// Set the maximum total string payload size in bytes.
+    pub const fn with_max_payload_bytes(mut self, max_payload_bytes: usize) -> Self {
+        self.max_payload_bytes = Some(max_payload_bytes);
+        self
+    }
+
+    /// Return the configured element limit.
+    pub const fn max_elements(&self) -> Option<usize> {
+        self.max_elements
+    }
+
+    /// Return the configured payload-byte limit.
+    pub const fn max_payload_bytes(&self) -> Option<usize> {
+        self.max_payload_bytes
+    }
+}
 
 /// A parsed variable-length element reference (global heap ID).
 #[derive(Debug, Clone)]
@@ -110,6 +155,178 @@ fn is_undefined_address(addr: u64, offset_size: u8) -> bool {
     }
 }
 
+/// Whether a datatype is one of the string-shaped VL encodings understood by
+/// this module.
+pub(crate) fn is_vlen_string_datatype(datatype: &Datatype) -> bool {
+    match datatype {
+        Datatype::VariableLength {
+            is_string: true, ..
+        } => true,
+        Datatype::VariableLength {
+            is_string: false,
+            base_type,
+            ..
+        } => matches!(
+            base_type.as_ref(),
+            Datatype::String {
+                size: 1,
+                charset: CharacterSet::Ascii,
+                ..
+            }
+        ),
+        _ => false,
+    }
+}
+
+fn check_element_limit(
+    num_elements: u64,
+    options: VlenStringReadOptions,
+) -> Result<(), FormatError> {
+    if let Some(limit) = options.max_elements
+        && num_elements > limit as u64
+    {
+        return Err(FormatError::VariableLengthElementLimitExceeded {
+            limit,
+            actual: num_elements,
+        });
+    }
+    Ok(())
+}
+
+fn payload_size(refs: &[VlElement], options: VlenStringReadOptions) -> Result<u64, FormatError> {
+    let mut required = 0u64;
+    for element in refs {
+        required =
+            required
+                .checked_add(u64::from(element.length))
+                .ok_or(FormatError::OffsetOverflow {
+                    offset: required,
+                    length: u64::from(element.length),
+                })?;
+    }
+    if let Some(limit) = options.max_payload_bytes
+        && required > limit as u64
+    {
+        return Err(FormatError::VariableLengthByteLimitExceeded { limit, required });
+    }
+    Ok(required)
+}
+
+/// Return the total payload bytes named by a set of VL references.
+pub fn vlen_string_payload_size(
+    raw_data: &[u8],
+    num_elements: u64,
+    offset_size: u8,
+) -> Result<u64, FormatError> {
+    check_element_limit(num_elements, VlenStringReadOptions::default())?;
+    let refs = parse_vl_references(raw_data, num_elements, offset_size)?;
+    payload_size(&refs, VlenStringReadOptions::default())
+}
+
+/// Resolve VL strings from a random-access file source and pass them to a
+/// visitor one at a time.
+pub fn visit_vl_strings_from_source<S, F>(
+    source: &S,
+    raw_data: &[u8],
+    num_elements: u64,
+    offset_size: u8,
+    length_size: u8,
+    base_address: u64,
+    options: VlenStringReadOptions,
+    mut visitor: F,
+) -> Result<(), FormatError>
+where
+    S: FileSource + ?Sized,
+    F: FnMut(&str),
+{
+    check_element_limit(num_elements, options)?;
+    let refs = parse_vl_references(raw_data, num_elements, offset_size)?;
+    payload_size(&refs, options)?;
+
+    let mut collections: Vec<(u64, GlobalHeapIndex)> = Vec::new();
+    for element in &refs {
+        if element.length == 0
+            && (is_undefined_address(element.collection_address, offset_size)
+                || element.collection_address == 0)
+        {
+            visitor("");
+            continue;
+        }
+        if is_undefined_address(element.collection_address, offset_size) {
+            return Err(FormatError::VlDataError(
+                "non-empty VL element has an undefined heap address".into(),
+            ));
+        }
+
+        let collection_address = element.collection_address.checked_add(base_address).ok_or(
+            FormatError::OffsetOverflow {
+                offset: element.collection_address,
+                length: base_address,
+            },
+        )?;
+        let collection_pos = match collections
+            .iter()
+            .position(|(address, _)| *address == collection_address)
+        {
+            Some(pos) => pos,
+            None => {
+                let collection = GlobalHeapIndex::parse(source, collection_address, length_size)?;
+                collections.push((collection_address, collection));
+                collections.len() - 1
+            }
+        };
+
+        let index = u16::try_from(element.object_index).map_err(|_| {
+            FormatError::VlDataError(format!(
+                "global heap object index {} does not fit u16",
+                element.object_index
+            ))
+        })?;
+        let object = collections[collection_pos].1.get_object(index).ok_or(
+            FormatError::GlobalHeapObjectNotFound {
+                collection_address,
+                index,
+            },
+        )?;
+        if u64::from(element.length) > object.size {
+            return Err(FormatError::VlDataError(format!(
+                "VL element length {} exceeds global heap object size {}",
+                element.length, object.size
+            )));
+        }
+
+        let bytes = source.read_exact_at(object.data_address, element.length as usize)?;
+        let string = String::from_utf8_lossy(&bytes);
+        visitor(&string);
+    }
+
+    Ok(())
+}
+
+/// Resolve VL strings from a random-access file source.
+pub fn read_vl_strings_from_source<S: FileSource + ?Sized>(
+    source: &S,
+    raw_data: &[u8],
+    num_elements: u64,
+    offset_size: u8,
+    length_size: u8,
+    base_address: u64,
+    options: VlenStringReadOptions,
+) -> Result<Vec<String>, FormatError> {
+    let mut strings = Vec::new();
+    visit_vl_strings_from_source(
+        source,
+        raw_data,
+        num_elements,
+        offset_size,
+        length_size,
+        base_address,
+        options,
+        |string| strings.push(String::from(string)),
+    )?;
+    Ok(strings)
+}
+
 /// Resolve VL strings from raw data by looking up each element in the global heap.
 pub fn read_vl_strings(
     file_data: &[u8],
@@ -118,41 +335,15 @@ pub fn read_vl_strings(
     offset_size: u8,
     length_size: u8,
 ) -> Result<Vec<String>, FormatError> {
-    let refs = parse_vl_references(raw_data, num_elements, offset_size)?;
-    let mut result = Vec::with_capacity(refs.len());
-
-    for vl in &refs {
-        if vl.length == 0 && is_undefined_address(vl.collection_address, offset_size) {
-            result.push(String::new());
-            continue;
-        }
-        if vl.length == 0 && vl.collection_address == 0 {
-            result.push(String::new());
-            continue;
-        }
-
-        let coll =
-            GlobalHeapCollection::parse(file_data, vl.collection_address.to_usize()?, length_size)?;
-        let index = u16::try_from(vl.object_index).map_err(|_| {
-            FormatError::VlDataError(format!(
-                "global heap object index {} does not fit u16",
-                vl.object_index
-            ))
-        })?;
-        let obj = coll
-            .get_object(index)
-            .ok_or(FormatError::GlobalHeapObjectNotFound {
-                collection_address: vl.collection_address,
-                index,
-            })?;
-
-        // The object data is the raw string bytes
-        let len = (vl.length as usize).min(obj.data.len());
-        let s = String::from_utf8_lossy(&obj.data[..len]).into_owned();
-        result.push(s);
-    }
-
-    Ok(result)
+    read_vl_strings_from_source(
+        &BytesSource::new(file_data),
+        raw_data,
+        num_elements,
+        offset_size,
+        length_size,
+        0,
+        VlenStringReadOptions::default(),
+    )
 }
 
 #[cfg(test)]
@@ -245,6 +436,32 @@ mod tests {
 
         let raw = build_vl_refs(&["Alice", "Bob"], gcol_offset as u64, 1, 8);
         let strings = read_vl_strings(&file_data, &raw, 2, 8, 8).unwrap();
+        assert_eq!(strings, vec!["Alice", "Bob"]);
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn read_vl_strings_from_seekable_source() {
+        use std::io::Cursor;
+
+        use crate::source::ReadSeekSource;
+
+        let gcol_offset = 256usize;
+        let mut file_data = vec![0u8; 512];
+        build_gcol_at(&mut file_data, gcol_offset, &[(1, b"Alice"), (2, b"Bob")]);
+        let raw = build_vl_refs(&["Alice", "Bob"], gcol_offset as u64, 1, 8);
+        let source = ReadSeekSource::new(Cursor::new(file_data)).unwrap();
+
+        let strings = read_vl_strings_from_source(
+            &source,
+            &raw,
+            2,
+            8,
+            8,
+            0,
+            VlenStringReadOptions::default(),
+        )
+        .unwrap();
         assert_eq!(strings, vec!["Alice", "Bob"]);
     }
 

--- a/tests/vlen_strings.rs
+++ b/tests/vlen_strings.rs
@@ -1,0 +1,97 @@
+use hdf5_pure::{Error, File, FormatError, VlenStringReadOptions};
+
+const FIXTURE: &str = "tests/fixtures/vl_strings.h5";
+
+fn expected_names() -> Vec<String> {
+    ["Alice", "Bob", "Charlie"]
+        .into_iter()
+        .map(str::to_owned)
+        .collect()
+}
+
+#[test]
+fn buffered_vlen_dataset_read_and_size() {
+    let file = File::open(FIXTURE).unwrap();
+    let dataset = file.dataset("names").unwrap();
+
+    assert_eq!(dataset.vlen_string_payload_size().unwrap(), 15);
+    assert_eq!(dataset.read_string().unwrap(), expected_names());
+    assert_eq!(
+        dataset
+            .read_vlen_strings(
+                VlenStringReadOptions::new()
+                    .with_max_elements(3)
+                    .with_max_payload_bytes(15),
+            )
+            .unwrap(),
+        expected_names()
+    );
+}
+
+#[test]
+fn vlen_element_limit_is_checked_before_payload_read() {
+    let file = File::open(FIXTURE).unwrap();
+    let dataset = file.dataset("names").unwrap();
+    let error = dataset
+        .read_vlen_strings(VlenStringReadOptions::new().with_max_elements(2))
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        Error::Format(FormatError::VariableLengthElementLimitExceeded {
+            limit: 2,
+            actual: 3,
+        })
+    ));
+}
+
+#[test]
+fn vlen_payload_limit_reports_required_bytes() {
+    let file = File::open(FIXTURE).unwrap();
+    let dataset = file.dataset("names").unwrap();
+    let error = dataset
+        .read_vlen_strings(VlenStringReadOptions::new().with_max_payload_bytes(14))
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        Error::Format(FormatError::VariableLengthByteLimitExceeded {
+            limit: 14,
+            required: 15,
+        })
+    ));
+}
+
+#[test]
+fn vlen_visitor_delivers_strings_in_order() {
+    let file = File::open(FIXTURE).unwrap();
+    let dataset = file.dataset("names").unwrap();
+    let mut names = Vec::new();
+
+    dataset
+        .visit_vlen_strings(
+            VlenStringReadOptions::new().with_max_payload_bytes(15),
+            |name| names.push(name.to_owned()),
+        )
+        .unwrap();
+
+    assert_eq!(names, expected_names());
+}
+
+#[test]
+fn vlen_specific_apis_reject_non_vlen_datasets() {
+    let file = File::open(FIXTURE).unwrap();
+    let dataset = file.dataset("names").unwrap();
+    let datatype = dataset.datatype().unwrap();
+    assert!(matches!(
+        datatype,
+        hdf5_pure::Datatype::VariableLength { .. }
+    ));
+
+    let numeric = File::open("tests/fixtures/simple_dataset.h5").unwrap();
+    let numeric_dataset = numeric.dataset("data").unwrap();
+    assert!(matches!(
+        numeric_dataset.vlen_string_payload_size(),
+        Err(Error::Format(FormatError::TypeMismatch { .. }))
+    ));
+}


### PR DESCRIPTION
## Summary

- add element-count and payload-byte limits for variable-length string reads
- add payload sizing and visitor-based APIs for incremental consumption
- index global heap metadata once and fetch only referenced payloads for buffered and streaming files
- document the APIs and cover limits, ordering, type errors, and payload sizing

## Testing

- `cargo fmt --all -- --check`
- `cargo test --locked`
- `cargo check --locked --no-default-features`
- `cargo clippy --locked --features "serde ndarray" --all-targets -- -D warnings`

Closes #50