### PR TITLE
Read fractal-heap huge objects (long dense link/attribute names)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Reading a dense group or dense attribute set whose link/attribute names are very long (the message exceeds the heap's ~4 KiB managed-object limit) failed with `InvalidObjectHeaderVersion` or `UnexpectedEof`. Such messages are stored as fractal-heap "huge" objects, but the reader took the heap-ID type from the wrong bits (the format version in bits 6-7 instead of the type in bits 4-5), so every huge object was mis-decoded as managed and resolved to a garbage address. The reader now classifies heap IDs correctly and resolves huge objects through the heap's huge-objects v2 B-tree (and tiny objects inline), in both the buffered and streaming readers. Validated against the reference HDF5 C library for long-named links and attributes, including a group mixing managed and huge links.
+
 ## [0.14.0] - 2026-06-15
 
 Completes free-space management ([#21](https://github.com/stephenberry/hdf5-pure/issues/21)) and closes several reader/writer interoperability gaps with the reference HDF5 C library. Additive: the new public surface (the file-space-strategy and persisted-free-space APIs) makes this a minor bump; cargo-semver-checks confirms no breaking change.

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -381,8 +381,8 @@ fn extract_dense_attributes(
         }
         let id_bytes = &record.data[id_offset..id_offset + fh.heap_id_length as usize];
 
-        // Read attribute message from fractal heap
-        let attr_data = fh.read_managed_object(file_data, id_bytes, offset_size)?;
+        // Read the attribute message from the fractal heap (managed or huge object).
+        let attr_data = fh.read_object(file_data, id_bytes, offset_size, length_size)?;
 
         // The data in the heap is a complete attribute message
         let attr = AttributeMessage::parse(&attr_data, length_size)?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -141,6 +141,13 @@ pub enum FormatError {
     InvalidFractalHeapVersion(u8),
     /// Invalid heap ID type.
     InvalidHeapIdType(u8),
+    /// A fractal-heap "huge" object's heap ID referenced a B-tree key that is
+    /// not present in the heap's huge-objects v2 B-tree.
+    HugeObjectNotFound(u64),
+    /// A fractal-heap object uses an I/O filter pipeline (filtered huge or tiny
+    /// storage), which this reader does not support. Link and attribute heaps
+    /// are never filtered, so this does not arise for them.
+    UnsupportedFilteredHeapObject,
     /// Invalid attribute message version.
     InvalidAttributeVersion(u8),
     /// Invalid Attribute Info message version.
@@ -427,6 +434,12 @@ impl fmt::Display for FormatError {
             }
             FormatError::InvalidHeapIdType(t) => {
                 write!(f, "invalid heap ID type: {t}")
+            }
+            FormatError::HugeObjectNotFound(id) => {
+                write!(f, "fractal-heap huge object {id} not found in B-tree")
+            }
+            FormatError::UnsupportedFilteredHeapObject => {
+                write!(f, "filtered fractal-heap objects are not supported")
             }
             FormatError::InvalidAttributeVersion(v) => {
                 write!(f, "invalid attribute message version: {v}")

--- a/src/file_writer.rs
+++ b/src/file_writer.rs
@@ -1355,6 +1355,7 @@ mod tests {
             heap_id_length: 8,
             io_filter_encoded_length: 0,
             max_managed_object_size: 1024,
+            btree_huge_objects_address: u64::MAX,
             table_width: 4,
             starting_block_size: 4096,
             max_direct_block_size: 65536,

--- a/src/fractal_heap.rs
+++ b/src/fractal_heap.rs
@@ -6,9 +6,25 @@ use alloc::vec::Vec;
 #[cfg(feature = "checksum")]
 use byteorder::{ByteOrder, LittleEndian};
 
+use crate::btree_v2::{
+    BTreeV2Header, BTreeV2Record, collect_btree_v2_records, collect_btree_v2_records_from_source,
+};
 use crate::convert::TryToUsize;
 use crate::error::FormatError;
 use crate::source::FileSource;
+
+/// The kind of object a fractal-heap heap ID refers to, encoded in bits 4-5 of
+/// the heap ID's first byte (bits 6-7 are the format version, which must be 0).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HeapIdType {
+    /// Stored in the heap's managed direct/indirect blocks.
+    Managed,
+    /// Too large to manage; stored directly in the file and indexed by the
+    /// heap's huge-objects v2 B-tree (or, for wide heap IDs, inline).
+    Huge,
+    /// Small enough to be stored directly inside the heap ID.
+    Tiny,
+}
 
 /// A child entry of a fractal-heap indirect block: either a direct block (a leaf
 /// holding object bytes) or a nested indirect block. Returned by
@@ -38,8 +54,12 @@ pub struct FractalHeapHeader {
     pub heap_id_length: u16,
     /// I/O filter encoded length (0 = no filters).
     pub io_filter_encoded_length: u16,
-    /// Maximum size of a managed object.
+    /// Maximum size of a managed object. Objects larger than this are stored
+    /// as "huge" objects outside the managed direct/indirect blocks.
     pub max_managed_object_size: u32,
+    /// Address of the v2 B-tree that indexes "huge" objects (objects too large
+    /// to be managed). Undefined (all-ones) when the heap has no huge objects.
+    pub btree_huge_objects_address: u64,
     /// Width of the doubling table.
     pub table_width: u16,
     /// Starting block size in the doubling table.
@@ -113,6 +133,99 @@ fn log2_floor(v: u64) -> u32 {
     if v == 0 { 0 } else { 63 - v.leading_zeros() }
 }
 
+/// Read a little-endian integer from up to the first 8 bytes of `payload`. Used
+/// for the variable-width "huge object ID" packed into a heap ID.
+fn read_var_le(payload: &[u8]) -> u64 {
+    let mut value = 0u64;
+    for (i, &b) in payload.iter().take(8).enumerate() {
+        value |= (b as u64) << (i * 8);
+    }
+    value
+}
+
+/// Copy `len` bytes at `addr` out of an in-memory file image, bounds-checked.
+fn slice_object(file_data: &[u8], addr: u64, len: usize) -> Result<Vec<u8>, FormatError> {
+    let start = addr.to_usize()?;
+    let end = start.checked_add(len).ok_or(FormatError::OffsetOverflow {
+        offset: addr,
+        length: len as u64,
+    })?;
+    if end > file_data.len() {
+        return Err(FormatError::UnexpectedEof {
+            expected: end,
+            available: file_data.len(),
+        });
+    }
+    Ok(file_data[start..end].to_vec())
+}
+
+/// Read `len` bytes at `addr` from a streaming source.
+fn read_object_at_source<S: FileSource + ?Sized>(
+    source: &S,
+    addr: u64,
+    len: usize,
+) -> Result<Vec<u8>, FormatError> {
+    source.read_exact_at(addr, len)
+}
+
+/// Find the (address, length) of a huge object in the heap's huge-objects v2
+/// B-tree records. Each record (type 1, indirectly accessed, non-filtered) is
+/// `address(offset_size) + length(length_size) + id(length_size)`, sorted by id.
+fn find_huge_record(
+    records: &[BTreeV2Record],
+    huge_id: u64,
+    offset_size: u8,
+    length_size: u8,
+) -> Result<(u64, u64), FormatError> {
+    let os = offset_size as usize;
+    let ls = length_size as usize;
+    for record in records {
+        let data = &record.data;
+        if data.len() < os + 2 * ls {
+            continue;
+        }
+        let id = read_offset(data, os + ls, length_size)?;
+        if id == huge_id {
+            let addr = read_offset(data, 0, offset_size)?;
+            let len = read_offset(data, os, length_size)?;
+            return Ok((addr, len));
+        }
+    }
+    Err(FormatError::HugeObjectNotFound(huge_id))
+}
+
+/// Decode a "tiny" object whose bytes are stored directly inside the heap ID.
+/// HDF5 uses a short form (length in the low nibble of byte 0) and, when the ID
+/// is wide enough that the data would not otherwise fit, an extended form
+/// (12-bit length across bytes 0-1). Per `H5HFtiny.c` the short form is kept
+/// while `heap_id_length - 1 <= 16` (i.e. `heap_id_length <= 17`); the extended
+/// form begins at `heap_id_length == 18`. The format version (bits 6-7) must be 0.
+fn read_tiny_object(heap_id_length: u16, id_bytes: &[u8]) -> Result<Vec<u8>, FormatError> {
+    const TINY_LEN_SHORT: u16 = 16;
+    let extended = heap_id_length.saturating_sub(1) > TINY_LEN_SHORT;
+    let (len, data_start) = if extended {
+        if id_bytes.len() < 2 {
+            return Err(FormatError::UnexpectedEof {
+                expected: 2,
+                available: id_bytes.len(),
+            });
+        }
+        let len = ((((id_bytes[0] & 0x0F) as usize) << 8) | id_bytes[1] as usize) + 1;
+        (len, 2)
+    } else {
+        let len = (id_bytes[0] & 0x0F) as usize + 1;
+        (len, 1)
+    };
+    let end = data_start + len;
+    if end > id_bytes.len() {
+        return Err(FormatError::UnexpectedEof {
+            expected: end,
+            available: id_bytes.len(),
+        });
+    }
+    Ok(id_bytes[data_start..end].to_vec())
+}
+
 impl FractalHeapHeader {
     /// Parse a fractal heap header at the given offset.
     pub fn parse(
@@ -156,11 +269,21 @@ impl FractalHeapHeader {
         ]);
         pos += 4;
 
-        // Skip several fixed fields: next_huge_object_id(ls), btree_huge_objects_address(os),
-        // free_space_managed_blocks(ls), managed_block_free_space_manager_address(os),
-        // managed_space_in_heap(ls), allocated_managed_space_in_heap(ls),
+        // next_huge_object_id (length_size) — skip
+        ensure_len(file_data, pos, ls)?;
+        pos += ls;
+
+        // btree_huge_objects_address (offset_size) — root of the v2 B-tree that
+        // indexes "huge" objects (used when a stored object exceeds
+        // max_managed_object_size, e.g. links/attributes with very long names).
+        let btree_huge_objects_address = read_offset(file_data, pos, offset_size)?;
+        pos += os;
+
+        // Skip the remaining fixed fields: free_space_managed_blocks(ls),
+        // managed_block_free_space_manager_address(os), managed_space_in_heap(ls),
+        // allocated_managed_space_in_heap(ls),
         // direct_block_allocation_iterator_offset(ls)
-        let skip_size = 5 * ls + 2 * os;
+        let skip_size = 4 * ls + os;
         ensure_len(file_data, pos, skip_size)?;
         pos += skip_size;
 
@@ -238,6 +361,7 @@ impl FractalHeapHeader {
             heap_id_length,
             io_filter_encoded_length,
             max_managed_object_size,
+            btree_huge_objects_address,
             table_width,
             starting_block_size,
             max_direct_block_size,
@@ -252,7 +376,7 @@ impl FractalHeapHeader {
     /// Decode a managed heap ID into (offset_in_heap, object_length).
     ///
     /// The heap ID layout for managed objects (type 0):
-    /// - Byte 0: bits 6-7 = type (0), bits 4-5 = version (0), bits 0-3 = reserved
+    /// - Byte 0: bits 6-7 = version (0), bits 4-5 = type (0), bits 0-3 = reserved
     /// - Bytes 1+: offset (max_heap_size bits, LE) then length (remaining bits, LE)
     pub fn decode_managed_id(&self, id_bytes: &[u8]) -> Result<(u64, u64), FormatError> {
         if id_bytes.is_empty() {
@@ -262,7 +386,8 @@ impl FractalHeapHeader {
             });
         }
 
-        let id_type = (id_bytes[0] >> 6) & 0x03;
+        // Object type lives in bits 4-5 of byte 0 (bits 6-7 are the version).
+        let id_type = (id_bytes[0] >> 4) & 0x03;
         if id_type != 0 {
             return Err(FormatError::InvalidHeapIdType(id_type));
         }
@@ -342,6 +467,88 @@ impl FractalHeapHeader {
                 64, // max recursion depth
             )
         }
+    }
+
+    /// Classify a heap ID by its type bits (bits 4-5 of byte 0). Bits 6-7 carry
+    /// the format version, which must be 0.
+    fn heap_id_type(id_bytes: &[u8]) -> Result<HeapIdType, FormatError> {
+        let byte0 = *id_bytes.first().ok_or(FormatError::UnexpectedEof {
+            expected: 1,
+            available: 0,
+        })?;
+        match (byte0 >> 4) & 0x03 {
+            0 => Ok(HeapIdType::Managed),
+            1 => Ok(HeapIdType::Huge),
+            2 => Ok(HeapIdType::Tiny),
+            other => Err(FormatError::InvalidHeapIdType(other)),
+        }
+    }
+
+    /// Whether this heap stores "huge" object addresses and lengths inline in the
+    /// heap ID (`huge_ids_direct` in HDF5) rather than behind the huge-objects
+    /// v2 B-tree. The writer makes this choice from the heap ID length and the
+    /// address/length widths; a reader must recompute it the same way
+    /// (H5HFhuge.c, `H5HF__huge_init`).
+    fn huge_ids_direct(&self, offset_size: u8, length_size: u8) -> bool {
+        let avail = (self.heap_id_length as usize).saturating_sub(1);
+        if self.io_filter_encoded_length > 0 {
+            avail >= offset_size as usize + length_size as usize + 4 + length_size as usize
+        } else {
+            avail >= offset_size as usize + length_size as usize
+        }
+    }
+
+    /// Read an object from the heap given its raw heap ID bytes, dispatching on
+    /// the heap-ID type. Managed objects live in the doubling-table blocks; huge
+    /// objects are stored directly in the file (resolved here through the
+    /// huge-objects v2 B-tree); tiny objects are encoded in the ID itself.
+    pub fn read_object(
+        &self,
+        file_data: &[u8],
+        id_bytes: &[u8],
+        offset_size: u8,
+        length_size: u8,
+    ) -> Result<Vec<u8>, FormatError> {
+        match Self::heap_id_type(id_bytes)? {
+            HeapIdType::Managed => self.read_managed_object(file_data, id_bytes, offset_size),
+            HeapIdType::Huge => {
+                self.read_huge_object(file_data, id_bytes, offset_size, length_size)
+            }
+            HeapIdType::Tiny => read_tiny_object(self.heap_id_length, id_bytes),
+        }
+    }
+
+    /// Resolve and read a "huge" object given its heap ID.
+    fn read_huge_object(
+        &self,
+        file_data: &[u8],
+        id_bytes: &[u8],
+        offset_size: u8,
+        length_size: u8,
+    ) -> Result<Vec<u8>, FormatError> {
+        if self.io_filter_encoded_length > 0 {
+            return Err(FormatError::UnsupportedFilteredHeapObject);
+        }
+        let payload = &id_bytes[1..];
+
+        if self.huge_ids_direct(offset_size, length_size) {
+            // The address and length are stored inline in the heap ID.
+            let addr = read_offset(payload, 0, offset_size)?;
+            let len = read_offset(payload, offset_size as usize, length_size)?;
+            return slice_object(file_data, addr, len.to_usize()?);
+        }
+
+        // Indirect: the heap ID holds a B-tree key (the huge object ID); the
+        // huge-objects v2 B-tree maps it to (address, length).
+        let huge_id = read_var_le(payload);
+        if is_undefined(self.btree_huge_objects_address, offset_size) {
+            return Err(FormatError::HugeObjectNotFound(huge_id));
+        }
+        let btree_addr = self.btree_huge_objects_address.to_usize()?;
+        let header = BTreeV2Header::parse(file_data, btree_addr, offset_size, length_size)?;
+        let records = collect_btree_v2_records(file_data, &header, offset_size, length_size)?;
+        let (addr, len) = find_huge_record(&records, huge_id, offset_size, length_size)?;
+        slice_object(file_data, addr, len.to_usize()?)
     }
 
     /// Read an object from a direct block.
@@ -590,6 +797,60 @@ impl FractalHeapHeader {
                 64,
             )
         }
+    }
+
+    /// Streaming counterpart to [`FractalHeapHeader::read_object`].
+    pub fn read_object_from_source<S: FileSource + ?Sized>(
+        &self,
+        source: &S,
+        id_bytes: &[u8],
+        offset_size: u8,
+        length_size: u8,
+    ) -> Result<Vec<u8>, FormatError> {
+        match Self::heap_id_type(id_bytes)? {
+            HeapIdType::Managed => {
+                self.read_managed_object_from_source(source, id_bytes, offset_size)
+            }
+            HeapIdType::Huge => {
+                self.read_huge_object_from_source(source, id_bytes, offset_size, length_size)
+            }
+            HeapIdType::Tiny => read_tiny_object(self.heap_id_length, id_bytes),
+        }
+    }
+
+    /// Resolve and read a "huge" object via a [`FileSource`].
+    fn read_huge_object_from_source<S: FileSource + ?Sized>(
+        &self,
+        source: &S,
+        id_bytes: &[u8],
+        offset_size: u8,
+        length_size: u8,
+    ) -> Result<Vec<u8>, FormatError> {
+        if self.io_filter_encoded_length > 0 {
+            return Err(FormatError::UnsupportedFilteredHeapObject);
+        }
+        let payload = &id_bytes[1..];
+
+        if self.huge_ids_direct(offset_size, length_size) {
+            let addr = read_offset(payload, 0, offset_size)?;
+            let len = read_offset(payload, offset_size as usize, length_size)?;
+            return read_object_at_source(source, addr, len.to_usize()?);
+        }
+
+        let huge_id = read_var_le(payload);
+        if is_undefined(self.btree_huge_objects_address, offset_size) {
+            return Err(FormatError::HugeObjectNotFound(huge_id));
+        }
+        let header = BTreeV2Header::parse_from_source(
+            source,
+            self.btree_huge_objects_address,
+            offset_size,
+            length_size,
+        )?;
+        let records =
+            collect_btree_v2_records_from_source(source, &header, offset_size, length_size)?;
+        let (addr, len) = find_huge_record(&records, huge_id, offset_size, length_size)?;
+        read_object_at_source(source, addr, len.to_usize()?)
     }
 
     fn read_from_direct_block_from_source<S: FileSource + ?Sized>(
@@ -963,10 +1224,96 @@ mod tests {
     fn invalid_heap_id_type() {
         let (file_data, _) = build_simple_heap(8, 8);
         let hdr = FractalHeapHeader::parse(&file_data, 0, 8, 8).unwrap();
-        // Type = 1 (tiny) in bits 6-7
-        let id = vec![0x40u8, 0, 0, 0, 0, 0, 0]; // bit 6 set = type 1
+        // Type lives in bits 4-5; type 1 (huge) = 0x10. decode_managed_id only
+        // accepts managed (type 0) IDs.
+        let id = vec![0x10u8, 0, 0, 0, 0, 0, 0];
         let err = hdr.decode_managed_id(&id).unwrap_err();
         assert_eq!(err, FormatError::InvalidHeapIdType(1));
+    }
+
+    #[test]
+    fn heap_id_type_reads_bits_4_5() {
+        // Type is bits 4-5; the version (bits 6-7) must not be read as type.
+        assert_eq!(
+            FractalHeapHeader::heap_id_type(&[0x00]).unwrap(),
+            HeapIdType::Managed
+        );
+        assert_eq!(
+            FractalHeapHeader::heap_id_type(&[0x10]).unwrap(),
+            HeapIdType::Huge
+        );
+        assert_eq!(
+            FractalHeapHeader::heap_id_type(&[0x20]).unwrap(),
+            HeapIdType::Tiny
+        );
+        // Reserved type 3.
+        assert_eq!(
+            FractalHeapHeader::heap_id_type(&[0x30]),
+            Err(FormatError::InvalidHeapIdType(3))
+        );
+        // Version bits set (0xC0) must not change the decoded type.
+        assert_eq!(
+            FractalHeapHeader::heap_id_type(&[0xC0 | 0x10]).unwrap(),
+            HeapIdType::Huge
+        );
+    }
+
+    #[test]
+    fn huge_ids_direct_matches_hdf5_rule() {
+        // Unfiltered: direct when (id_len - 1) >= offset_size + length_size.
+        let mut h = dtable_header(512, 65536, 4);
+        h.heap_id_length = 7; // 6 payload bytes < 8 + 8 -> indirect (B-tree)
+        assert!(!h.huge_ids_direct(8, 8));
+        h.heap_id_length = 17; // 16 payload bytes == 8 + 8 -> direct
+        assert!(h.huge_ids_direct(8, 8));
+        // Filtered heaps need extra room (addr + len + filter_mask(4) + filtered
+        // len); 17 is no longer enough.
+        h.io_filter_encoded_length = 4;
+        assert!(!h.huge_ids_direct(8, 8));
+    }
+
+    #[test]
+    fn find_huge_record_matches_by_id() {
+        // Type-1 record: address(8) + length(8) + id(8), little-endian.
+        let rec = |addr: u64, len: u64, id: u64| {
+            let mut d = Vec::new();
+            d.extend_from_slice(&addr.to_le_bytes());
+            d.extend_from_slice(&len.to_le_bytes());
+            d.extend_from_slice(&id.to_le_bytes());
+            BTreeV2Record { data: d }
+        };
+        let records = vec![
+            rec(0x1000, 5000, 1),
+            rec(0x2000, 6000, 2),
+            rec(0x3000, 7000, 5),
+        ];
+        assert_eq!(find_huge_record(&records, 2, 8, 8).unwrap(), (0x2000, 6000));
+        assert_eq!(find_huge_record(&records, 5, 8, 8).unwrap(), (0x3000, 7000));
+        assert_eq!(
+            find_huge_record(&records, 9, 8, 8),
+            Err(FormatError::HugeObjectNotFound(9))
+        );
+    }
+
+    #[test]
+    fn read_tiny_object_short_and_extended() {
+        // Short form (heap ID <= 16 bytes): low nibble of byte 0 is length - 1.
+        let id = [0x20 | 0x03, b'a', b'b', b'c', b'd', 0, 0];
+        assert_eq!(read_tiny_object(7, &id).unwrap(), b"abcd");
+        // Extended form (heap ID >= 18 bytes): 12-bit length across bytes 0-1.
+        // length 5 -> stored value 4 = 0x004: byte0 low nibble 0x0, byte1 0x04.
+        let mut id = vec![0x20, 0x04];
+        id.extend_from_slice(b"hello");
+        id.resize(20, 0);
+        assert_eq!(read_tiny_object(20, &id).unwrap(), b"hello");
+
+        // Boundary: heap_id_length == 17 still uses the short form (HDF5 keeps
+        // short while heap_id_length - 1 <= 16). Decoding it as extended would
+        // misread the length, so this pins the off-by-one.
+        let mut id = vec![0x20 | 0x04]; // short form, length 5
+        id.extend_from_slice(b"world");
+        id.resize(17, 0);
+        assert_eq!(read_tiny_object(17, &id).unwrap(), b"world");
     }
 
     #[test]
@@ -992,6 +1339,7 @@ mod tests {
             heap_id_length: 7,
             io_filter_encoded_length: 0,
             max_managed_object_size: 0,
+            btree_huge_objects_address: u64::MAX,
             table_width,
             starting_block_size: start_block_size,
             max_direct_block_size,

--- a/src/group_v2.rs
+++ b/src/group_v2.rs
@@ -101,8 +101,8 @@ fn resolve_dense_entries(
         }
         let id_bytes = &record.data[id_offset..id_offset + fh.heap_id_length as usize];
 
-        // Read managed object from fractal heap
-        let link_data = fh.read_managed_object(file_data, id_bytes, offset_size)?;
+        // Read the link message from the fractal heap (managed or huge object).
+        let link_data = fh.read_object(file_data, id_bytes, offset_size, length_size)?;
 
         // Parse as Link message
         let link = LinkMessage::parse(&link_data, offset_size)?;
@@ -348,7 +348,7 @@ fn resolve_dense_entries_from_source<S: FileSource + ?Sized>(
             continue;
         }
         let id_bytes = &record.data[id_offset..id_offset + fh.heap_id_length as usize];
-        let link_data = fh.read_managed_object_from_source(source, id_bytes, offset_size)?;
+        let link_data = fh.read_object_from_source(source, id_bytes, offset_size, length_size)?;
         let link = LinkMessage::parse(&link_data, offset_size)?;
         if let LinkTarget::Hard {
             object_header_address,

--- a/tests/dense_huge_objects.rs
+++ b/tests/dense_huge_objects.rs
@@ -1,0 +1,138 @@
+// Crosschecks link the reference HDF5 C library (the `hdf5-metno` dev-dependency),
+// gated to 64-bit-pointer targets.
+#![cfg(not(target_pointer_width = "32"))]
+//! Reading dense group-link and dense-attribute storage whose messages are too
+//! large for the fractal heap to "manage" and are instead stored as "huge"
+//! objects, resolved through the heap's huge-objects v2 B-tree.
+//!
+//! Regression: a fractal-heap heap ID encodes its object type in bits 4-5 of the
+//! first byte, but the reader read bits 6-7 (the format version). Every huge
+//! object was therefore mis-decoded as managed, producing a garbage heap offset
+//! and a downstream `InvalidObjectHeaderVersion`/`UnexpectedEof`. A link or
+//! attribute message larger than the heap's max managed object size (4096 bytes
+//! for these heaps, reached with ~4 KiB names) is stored as a huge object and
+//! exercises this path. Files are written by the reference C library and read
+//! back through both the buffered and streaming readers.
+
+use hdf5_pure::{AttrValue, File};
+use std::path::Path;
+use tempfile::tempdir;
+
+/// A unique, deterministic name of about `len` bytes that starts with `d{i}_`.
+fn long_name(i: usize, len: usize) -> String {
+    let prefix = format!("d{i}_");
+    let pad = len.saturating_sub(prefix.len());
+    format!("{prefix}{}", "x".repeat(pad))
+}
+
+/// Write group `g` with one single-i32 dataset per name, value `i`, using the
+/// latest format so the C library stores the links densely in a fractal heap.
+fn write_group(path: &Path, names: &[String]) {
+    let file = hdf5::FileBuilder::new()
+        .with_fapl(|fapl| fapl.libver_latest())
+        .create(path)
+        .unwrap();
+    let g = file.create_group("g").unwrap();
+    for (i, name) in names.iter().enumerate() {
+        g.new_dataset::<i32>()
+            .shape((1,))
+            .create(name.as_str())
+            .unwrap()
+            .write(&[i as i32])
+            .unwrap();
+    }
+    file.close().unwrap();
+}
+
+/// Assert every `g/{name}` resolves to its dataset value `i`, through both the
+/// buffered and the streaming reader.
+fn assert_links_resolve(path: &Path, names: &[String]) {
+    let buffered = File::open(path).unwrap();
+    let streaming = File::open_streaming(path).unwrap();
+    for (i, name) in names.iter().enumerate() {
+        let p = format!("g/{name}");
+        assert_eq!(
+            buffered.dataset(&p).unwrap().read_i32().unwrap(),
+            vec![i as i32],
+            "buffered link {i}"
+        );
+        assert_eq!(
+            streaming.dataset(&p).unwrap().read_i32().unwrap(),
+            vec![i as i32],
+            "streaming link {i}"
+        );
+    }
+}
+
+#[test]
+fn reads_dense_links_stored_as_huge_objects() {
+    let dir = tempdir().unwrap();
+    // 4 KiB names push every link message just past the heap's 4096-byte managed
+    // limit, so each is a huge object; 40 entries give the huge-objects B-tree
+    // several records to search.
+    let names: Vec<String> = (0..40).map(|i| long_name(i, 4096)).collect();
+    let path = dir.path().join("huge_links.h5");
+    write_group(&path, &names);
+    assert_links_resolve(&path, &names);
+}
+
+#[test]
+fn reads_dense_links_mixing_managed_and_huge() {
+    let dir = tempdir().unwrap();
+    // Alternate short (managed) and very long (huge) names within one dense
+    // group, so both heap-ID types are decoded from the same heap.
+    let names: Vec<String> = (0..40)
+        .map(|i| {
+            if i % 2 == 0 {
+                format!("short_{i}")
+            } else {
+                long_name(i, 5000)
+            }
+        })
+        .collect();
+    let path = dir.path().join("mixed_links.h5");
+    write_group(&path, &names);
+    assert_links_resolve(&path, &names);
+}
+
+#[test]
+fn reads_dense_attributes_stored_as_huge_objects() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("huge_attrs.h5");
+    {
+        let file = hdf5::FileBuilder::new()
+            .with_fapl(|fapl| fapl.libver_latest())
+            .create(&path)
+            .unwrap();
+        let ds = file
+            .new_dataset::<i32>()
+            .shape((1,))
+            .create("data")
+            .unwrap();
+        ds.write(&[7i32]).unwrap();
+        // Enough attributes to force dense storage, each with a ~5 KiB name so
+        // the whole attribute message is stored as a huge object.
+        for i in 0..30 {
+            let name = format!("a{i}_{}", "y".repeat(5000));
+            ds.new_attr::<i64>()
+                .shape(())
+                .create(name.as_str())
+                .unwrap()
+                .write_scalar(&(i as i64))
+                .unwrap();
+        }
+        file.close().unwrap();
+    }
+
+    let f = File::open(&path).unwrap();
+    let ds = f.dataset("data").unwrap();
+    assert_eq!(ds.read_i32().unwrap(), vec![7]);
+
+    let attrs = ds.attrs().unwrap();
+    assert_eq!(attrs.len(), 30, "all dense attributes resolved");
+    for (name, value) in &attrs {
+        // Name is "a{i}_yyyy..."; the value written was `i`.
+        let i: i64 = name[1..name.find('_').unwrap()].parse().unwrap();
+        assert_eq!(*value, AttrValue::I64(i), "attribute {name}");
+    }
+}


### PR DESCRIPTION
## Problem

Reading a dense group, or a dense attribute set, whose link/attribute **names are very long** failed with `InvalidObjectHeaderVersion` (or `UnexpectedEof`). This is the pre-existing, lower-priority follow-up tracked during the #62 work on large dense groups.

When a link or attribute message is larger than the fractal heap's managed-object limit (~4 KiB for these heaps, reached with roughly 4 KiB names), HDF5 stores it as a **"huge" object** rather than inside the heap's managed blocks. The reader only handled managed objects, and worse, it read the heap-ID *type* from the wrong bits of byte 0: it used bits 6-7 (the format version) instead of bits 4-5 (the object type). So every huge object was mis-classified as managed, decoded to a garbage heap offset, and resolved to a bogus address whose "object header" then failed to parse.

## Fix

- Classify heap IDs by the correct bits (4-5), and add the two missing object kinds:
  - **Huge** objects are resolved through the heap's huge-objects v2 B-tree (the inline address/length form is also handled for heaps with wide enough IDs; filtered huge objects, which never occur for link/attribute heaps, return a clear error rather than misreading).
  - **Tiny** objects are decoded directly from the heap ID (short and extended forms).
- The fractal-heap header now captures `btree_huge_objects_address`.
- Both the **buffered and the streaming** readers are fixed, through one shared dispatch (`read_object` / `read_object_from_source`), so dense links and dense attributes are both covered.

Read-only behavior for existing (managed-only) files is unchanged; no on-disk format change.

## Validation

- New crosscheck `tests/dense_huge_objects.rs` writes files with the reference HDF5 C library and reads them back through both readers:
  - a dense group whose links are all huge,
  - a dense group **mixing** managed and huge links,
  - a dataset with dense, huge-named attributes (verified to actually exercise the huge path).
- **Mutation-checked**: reintroducing the bit bug fails all three crosschecks.
- Unit tests pin the heap-ID classification, the direct/indirect (`huge_ids_direct`) decision, the huge-record B-tree lookup, and tiny-object decoding (including the `heap_id_length == 17` short/extended boundary).
- Gates: `cargo fmt --check`, `clippy -D warnings`, no_std + `thumbv7em-none-eabi`, and the i686 narrowing-cast ratchet (unchanged at the baseline).

An adversarial review against the HDF5 spec / C source caught one latent off-by-one in the tiny extended-form threshold (it diverged from `H5HFtiny.c` only at `heap_id_length == 17`), now fixed and pinned by a boundary test.