### PR TITLE
Add metadata cache access options

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,17 @@ let values = ds.read_f64().unwrap();  // only this dataset's chunks are read
 
 The reading API is identical to `File::open`; only the backing store differs. Dataset reads are fully supported: contiguous, compact, and every chunk-index layout (B-tree v1, fixed array, and extensible array). Two limits apply to the streaming backend that in-memory reading does not have: only latest-format (v2) groups resolve along a path (a v1 symbol-table group is rejected), and reading attributes is not yet supported. `open_streaming` requires the `std` filesystem.
 
+Use `File::open_streaming_with_options` to bound retained metadata and dataset chunk cache memory. `MetadataCacheConfig` controls the streaming metadata cache, while `ChunkCacheConfig` controls decompressed chunk data and whether parsed chunk indexes are retained between repeated reads of the same dataset.
+
+```rust
+use hdf5_pure::{ChunkCacheConfig, File, FileAccessOptions, MetadataCacheConfig};
+
+let options = FileAccessOptions::new()
+    .with_metadata_cache(MetadataCacheConfig::new(8 * 1024 * 1024).with_max_entry_bytes(64 * 1024))
+    .with_chunk_cache(ChunkCacheConfig::new().with_max_bytes(256 * 1024));
+let file = File::open_streaming_with_options("huge.h5", options).unwrap();
+```
+
 ### In-memory (WASM)
 
 ```rust

--- a/src/btree_v2.rs
+++ b/src/btree_v2.rs
@@ -177,7 +177,7 @@ impl BTreeV2Header {
         let window = MAX_HEADER
             .min(source.len().saturating_sub(address))
             .to_usize()?;
-        let buf = source.read_exact_at(address, window)?;
+        let buf = source.read_metadata_at(address, window)?;
         Self::parse(&buf, 0, offset_size, length_size)
     }
 }
@@ -524,7 +524,7 @@ fn collect_node_from_source<S: FileSource + ?Sized>(
     let node_len = u64::from(node_size)
         .min(source.len().saturating_sub(address))
         .to_usize()?;
-    let node = source.read_exact_at(address, node_len)?;
+    let node = source.read_metadata_at(address, node_len)?;
 
     if depth == 0 {
         out.extend(parse_leaf_records(&node, 0, num_records, record_size)?);

--- a/src/chunk_cache.rs
+++ b/src/chunk_cache.rs
@@ -204,6 +204,80 @@ pub const DEFAULT_CACHE_BYTES: usize = 1024 * 1024; // 1 MiB
 /// Default maximum number of cached decompressed chunks.
 pub const DEFAULT_MAX_SLOTS: usize = 16;
 
+/// Configuration for a per-dataset chunk cache.
+///
+/// The byte and slot limits apply to decompressed raw chunk data. The optional
+/// chunk-index cache controls whether `hdf5-pure` retains the parsed chunk
+/// address index between reads of the same [`crate::Dataset`]. Disabling the
+/// index cache lowers retained metadata memory at the cost of re-scanning the
+/// on-disk chunk index for repeated reads.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChunkCacheConfig {
+    max_bytes: usize,
+    max_slots: usize,
+    cache_index: bool,
+}
+
+impl ChunkCacheConfig {
+    /// Create a config matching the historical defaults: 1 MiB of decompressed
+    /// chunks, 16 slots, and retained parsed chunk indexes.
+    pub const fn new() -> Self {
+        Self {
+            max_bytes: DEFAULT_CACHE_BYTES,
+            max_slots: DEFAULT_MAX_SLOTS,
+            cache_index: true,
+        }
+    }
+
+    /// Disable retained decompressed chunks and parsed chunk indexes.
+    pub const fn disabled() -> Self {
+        Self {
+            max_bytes: 0,
+            max_slots: 0,
+            cache_index: false,
+        }
+    }
+
+    /// Set the maximum decompressed chunk bytes retained per dataset.
+    pub const fn with_max_bytes(mut self, max_bytes: usize) -> Self {
+        self.max_bytes = max_bytes;
+        self
+    }
+
+    /// Set the maximum number of decompressed chunk slots retained per dataset.
+    pub const fn with_max_slots(mut self, max_slots: usize) -> Self {
+        self.max_slots = max_slots;
+        self
+    }
+
+    /// Enable or disable retaining the parsed chunk index between reads.
+    pub const fn with_index_cache(mut self, enabled: bool) -> Self {
+        self.cache_index = enabled;
+        self
+    }
+
+    /// Return the maximum decompressed chunk bytes retained per dataset.
+    pub const fn max_bytes(&self) -> usize {
+        self.max_bytes
+    }
+
+    /// Return the maximum decompressed chunk slots retained per dataset.
+    pub const fn max_slots(&self) -> usize {
+        self.max_slots
+    }
+
+    /// Return whether parsed chunk indexes are retained between reads.
+    pub const fn index_cache_enabled(&self) -> bool {
+        self.cache_index
+    }
+}
+
+impl Default for ChunkCacheConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 // ---------------------------------------------------------------------------
 // LRU entry
 // ---------------------------------------------------------------------------
@@ -256,6 +330,9 @@ struct CacheInner {
 
     /// Monotonic counter for LRU ordering.
     tick: u64,
+
+    /// Whether the parsed chunk index should be retained between reads.
+    cache_index: bool,
 }
 
 impl ChunkCache {
@@ -266,14 +343,24 @@ impl ChunkCache {
 
     /// Create a new chunk cache with custom byte budget and slot count.
     pub fn with_capacity(max_bytes: usize, max_slots: usize) -> Self {
+        Self::with_config(
+            ChunkCacheConfig::new()
+                .with_max_bytes(max_bytes)
+                .with_max_slots(max_slots),
+        )
+    }
+
+    /// Create a new chunk cache from a full configuration.
+    pub fn with_config(config: ChunkCacheConfig) -> Self {
         Self {
             inner: Mutex::new(CacheInner {
                 index: None,
-                slots: Vec::with_capacity(max_slots.min(64)),
+                slots: Vec::with_capacity(config.max_slots.min(64)),
                 current_bytes: 0,
-                max_bytes,
-                max_slots,
+                max_bytes: config.max_bytes,
+                max_slots: config.max_slots,
                 tick: 0,
+                cache_index: config.cache_index,
             }),
         }
     }
@@ -281,6 +368,7 @@ impl ChunkCache {
     // ----- Index operations -----
 
     /// Returns `true` if the chunk index has been built.
+    #[cfg(test)]
     pub fn has_index(&self) -> bool {
         self.inner.lock().unwrap().index.is_some()
     }
@@ -291,6 +379,9 @@ impl ChunkCache {
     /// (B-tree v1 stores rank+1 offsets).
     pub fn populate_index(&self, chunks: &[ChunkInfo], rank: usize) {
         let mut inner = self.inner.lock().unwrap();
+        if !inner.cache_index {
+            return;
+        }
         if inner.index.is_some() {
             return; // already populated
         }
@@ -363,8 +454,8 @@ impl ChunkCache {
         let mut inner = self.inner.lock().unwrap();
         let data_len = data.len();
 
-        // Don't cache if single chunk exceeds budget
-        if data_len > inner.max_bytes {
+        // Don't cache if disabled or if a single chunk exceeds the budget.
+        if inner.max_bytes == 0 || inner.max_slots == 0 || data_len > inner.max_bytes {
             return;
         }
 
@@ -524,6 +615,18 @@ mod tests {
         let cache = ChunkCache::with_capacity(10, 16);
         cache.put_decompressed(vec![0], vec![0; 100]); // too big
         assert_eq!(cache.cached_chunk_count(), 0);
+    }
+
+    #[test]
+    fn disabled_cache_retains_no_index_or_chunks() {
+        let cache = ChunkCache::with_config(ChunkCacheConfig::disabled());
+        let chunks = vec![make_chunk(vec![0, 0], 0x1000, 80)];
+        cache.populate_index(&chunks, 1);
+        assert!(!cache.has_index());
+
+        cache.put_decompressed(vec![0], vec![1, 2, 3]);
+        assert_eq!(cache.cached_chunk_count(), 0);
+        assert_eq!(cache.cached_bytes(), 0);
     }
 
     #[test]

--- a/src/chunked_read.rs
+++ b/src/chunked_read.rs
@@ -277,7 +277,7 @@ pub fn collect_chunk_info_from_source<S: FileSource + ?Sized>(
     let header_size = btree_v1_node_header_size(offset_size);
 
     // Node header: signature(4) + type(1) + level(1) + entries_used(2) + 2 siblings.
-    let header = source.read_exact_at(btree_address, header_size)?;
+    let header = source.read_metadata_at(btree_address, header_size)?;
     if &header[0..4] != b"TREE" {
         return Err(FormatError::InvalidBTreeSignature);
     }
@@ -298,7 +298,7 @@ pub fn collect_chunk_info_from_source<S: FileSource + ?Sized>(
                 offset: btree_address,
                 length: header_size as u64,
             })?;
-    let body = source.read_exact_at(body_addr, needed)?;
+    let body = source.read_metadata_at(body_addr, needed)?;
     let mut pos = 0usize;
 
     if node_level == 0 {
@@ -615,68 +615,19 @@ pub fn read_chunked_data_from_source<S: FileSource + ?Sized>(
         )));
     }
 
-    let chunks = match (version, chunk_index_type) {
-        (3, _) => collect_chunk_info_from_source(source, addr, ndims, offset_size, length_size)?,
-        (4, Some(1)) => {
-            // Single chunk covering the whole dataset.
-            let chunk_byte_size: usize = chunk_dims.iter().product::<usize>() * elem_size;
-            let (csize, fmask) = if let Some(fs) = single_filtered_size {
-                (u32_from(fs)?, single_filter_mask.unwrap_or(0))
-            } else {
-                (u32_from(chunk_byte_size as u64)?, 0)
-            };
-            vec![ChunkInfo {
-                chunk_size: csize,
-                filter_mask: fmask,
-                offsets: vec![0u64; rank],
-                address: addr,
-            }]
-        }
-        (4, Some(2)) => {
-            let spatial_chunk_dims: Vec<u32> = chunk_dimensions[..rank].to_vec();
-            generate_implicit_chunks(
-                addr,
-                &dataspace.dimensions,
-                &spatial_chunk_dims,
-                u32_from(elem_size as u64)?,
-            )
-        }
-        (4, Some(3)) => {
-            // Fixed Array — spatial chunk dims only.
-            let spatial_chunk_dims: Vec<u32> = chunk_dimensions[..rank].to_vec();
-            let header =
-                FixedArrayHeader::parse_from_source(source, addr, offset_size, length_size)?;
-            read_fixed_array_chunks_from_source(
-                source,
-                &header,
-                &dataspace.dimensions,
-                &spatial_chunk_dims,
-                u32_from(elem_size as u64)?,
-                offset_size,
-                length_size,
-            )?
-        }
-        (4, Some(4)) => {
-            // Extensible Array — spatial chunk dims only.
-            let spatial_chunk_dims: Vec<u32> = chunk_dimensions[..rank].to_vec();
-            let header =
-                ExtensibleArrayHeader::parse_from_source(source, addr, offset_size, length_size)?;
-            read_extensible_array_chunks_from_source(
-                source,
-                &header,
-                &dataspace.dimensions,
-                &spatial_chunk_dims,
-                u32_from(elem_size as u64)?,
-                offset_size,
-                length_size,
-            )?
-        }
-        (v, idx) => {
-            return Err(FormatError::ChunkedReadError(format!(
-                "unsupported chunked layout version={v}, index_type={idx:?}"
-            )));
-        }
-    };
+    let chunks = collect_chunks_for_layout_from_source(
+        source,
+        version,
+        chunk_index_type,
+        addr,
+        single_filtered_size,
+        single_filter_mask,
+        chunk_dimensions,
+        dataspace,
+        elem_size,
+        offset_size,
+        length_size,
+    )?;
 
     let chunk_dims_u64: Vec<u64> = chunk_dims.iter().map(|&d| d as u64).collect();
     let ctx = ChunkContext::from_datatype(&chunk_dims_u64, datatype);
@@ -691,6 +642,244 @@ pub fn read_chunked_data_from_source<S: FileSource + ?Sized>(
         elem_size,
         total_bytes,
     ))
+}
+
+/// Read a chunked dataset from a [`FileSource`] with parsed-index and
+/// decompressed-chunk caching.
+///
+/// This is the streaming counterpart of [`read_chunked_data_cached`].
+#[allow(clippy::too_many_arguments)]
+pub fn read_chunked_data_cached_from_source<S: FileSource + ?Sized>(
+    source: &S,
+    layout: &DataLayout,
+    dataspace: &Dataspace,
+    datatype: &Datatype,
+    pipeline: Option<&FilterPipeline>,
+    offset_size: u8,
+    length_size: u8,
+    cache: &ChunkCache,
+) -> Result<Vec<u8>, FormatError> {
+    let (
+        chunk_dimensions,
+        version,
+        chunk_index_type,
+        addr_opt,
+        single_filtered_size,
+        single_filter_mask,
+    ) = match layout {
+        DataLayout::Chunked {
+            chunk_dimensions,
+            btree_address,
+            version,
+            chunk_index_type,
+            single_chunk_filtered_size,
+            single_chunk_filter_mask,
+        } => (
+            chunk_dimensions,
+            *version,
+            *chunk_index_type,
+            *btree_address,
+            *single_chunk_filtered_size,
+            *single_chunk_filter_mask,
+        ),
+        _ => {
+            return Err(FormatError::ChunkedReadError(
+                "expected chunked layout".into(),
+            ));
+        }
+    };
+
+    let addr = addr_opt
+        .ok_or_else(|| FormatError::ChunkedReadError("no address for chunked layout".into()))?;
+
+    let elem_size = datatype.type_size() as usize;
+    let ndims = chunk_dimensions.len();
+    let rank = ndims - 1;
+    let chunk_dims: Vec<usize> = chunk_dimensions[..rank]
+        .iter()
+        .map(|&d| d as usize)
+        .collect();
+    let ds_dims: Vec<usize> = dataspace
+        .dimensions
+        .iter()
+        .map(|&d| d.to_usize())
+        .collect::<Result<_, _>>()?;
+    if ds_dims.len() != rank {
+        return Err(FormatError::ChunkedReadError(format!(
+            "rank mismatch: dataspace has {} dims, layout has {} chunk dims (rank={})",
+            ds_dims.len(),
+            chunk_dimensions.len(),
+            rank
+        )));
+    }
+
+    let chunks = if let Some(chunks) = cache.all_indexed_chunks() {
+        chunks
+    } else {
+        let chunks = collect_chunks_for_layout_from_source(
+            source,
+            version,
+            chunk_index_type,
+            addr,
+            single_filtered_size,
+            single_filter_mask,
+            chunk_dimensions,
+            dataspace,
+            elem_size,
+            offset_size,
+            length_size,
+        )?;
+        cache.populate_index(&chunks, rank);
+        chunks
+    };
+
+    let total_elements = dataspace.num_elements().to_usize()?;
+    let total_bytes = total_elements
+        .checked_mul(elem_size)
+        .ok_or(FormatError::OffsetOverflow {
+            offset: total_elements as u64,
+            length: elem_size as u64,
+        })?;
+    let mut output = vec![0u8; total_bytes];
+
+    let mut ds_strides = vec![1usize; rank];
+    for i in (0..rank.saturating_sub(1)).rev() {
+        ds_strides[i] = ds_strides[i + 1] * ds_dims[i + 1];
+    }
+
+    let mut chunk_strides = vec![1usize; rank];
+    for i in (0..rank.saturating_sub(1)).rev() {
+        chunk_strides[i] = chunk_strides[i + 1] * chunk_dims[i + 1];
+    }
+
+    let chunk_dims_u64: Vec<u64> = chunk_dims.iter().map(|&d| d as u64).collect();
+    let ctx = ChunkContext::from_datatype(&chunk_dims_u64, datatype);
+
+    for chunk_info in &chunks {
+        let coord: Vec<u64> = chunk_info.offsets.iter().take(rank).copied().collect();
+        let decompressed = if let Some(cached) = cache.get_decompressed(&coord) {
+            cached
+        } else {
+            let raw_chunk =
+                source.read_exact_at(chunk_info.address, chunk_info.chunk_size.to_usize()?)?;
+            let dec = if let Some(pl) = pipeline {
+                if chunk_info.filter_mask == 0 {
+                    decompress_chunk(&raw_chunk, pl, ctx)?
+                } else {
+                    raw_chunk
+                }
+            } else {
+                raw_chunk
+            };
+            cache.put_decompressed(coord.clone(), dec.clone());
+            dec
+        };
+
+        let chunk_offsets: Vec<usize> = chunk_info
+            .offsets
+            .iter()
+            .take(rank)
+            .map(|&o| o.to_usize())
+            .collect::<Result<_, _>>()?;
+
+        if rank == 0 {
+            let copy_len = decompressed.len().min(output.len());
+            output[..copy_len].copy_from_slice(&decompressed[..copy_len]);
+        } else {
+            copy_chunk_to_output(
+                &decompressed,
+                &mut output,
+                &chunk_offsets,
+                &chunk_dims,
+                &ds_dims,
+                &ds_strides,
+                &chunk_strides,
+                elem_size,
+                rank,
+            );
+        }
+    }
+
+    Ok(output)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn collect_chunks_for_layout_from_source<S: FileSource + ?Sized>(
+    source: &S,
+    version: u8,
+    chunk_index_type: Option<u8>,
+    addr: u64,
+    single_filtered_size: Option<u64>,
+    single_filter_mask: Option<u32>,
+    chunk_dimensions: &[u32],
+    dataspace: &Dataspace,
+    elem_size: usize,
+    offset_size: u8,
+    length_size: u8,
+) -> Result<Vec<ChunkInfo>, FormatError> {
+    let ndims = chunk_dimensions.len();
+    let rank = ndims - 1;
+    match (version, chunk_index_type) {
+        (3, _) => collect_chunk_info_from_source(source, addr, ndims, offset_size, length_size),
+        (4, Some(1)) => {
+            let chunk_byte_size: usize = chunk_dimensions[..rank]
+                .iter()
+                .map(|&d| d as usize)
+                .product::<usize>()
+                * elem_size;
+            let (csize, fmask) = if let Some(fs) = single_filtered_size {
+                (u32_from(fs)?, single_filter_mask.unwrap_or(0))
+            } else {
+                (u32_from(chunk_byte_size as u64)?, 0)
+            };
+            Ok(vec![ChunkInfo {
+                chunk_size: csize,
+                filter_mask: fmask,
+                offsets: vec![0u64; rank],
+                address: addr,
+            }])
+        }
+        (4, Some(2)) => {
+            let spatial_chunk_dims: Vec<u32> = chunk_dimensions[..rank].to_vec();
+            Ok(generate_implicit_chunks(
+                addr,
+                &dataspace.dimensions,
+                &spatial_chunk_dims,
+                u32_from(elem_size as u64)?,
+            ))
+        }
+        (4, Some(3)) => {
+            let spatial_chunk_dims: Vec<u32> = chunk_dimensions[..rank].to_vec();
+            let header =
+                FixedArrayHeader::parse_from_source(source, addr, offset_size, length_size)?;
+            read_fixed_array_chunks_from_source(
+                source,
+                &header,
+                &dataspace.dimensions,
+                &spatial_chunk_dims,
+                u32_from(elem_size as u64)?,
+                offset_size,
+                length_size,
+            )
+        }
+        (4, Some(4)) => {
+            let spatial_chunk_dims: Vec<u32> = chunk_dimensions[..rank].to_vec();
+            let header =
+                ExtensibleArrayHeader::parse_from_source(source, addr, offset_size, length_size)?;
+            read_extensible_array_chunks_from_source(
+                source,
+                &header,
+                &dataspace.dimensions,
+                &spatial_chunk_dims,
+                u32_from(elem_size as u64)?,
+                offset_size,
+                length_size,
+            )
+        }
+        (v, idx) => Err(FormatError::ChunkedReadError(format!(
+            "unsupported chunked layout version={v}, index_type={idx:?}"
+        ))),
+    }
 }
 
 /// Scatter decompressed chunks into the dense output buffer. Pure (no file
@@ -811,8 +1000,9 @@ pub fn read_chunked_data_cached(
         )));
     }
 
-    // Populate chunk index on first access
-    if !cache.has_index() {
+    let chunks = if let Some(chunks) = cache.all_indexed_chunks() {
+        chunks
+    } else {
         let chunks = match (version, chunk_index_type) {
             (3, _) => collect_chunk_info(file_data, addr, ndims, offset_size, length_size)?,
             (4, Some(1)) => {
@@ -877,9 +1067,8 @@ pub fn read_chunked_data_cached(
             }
         };
         cache.populate_index(&chunks, rank);
-    }
-
-    let chunks = cache.all_indexed_chunks().unwrap_or_default();
+        chunks
+    };
 
     // Assemble output
     let total_elements = dataspace.num_elements() as usize;

--- a/src/data_read.rs
+++ b/src/data_read.rs
@@ -5,7 +5,8 @@ use alloc::{string::String, vec, vec::Vec};
 
 use crate::chunk_cache::ChunkCache;
 use crate::chunked_read::{
-    read_chunked_data, read_chunked_data_cached, read_chunked_data_from_source,
+    read_chunked_data, read_chunked_data_cached, read_chunked_data_cached_from_source,
+    read_chunked_data_from_source,
 };
 use crate::convert::{TryToUsize, slice_range};
 use crate::data_layout::DataLayout;
@@ -206,10 +207,6 @@ pub fn read_raw_data_full_from_source<S: FileSource + ?Sized>(
 }
 
 /// Streaming counterpart of [`read_raw_data_cached`].
-///
-/// The chunk cache is not yet consulted on the streaming path (a follow-up); the
-/// result is identical to the buffered cached read, only the chunk index is
-/// re-scanned on each call.
 #[allow(clippy::too_many_arguments)]
 pub fn read_raw_data_cached_from_source<S: FileSource + ?Sized>(
     source: &S,
@@ -219,17 +216,29 @@ pub fn read_raw_data_cached_from_source<S: FileSource + ?Sized>(
     pipeline: Option<&FilterPipeline>,
     offset_size: u8,
     length_size: u8,
-    _cache: &ChunkCache,
+    cache: &ChunkCache,
 ) -> Result<Vec<u8>, FormatError> {
-    read_raw_data_full_from_source(
-        source,
-        layout,
-        dataspace,
-        datatype,
-        pipeline,
-        offset_size,
-        length_size,
-    )
+    match layout {
+        DataLayout::Chunked { .. } => read_chunked_data_cached_from_source(
+            source,
+            layout,
+            dataspace,
+            datatype,
+            pipeline,
+            offset_size,
+            length_size,
+            cache,
+        ),
+        _ => read_raw_data_full_from_source(
+            source,
+            layout,
+            dataspace,
+            datatype,
+            pipeline,
+            offset_size,
+            length_size,
+        ),
+    }
 }
 
 fn datatype_name(dt: &Datatype) -> &'static str {

--- a/src/extensible_array.rs
+++ b/src/extensible_array.rs
@@ -170,7 +170,7 @@ impl ExtensibleArrayHeader {
         length_size: u8,
     ) -> Result<Self, FormatError> {
         let size = Self::serialized_size(offset_size, length_size);
-        let buf = source.read_exact_at(address, size)?;
+        let buf = source.read_metadata_at(address, size)?;
         Self::parse(&buf, 0, offset_size, length_size)
     }
 }
@@ -844,7 +844,7 @@ pub fn read_extensible_array_chunks_from_source<S: FileSource + ?Sized>(
             length: os as u64,
         })?;
     let ib_len = ib_header_size + inline_bytes + addr_bytes;
-    let ib = source.read_exact_at(header.index_block_address, ib_len)?;
+    let ib = source.read_metadata_at(header.index_block_address, ib_len)?;
     if &ib[0..4] != b"EAIB" {
         return Err(FormatError::ChunkedReadError(
             "invalid Extensible Array index block signature".into(),
@@ -972,7 +972,7 @@ fn read_data_block_elements_from_source<S: FileSource + ?Sized>(
             length: elem_stride as u64,
         })?;
     let region_len = db_header_size + blk_off_size + elem_bytes;
-    let block = source.read_exact_at(db_address, region_len)?;
+    let block = source.read_metadata_at(db_address, region_len)?;
     if &block[0..4] != b"EADB" {
         return Err(FormatError::ChunkedReadError(
             "invalid Extensible Array data block signature".into(),
@@ -1051,7 +1051,7 @@ fn read_paged_data_block_from_source<S: FileSource + ?Sized>(
             length: page_stride as u64,
         })?;
     let region_len = (db_header_size + pages_bytes).min(avail);
-    let block = source.read_exact_at(db_address, region_len)?;
+    let block = source.read_metadata_at(db_address, region_len)?;
     if block.len() < 4 || &block[0..4] != b"EADB" {
         return Err(FormatError::ChunkedReadError(
             "invalid Extensible Array data block signature".into(),
@@ -1135,7 +1135,7 @@ fn read_super_block_from_source<S: FileSource + ?Sized>(
         length: os as u64,
     })?;
     let region_len = sb_header_size + bitmap_size + addr_bytes;
-    let block = source.read_exact_at(sb_address, region_len)?;
+    let block = source.read_metadata_at(sb_address, region_len)?;
     if &block[0..4] != b"EASB" {
         return Err(FormatError::ChunkedReadError(
             "invalid Extensible Array super block signature".into(),

--- a/src/fixed_array.rs
+++ b/src/fixed_array.rs
@@ -115,7 +115,7 @@ impl FixedArrayHeader {
         length_size: u8,
     ) -> Result<Self, FormatError> {
         let min_size = 4 + 1 + 1 + 1 + 1 + length_size as usize + offset_size as usize + 4;
-        let buf = source.read_exact_at(address, min_size)?;
+        let buf = source.read_metadata_at(address, min_size)?;
         Self::parse(&buf, 0, offset_size, length_size)
     }
 }
@@ -355,7 +355,7 @@ pub fn read_fixed_array_chunks_from_source<S: FileSource + ?Sized>(
     let db_header_size = 4 + 1 + 1 + os;
 
     // Data block prefix: FADB(4) + version(1) + client_id(1) + header_address.
-    let prefix = source.read_exact_at(db_address, db_header_size)?;
+    let prefix = source.read_metadata_at(db_address, db_header_size)?;
     if &prefix[0..4] != b"FADB" {
         return Err(FormatError::ChunkedReadError(
             "invalid Fixed Array data block signature".into(),
@@ -393,7 +393,7 @@ pub fn read_fixed_array_chunks_from_source<S: FileSource + ?Sized>(
 
     if !is_paged {
         // All elements live directly after the prefix; read them in one window.
-        let region = source.read_exact_at(
+        let region = source.read_metadata_at(
             db_address + db_header_size as u64,
             num_elements
                 .checked_mul(elem_size)
@@ -425,7 +425,7 @@ pub fn read_fixed_array_chunks_from_source<S: FileSource + ?Sized>(
     let npages = num_elements.div_ceil(page_size);
     let bitmap_size = npages.div_ceil(8);
     let bitmap_addr = db_address + db_header_size as u64;
-    let bitmap = source.read_exact_at(bitmap_addr, bitmap_size)?;
+    let bitmap = source.read_metadata_at(bitmap_addr, bitmap_size)?;
     let pages_start_addr = bitmap_addr + bitmap_size as u64 + 4;
     let page_stride = page_size
         .checked_mul(elem_size)
@@ -448,7 +448,7 @@ pub fn read_fixed_array_chunks_from_source<S: FileSource + ?Sized>(
                 length: page_stride as u64,
             })?;
         let page_addr = pages_start_addr + page_offset as u64;
-        let region = source.read_exact_at(
+        let region = source.read_metadata_at(
             page_addr,
             nelem_in_page
                 .checked_mul(elem_size)

--- a/src/fractal_heap.rs
+++ b/src/fractal_heap.rs
@@ -165,7 +165,7 @@ fn read_object_at_source<S: FileSource + ?Sized>(
     addr: u64,
     len: usize,
 ) -> Result<Vec<u8>, FormatError> {
-    source.read_exact_at(addr, len)
+    source.read_metadata_at(addr, len)
 }
 
 /// Find the (address, length) of a huge object in the heap's huge-objects v2
@@ -759,7 +759,7 @@ impl FractalHeapHeader {
         let window = MAX_HEADER
             .min(source.len().saturating_sub(address))
             .to_usize()?;
-        let buf = source.read_exact_at(address, window)?;
+        let buf = source.read_metadata_at(address, window)?;
         Self::parse(&buf, 0, offset_size, length_size)
     }
 
@@ -868,7 +868,7 @@ impl FractalHeapHeader {
                 offset: block_addr,
                 length: local_offset,
             })?;
-        source.read_exact_at(pos, length)
+        source.read_metadata_at(pos, length)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -891,7 +891,7 @@ impl FractalHeapHeader {
         let region_len = (self.indirect_block_entries_len(nrows, offset_size) as u64)
             .min(source.len().saturating_sub(iblock_addr))
             .to_usize()?;
-        let block = source.read_exact_at(iblock_addr, region_len)?;
+        let block = source.read_metadata_at(iblock_addr, region_len)?;
         match self.find_child_for_offset(
             &block,
             nrows,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,7 +191,11 @@ pub use error::Error;
 pub use error::FormatError;
 
 #[cfg(feature = "std")]
-pub use reader::{Dataset, File, Group, is_hdf5, is_hdf5_bytes};
+pub use reader::{Dataset, File, FileAccessOptions, Group, is_hdf5, is_hdf5_bytes};
+
+pub use chunk_cache::ChunkCacheConfig;
+
+pub use source::MetadataCacheConfig;
 
 #[cfg(feature = "std")]
 pub use vl_data::VlenStringReadOptions;

--- a/src/object_header.rs
+++ b/src/object_header.rs
@@ -587,7 +587,7 @@ impl ObjectHeader {
         let head_len = MAX_PREFIX
             .min(source.len().saturating_sub(address))
             .to_usize()?;
-        let head = source.read_exact_at(address, head_len)?;
+        let head = source.read_metadata_at(address, head_len)?;
         if head.len() < 6 {
             return Err(FormatError::UnexpectedEof {
                 expected: 6,
@@ -646,7 +646,7 @@ impl ObjectHeader {
                     offset: chunk0_end as u64,
                     length: 4,
                 })?;
-        let chunk0 = source.read_exact_at(address, chunk0_total.to_usize()?)?;
+        let chunk0 = source.read_metadata_at(address, chunk0_total.to_usize()?)?;
 
         #[cfg(feature = "checksum")]
         {
@@ -682,7 +682,7 @@ impl ObjectHeader {
             }
             cont_remaining -= 1;
             let cont_len = cont_len.to_usize()?;
-            let region = source.read_exact_at(cont_off, cont_len)?;
+            let region = source.read_metadata_at(cont_off, cont_len)?;
             Self::parse_v2_continuation(
                 &region,
                 0,
@@ -716,7 +716,7 @@ impl ObjectHeader {
     ) -> Result<ObjectHeader, FormatError> {
         // version(1) + reserved(1) + num_messages(2) + ref_count(4) +
         // header_size(4) = 12, padded to 16 before the first message.
-        let prefix = source.read_exact_at(address, 16)?;
+        let prefix = source.read_metadata_at(address, 16)?;
         let version = prefix[0];
         if version != 1 {
             return Err(FormatError::InvalidObjectHeaderVersion(version));
@@ -768,7 +768,7 @@ impl ObjectHeader {
         if depth_remaining == 0 {
             return Err(FormatError::NestingDepthExceeded);
         }
-        let region = source.read_exact_at(region_addr, region_len.to_usize()?)?;
+        let region = source.read_metadata_at(region_addr, region_len.to_usize()?)?;
         let end = region.len();
         let mut pos = 0usize;
         let mut count = 0u16;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::io::{Read, Seek, SeekFrom};
 
 use crate::attribute::extract_attributes_full;
-use crate::chunk_cache::ChunkCache;
+use crate::chunk_cache::{ChunkCache, ChunkCacheConfig};
 use crate::compound::CompoundType;
 use crate::convert::TryToUsize;
 use crate::data_layout::DataLayout;
@@ -21,7 +21,9 @@ use crate::libver::LibVer;
 use crate::message_type::MessageType;
 use crate::object_header::ObjectHeader;
 use crate::signature;
-use crate::source::{BytesSource, FileSource, ReadSeekSource};
+use crate::source::{
+    BytesSource, FileSource, MetadataCacheConfig, MetadataCachingSource, ReadSeekSource,
+};
 use crate::superblock::Superblock;
 use crate::vl_data::{self, VlenStringReadOptions};
 
@@ -57,6 +59,57 @@ impl FileSource for SourceView<'_> {
             SourceView::Mem(b) => BytesSource::new(*b).read_at(offset, buf),
             SourceView::Stream(s) => s.read_at(offset, buf),
         }
+    }
+
+    fn read_metadata_at(&self, offset: u64, len: usize) -> Result<Vec<u8>, FormatError> {
+        match self {
+            SourceView::Mem(b) => BytesSource::new(*b).read_metadata_at(offset, len),
+            SourceView::Stream(s) => s.read_metadata_at(offset, len),
+        }
+    }
+}
+
+/// File-access options applied when opening an HDF5 file.
+///
+/// This is the `hdf5-pure` analogue of the HDF5 file access property list
+/// settings relevant to read-time memory usage. The metadata cache only affects
+/// streaming opens; in-memory opens already have the whole file in one buffer.
+/// The chunk cache applies to datasets opened from either backend.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct FileAccessOptions {
+    metadata_cache: MetadataCacheConfig,
+    chunk_cache: ChunkCacheConfig,
+}
+
+impl FileAccessOptions {
+    /// Create options with the crate's default access behavior.
+    pub const fn new() -> Self {
+        Self {
+            metadata_cache: MetadataCacheConfig::disabled(),
+            chunk_cache: ChunkCacheConfig::new(),
+        }
+    }
+
+    /// Configure the bounded streaming metadata cache.
+    pub const fn with_metadata_cache(mut self, metadata_cache: MetadataCacheConfig) -> Self {
+        self.metadata_cache = metadata_cache;
+        self
+    }
+
+    /// Configure the per-dataset chunk cache.
+    pub const fn with_chunk_cache(mut self, chunk_cache: ChunkCacheConfig) -> Self {
+        self.chunk_cache = chunk_cache;
+        self
+    }
+
+    /// Return the configured streaming metadata cache.
+    pub const fn metadata_cache(&self) -> MetadataCacheConfig {
+        self.metadata_cache
+    }
+
+    /// Return the configured per-dataset chunk cache.
+    pub const fn chunk_cache(&self) -> ChunkCacheConfig {
+        self.chunk_cache
     }
 }
 
@@ -103,6 +156,7 @@ pub struct File {
     /// one. Best-effort: a malformed or unreadable extension leaves this `None`
     /// rather than failing the open.
     file_space_info: Option<FileSpaceInfo>,
+    access_options: FileAccessOptions,
 }
 
 impl File {
@@ -113,8 +167,20 @@ impl File {
     /// To read a file larger than memory (e.g. on a 32-bit host) without
     /// buffering it, use [`File::open_streaming`].
     pub fn open<P: AsRef<std::path::Path>>(path: P) -> Result<Self, Error> {
+        Self::open_with_options(path, FileAccessOptions::new())
+    }
+
+    /// Open an HDF5 file from a filesystem path with explicit access options.
+    ///
+    /// Like [`open`](Self::open), this buffers the whole file in memory. Use
+    /// [`open_streaming_with_options`](Self::open_streaming_with_options) when
+    /// the metadata cache budget should apply to lazy metadata reads.
+    pub fn open_with_options<P: AsRef<std::path::Path>>(
+        path: P,
+        options: FileAccessOptions,
+    ) -> Result<Self, Error> {
         let bytes = std::fs::read(path.as_ref()).map_err(Error::Io)?;
-        Self::from_bytes(bytes)
+        Self::from_bytes_with_options(bytes, options)
     }
 
     /// Open an HDF5 file for **streaming** reads, fetching regions on demand from
@@ -131,14 +197,28 @@ impl File {
     /// supported. Dataset reads (contiguous, compact, and all chunked index
     /// types) are fully supported.
     pub fn open_streaming<P: AsRef<std::path::Path>>(path: P) -> Result<Self, Error> {
+        Self::open_streaming_with_options(path, FileAccessOptions::new())
+    }
+
+    /// Open an HDF5 file for streaming reads with explicit access options.
+    pub fn open_streaming_with_options<P: AsRef<std::path::Path>>(
+        path: P,
+        options: FileAccessOptions,
+    ) -> Result<Self, Error> {
         let handle = std::fs::File::open(path.as_ref()).map_err(Error::Io)?;
         let source = ReadSeekSource::new(handle).map_err(Error::Format)?;
-        let (superblock, addr_offset) = Self::parse_superblock_source(&source)?;
+        let source: Box<dyn FileSource + Send + Sync> = if options.metadata_cache.is_enabled() {
+            Box::new(MetadataCachingSource::new(source, options.metadata_cache))
+        } else {
+            Box::new(source)
+        };
+        let (superblock, addr_offset) = Self::parse_superblock_source(source.as_ref())?;
         Ok(Self::from_parts(
-            Backend::Streaming(Box::new(source)),
+            Backend::Streaming(source),
             superblock,
             addr_offset,
             None,
+            options,
         ))
     }
 
@@ -153,6 +233,17 @@ impl File {
     /// Only the `std` build supports this (it requires a live filesystem
     /// handle); the in-memory [`File::from_bytes`] path cannot refresh.
     pub fn open_swmr<P: AsRef<std::path::Path>>(path: P) -> Result<Self, Error> {
+        Self::open_swmr_with_options(path, FileAccessOptions::new())
+    }
+
+    /// Open an HDF5 file for SWMR reading with explicit access options.
+    ///
+    /// SWMR reads currently keep an in-memory mirror for refresh semantics, so
+    /// only the per-dataset chunk-cache settings affect this backend.
+    pub fn open_swmr_with_options<P: AsRef<std::path::Path>>(
+        path: P,
+        options: FileAccessOptions,
+    ) -> Result<Self, Error> {
         let mut handle = std::fs::File::open(path.as_ref()).map_err(Error::Io)?;
         let mut data = Vec::new();
         handle.read_to_end(&mut data).map_err(Error::Io)?;
@@ -162,17 +253,27 @@ impl File {
             superblock,
             addr_offset,
             Some(handle),
+            options,
         ))
     }
 
     /// Open an HDF5 file from an in-memory byte vector.
     pub fn from_bytes(data: Vec<u8>) -> Result<Self, Error> {
+        Self::from_bytes_with_options(data, FileAccessOptions::new())
+    }
+
+    /// Open an HDF5 file from an in-memory byte vector with explicit access options.
+    pub fn from_bytes_with_options(
+        data: Vec<u8>,
+        options: FileAccessOptions,
+    ) -> Result<Self, Error> {
         let (superblock, addr_offset) = Self::parse_superblock(&data)?;
         Ok(Self::from_parts(
             Backend::InMemory(data),
             superblock,
             addr_offset,
             None,
+            options,
         ))
     }
 
@@ -215,6 +316,7 @@ impl File {
         superblock: Superblock,
         addr_offset: u64,
         handle: Option<std::fs::File>,
+        access_options: FileAccessOptions,
     ) -> Self {
         let mut file = File {
             backend,
@@ -222,6 +324,7 @@ impl File {
             addr_offset,
             handle,
             file_space_info: None,
+            access_options,
         };
         file.file_space_info = file.read_file_space_info();
         file
@@ -338,7 +441,7 @@ impl File {
         Ok(Dataset {
             file: self,
             header: hdr,
-            chunk_cache: ChunkCache::new(),
+            chunk_cache: ChunkCache::with_config(self.access_options.chunk_cache),
         })
     }
 
@@ -358,6 +461,11 @@ impl File {
             Backend::InMemory(v) => v,
             Backend::Streaming(_) => &[],
         }
+    }
+
+    /// Return the access options used when opening this file.
+    pub const fn access_options(&self) -> FileAccessOptions {
+        self.access_options
     }
 
     /// Returns a reference to the parsed superblock.
@@ -608,7 +716,7 @@ impl<'f> Group<'f> {
         Ok(Dataset {
             file: self.file,
             header: hdr,
-            chunk_cache: ChunkCache::new(),
+            chunk_cache: ChunkCache::with_config(self.file.access_options.chunk_cache),
         })
     }
 

--- a/src/source.rs
+++ b/src/source.rs
@@ -83,6 +83,77 @@ use alloc::{vec, vec::Vec};
 use crate::convert::TryToUsize;
 use crate::error::FormatError;
 
+/// Default maximum size of one entry admitted to a streaming metadata cache.
+pub const DEFAULT_METADATA_CACHE_MAX_ENTRY_BYTES: usize = 64 * 1024;
+
+/// Initial metadata-cache settings for streaming file access.
+///
+/// This is the `hdf5-pure` counterpart to the memory-budget portion of HDF5's
+/// `H5Pset_mdc_config`: it bounds the bytes retained for parsed metadata reads
+/// while a file is opened through [`crate::File::open_streaming_with_options`].
+/// Raw dataset payload reads use [`FileSource::read_exact_at`] and are not
+/// admitted to this cache.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MetadataCacheConfig {
+    max_bytes: usize,
+    max_entry_bytes: usize,
+}
+
+impl MetadataCacheConfig {
+    /// Create a metadata cache with the given total byte budget.
+    ///
+    /// Individual cached reads are capped at
+    /// [`DEFAULT_METADATA_CACHE_MAX_ENTRY_BYTES`] by default so one large heap
+    /// or index block cannot monopolize the cache. Use
+    /// [`with_max_entry_bytes`](Self::with_max_entry_bytes) to change that.
+    pub const fn new(max_bytes: usize) -> Self {
+        let max_entry_bytes = if max_bytes < DEFAULT_METADATA_CACHE_MAX_ENTRY_BYTES {
+            max_bytes
+        } else {
+            DEFAULT_METADATA_CACHE_MAX_ENTRY_BYTES
+        };
+        Self {
+            max_bytes,
+            max_entry_bytes,
+        }
+    }
+
+    /// Disable metadata read caching.
+    pub const fn disabled() -> Self {
+        Self {
+            max_bytes: 0,
+            max_entry_bytes: 0,
+        }
+    }
+
+    /// Set the maximum size of a single metadata read admitted to the cache.
+    pub const fn with_max_entry_bytes(mut self, max_entry_bytes: usize) -> Self {
+        self.max_entry_bytes = max_entry_bytes;
+        self
+    }
+
+    /// Return the total metadata-cache byte budget.
+    pub const fn max_bytes(&self) -> usize {
+        self.max_bytes
+    }
+
+    /// Return the maximum size of one cached metadata entry.
+    pub const fn max_entry_bytes(&self) -> usize {
+        self.max_entry_bytes
+    }
+
+    /// Whether metadata read caching is enabled.
+    pub const fn is_enabled(&self) -> bool {
+        self.max_bytes > 0 && self.max_entry_bytes > 0
+    }
+}
+
+impl Default for MetadataCacheConfig {
+    fn default() -> Self {
+        Self::disabled()
+    }
+}
+
 /// A random-access, read-only source of the bytes of an HDF5 file.
 ///
 /// Offsets are `u64` (HDF5's native address width); lengths of individual reads
@@ -137,6 +208,16 @@ pub trait FileSource {
         let mut buf = vec![0u8; len];
         self.read_at(offset, &mut buf)?;
         Ok(buf)
+    }
+
+    /// Read metadata bytes, allowing source implementations to apply a bounded
+    /// metadata cache.
+    ///
+    /// The default implementation performs an uncached exact read. Raw dataset
+    /// payload readers intentionally call [`read_exact_at`](Self::read_exact_at)
+    /// instead, so a metadata cache does not retain user data chunks.
+    fn read_metadata_at(&self, offset: u64, len: usize) -> Result<Vec<u8>, FormatError> {
+        self.read_exact_at(offset, len)
     }
 }
 
@@ -202,6 +283,155 @@ impl<T: AsRef<[u8]>> FileSource for BytesSource<T> {
         }
         buf.copy_from_slice(&bytes[start..end]);
         Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Metadata-caching wrapper (std)
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "std")]
+struct CachedMetadataRead {
+    offset: u64,
+    len: usize,
+    bytes: Vec<u8>,
+    last_access: u64,
+}
+
+#[cfg(feature = "std")]
+struct MetadataReadCache {
+    entries: Vec<CachedMetadataRead>,
+    current_bytes: usize,
+    tick: u64,
+}
+
+#[cfg(feature = "std")]
+impl MetadataReadCache {
+    fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+            current_bytes: 0,
+            tick: 0,
+        }
+    }
+
+    fn get(&mut self, offset: u64, len: usize) -> Option<Vec<u8>> {
+        self.tick = self.tick.wrapping_add(1);
+        let tick = self.tick;
+        for entry in &mut self.entries {
+            if entry.offset == offset && entry.len == len {
+                entry.last_access = tick;
+                return Some(entry.bytes.clone());
+            }
+        }
+        None
+    }
+
+    fn insert(&mut self, offset: u64, len: usize, bytes: Vec<u8>, max_bytes: usize) {
+        if len == 0 || bytes.len() > max_bytes {
+            return;
+        }
+
+        self.tick = self.tick.wrapping_add(1);
+        let tick = self.tick;
+
+        for entry in &mut self.entries {
+            if entry.offset == offset && entry.len == len {
+                self.current_bytes = self.current_bytes - entry.bytes.len() + bytes.len();
+                entry.bytes = bytes;
+                entry.last_access = tick;
+                self.evict_to_budget(max_bytes);
+                return;
+            }
+        }
+
+        self.current_bytes += bytes.len();
+        self.entries.push(CachedMetadataRead {
+            offset,
+            len,
+            bytes,
+            last_access: tick,
+        });
+        self.evict_to_budget(max_bytes);
+    }
+
+    fn evict_to_budget(&mut self, max_bytes: usize) {
+        while self.current_bytes > max_bytes && !self.entries.is_empty() {
+            let lru_idx = self
+                .entries
+                .iter()
+                .enumerate()
+                .min_by_key(|(_, entry)| entry.last_access)
+                .map(|(idx, _)| idx)
+                .unwrap();
+            let removed = self.entries.swap_remove(lru_idx);
+            self.current_bytes -= removed.bytes.len();
+        }
+    }
+}
+
+/// A [`FileSource`] wrapper with a bounded cache for metadata reads.
+///
+/// The wrapper only caches calls to [`FileSource::read_metadata_at`]. Plain
+/// [`FileSource::read_exact_at`] calls still go directly to the inner source,
+/// which keeps raw dataset payloads out of the metadata cache.
+#[cfg(feature = "std")]
+pub struct MetadataCachingSource<S> {
+    inner: S,
+    config: MetadataCacheConfig,
+    cache: std::sync::Mutex<MetadataReadCache>,
+}
+
+#[cfg(feature = "std")]
+impl<S> MetadataCachingSource<S> {
+    /// Wrap a source with the supplied metadata-cache configuration.
+    pub fn new(inner: S, config: MetadataCacheConfig) -> Self {
+        Self {
+            inner,
+            config,
+            cache: std::sync::Mutex::new(MetadataReadCache::new()),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<S: FileSource> FileSource for MetadataCachingSource<S> {
+    fn len(&self) -> u64 {
+        self.inner.len()
+    }
+
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), FormatError> {
+        self.inner.read_at(offset, buf)
+    }
+
+    fn read_exact_at(&self, offset: u64, len: usize) -> Result<Vec<u8>, FormatError> {
+        self.inner.read_exact_at(offset, len)
+    }
+
+    fn read_metadata_at(&self, offset: u64, len: usize) -> Result<Vec<u8>, FormatError> {
+        if !self.config.is_enabled()
+            || len == 0
+            || len > self.config.max_entry_bytes
+            || len > self.config.max_bytes
+        {
+            return self.inner.read_metadata_at(offset, len);
+        }
+
+        if let Some(bytes) = self
+            .cache
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get(offset, len)
+        {
+            return Ok(bytes);
+        }
+
+        let bytes = self.inner.read_metadata_at(offset, len)?;
+        self.cache
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .insert(offset, len, bytes.clone(), self.config.max_bytes);
+        Ok(bytes)
     }
 }
 
@@ -360,6 +590,48 @@ mod tests {
         let mut buf = [0u8; 2];
         r.read_at(1, &mut buf).unwrap();
         assert_eq!(buf, [8, 7]);
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn metadata_cache_caches_only_metadata_reads() {
+        use std::sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        };
+
+        struct CountingSource {
+            data: Vec<u8>,
+            reads: Arc<AtomicUsize>,
+        }
+
+        impl FileSource for CountingSource {
+            fn len(&self) -> u64 {
+                self.data.len() as u64
+            }
+
+            fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), FormatError> {
+                self.reads.fetch_add(1, Ordering::SeqCst);
+                BytesSource::new(&self.data).read_at(offset, buf)
+            }
+        }
+
+        let reads = Arc::new(AtomicUsize::new(0));
+        let source = MetadataCachingSource::new(
+            CountingSource {
+                data: (0u8..16).collect(),
+                reads: Arc::clone(&reads),
+            },
+            MetadataCacheConfig::new(16),
+        );
+
+        assert_eq!(source.read_metadata_at(4, 4).unwrap(), vec![4, 5, 6, 7]);
+        assert_eq!(source.read_metadata_at(4, 4).unwrap(), vec![4, 5, 6, 7]);
+        assert_eq!(reads.load(Ordering::SeqCst), 1);
+
+        assert_eq!(source.read_exact_at(4, 4).unwrap(), vec![4, 5, 6, 7]);
+        assert_eq!(source.read_exact_at(4, 4).unwrap(), vec![4, 5, 6, 7]);
+        assert_eq!(reads.load(Ordering::SeqCst), 3);
     }
 
     #[cfg(feature = "std")]

--- a/src/superblock.rs
+++ b/src/superblock.rs
@@ -137,7 +137,7 @@ impl Superblock {
     ) -> Result<Superblock, FormatError> {
         let available = source.len().saturating_sub(signature_offset);
         let window = available.min(MAX_SUPERBLOCK_LEN).to_usize()?;
-        let buf = source.read_exact_at(signature_offset, window)?;
+        let buf = source.read_metadata_at(signature_offset, window)?;
         // The window begins at the signature, so within `buf` it sits at 0.
         Self::parse(&buf, 0)
     }

--- a/tests/streaming_reader.rs
+++ b/tests/streaming_reader.rs
@@ -7,7 +7,7 @@
 //! Fixed-Array / Extensible-Array chunked data reads — all from a `Read + Seek`
 //! source that never buffers the whole file.
 
-use hdf5_pure::{File, FileBuilder};
+use hdf5_pure::{ChunkCacheConfig, File, FileAccessOptions, FileBuilder, MetadataCacheConfig};
 
 #[test]
 fn open_streaming_matches_buffered() {
@@ -99,4 +99,30 @@ fn open_streaming_matches_buffered() {
             .read_i32()
             .unwrap()
     );
+}
+
+#[test]
+fn open_streaming_with_access_options_reads_chunked_data() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("streaming_options.h5");
+    let data: Vec<i32> = (0..256).map(|i| i * 2).collect();
+
+    {
+        let mut b = FileBuilder::new();
+        b.create_dataset("chunked")
+            .with_i32_data(&data)
+            .with_shape(&[256])
+            .with_chunks(&[32]);
+        b.write(&path).unwrap();
+    }
+
+    let options = FileAccessOptions::new()
+        .with_metadata_cache(MetadataCacheConfig::new(4096).with_max_entry_bytes(512))
+        .with_chunk_cache(ChunkCacheConfig::disabled());
+    let file = File::open_streaming_with_options(&path, options).unwrap();
+    assert_eq!(file.access_options(), options);
+
+    let dataset = file.dataset("chunked").unwrap();
+    assert_eq!(dataset.read_i32().unwrap(), data);
+    assert_eq!(dataset.read_i32().unwrap(), data);
 }


### PR DESCRIPTION
## Summary
- add FileAccessOptions, MetadataCacheConfig, and ChunkCacheConfig for read-time memory controls
- route streaming metadata parser reads through a bounded metadata cache while keeping raw payload reads uncached
- make per-dataset chunk cache limits configurable, including a disabled mode, and apply them to streaming chunked reads
- document the new streaming access options and add regression coverage

## Tests
- cargo test
- cargo check --no-default-features
- cargo clippy --all-targets

Closes #46