### PR TITLE
Add H5Pset_cache-style chunk cache options

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,14 +123,14 @@ let values = ds.read_f64().unwrap();  // only this dataset's chunks are read
 
 The reading API is identical to `File::open`; only the backing store differs. Dataset reads are fully supported: contiguous, compact, and every chunk-index layout (B-tree v1, fixed array, and extensible array). Two limits apply to the streaming backend that in-memory reading does not have: only latest-format (v2) groups resolve along a path (a v1 symbol-table group is rejected), and reading attributes is not yet supported. `open_streaming` requires the `std` filesystem.
 
-Use `File::open_streaming_with_options` to bound retained metadata and dataset chunk cache memory. `MetadataCacheConfig` controls the streaming metadata cache, while `ChunkCacheConfig` controls decompressed chunk data and whether parsed chunk indexes are retained between repeated reads of the same dataset.
+Use `File::open_streaming_with_options` to bound retained metadata and dataset chunk cache memory. `MetadataCacheConfig` mirrors the memory-budget role of `H5Pset_mdc_config`; `ChunkCacheConfig` mirrors the raw-data chunk-cache settings from `H5Pset_cache`, controlling decompressed chunk data and whether parsed chunk indexes are retained between repeated reads of the same dataset.
 
 ```rust
 use hdf5_pure::{ChunkCacheConfig, File, FileAccessOptions, MetadataCacheConfig};
 
 let options = FileAccessOptions::new()
     .with_metadata_cache(MetadataCacheConfig::new(8 * 1024 * 1024).with_max_entry_bytes(64 * 1024))
-    .with_chunk_cache(ChunkCacheConfig::new().with_max_bytes(256 * 1024));
+    .with_chunk_cache(ChunkCacheConfig::from_h5p_cache(521, 256 * 1024));
 let file = File::open_streaming_with_options("huge.h5", options).unwrap();
 ```
 

--- a/src/chunk_cache.rs
+++ b/src/chunk_cache.rs
@@ -206,7 +206,9 @@ pub const DEFAULT_MAX_SLOTS: usize = 16;
 
 /// Configuration for a per-dataset chunk cache.
 ///
-/// The byte and slot limits apply to decompressed raw chunk data. The optional
+/// The byte and slot limits are the `hdf5-pure` counterpart of the
+/// `rdcc_nbytes` and `rdcc_nslots` raw-data chunk-cache settings from HDF5's
+/// `H5Pset_cache`. They apply to decompressed raw chunk data. The optional
 /// chunk-index cache controls whether `hdf5-pure` retains the parsed chunk
 /// address index between reads of the same [`crate::Dataset`]. Disabling the
 /// index cache lowers retained metadata memory at the cost of re-scanning the
@@ -225,6 +227,22 @@ impl ChunkCacheConfig {
         Self {
             max_bytes: DEFAULT_CACHE_BYTES,
             max_slots: DEFAULT_MAX_SLOTS,
+            cache_index: true,
+        }
+    }
+
+    /// Create a config from HDF5 `H5Pset_cache` raw data chunk-cache values.
+    ///
+    /// `rdcc_nslots` maps to the maximum retained chunk slots and
+    /// `rdcc_nbytes` maps to the maximum retained decompressed chunk bytes.
+    /// Modern HDF5 ignores `H5Pset_cache`'s `mdc_nelmts`; use
+    /// [`crate::MetadataCacheConfig`] for the metadata-cache budget. The
+    /// `rdcc_w0` preemption policy has no direct equivalent because this
+    /// read-only cache uses strict LRU eviction.
+    pub const fn from_h5p_cache(rdcc_nslots: usize, rdcc_nbytes: usize) -> Self {
+        Self {
+            max_bytes: rdcc_nbytes,
+            max_slots: rdcc_nslots,
             cache_index: true,
         }
     }
@@ -445,8 +463,16 @@ impl ChunkCache {
     /// The data is stored in a [`CacheAlignedBuffer`] so subsequent reads
     /// return cache-line-aligned memory.
     pub fn put_decompressed(&self, coord: ChunkCoord, data: Vec<u8>) {
+        if !self.accepts_decompressed_len(data.len()) {
+            return;
+        }
         let aligned = CacheAlignedBuffer::from_slice(&data);
         self.put_decompressed_aligned(coord, aligned);
+    }
+
+    fn accepts_decompressed_len(&self, data_len: usize) -> bool {
+        let inner = self.inner.lock().unwrap();
+        inner.max_bytes != 0 && inner.max_slots != 0 && data_len <= inner.max_bytes
     }
 
     /// Insert an already-aligned buffer into the LRU cache.
@@ -627,6 +653,14 @@ mod tests {
         cache.put_decompressed(vec![0], vec![1, 2, 3]);
         assert_eq!(cache.cached_chunk_count(), 0);
         assert_eq!(cache.cached_bytes(), 0);
+    }
+
+    #[test]
+    fn h5p_cache_constructor_maps_raw_data_chunk_settings() {
+        let config = ChunkCacheConfig::from_h5p_cache(521, 2 * 1024 * 1024);
+        assert_eq!(config.max_slots(), 521);
+        assert_eq!(config.max_bytes(), 2 * 1024 * 1024);
+        assert!(config.index_cache_enabled());
     }
 
     #[test]

--- a/src/global_heap.rs
+++ b/src/global_heap.rs
@@ -80,7 +80,7 @@ impl GlobalHeapIndex {
         length_size: u8,
     ) -> Result<Self, FormatError> {
         let header_size = 8 + length_size as usize;
-        let header = source.read_exact_at(offset, header_size)?;
+        let header = source.read_metadata_at(offset, header_size)?;
 
         if header[..4] != GCOL_SIGNATURE {
             return Err(FormatError::InvalidGlobalHeapSignature);
@@ -124,7 +124,7 @@ impl GlobalHeapIndex {
             .checked_add(2)
             .is_some_and(|index_end| index_end <= collection_end)
         {
-            let index_bytes = source.read_exact_at(pos, 2)?;
+            let index_bytes = source.read_metadata_at(pos, 2)?;
             let object_index = u16::from_le_bytes([index_bytes[0], index_bytes[1]]);
             if object_index == 0 {
                 break;
@@ -142,7 +142,7 @@ impl GlobalHeapIndex {
                     available: collection_end.to_usize().unwrap_or(usize::MAX),
                 });
             }
-            let object_header = source.read_exact_at(pos, object_header_size)?;
+            let object_header = source.read_metadata_at(pos, object_header_size)?;
             let object_size = read_length(&object_header, 8, length_size)?;
             let data_address = object_header_end;
             let data_end =
@@ -262,6 +262,45 @@ mod tests {
                 .unwrap(),
             b"world!!!"
         );
+    }
+
+    #[test]
+    fn parse_reads_collection_headers_as_metadata() {
+        use core::cell::Cell;
+
+        struct TrackingSource {
+            data: Vec<u8>,
+            metadata_reads: Cell<usize>,
+            raw_reads: Cell<usize>,
+        }
+
+        impl FileSource for TrackingSource {
+            fn len(&self) -> u64 {
+                self.data.len() as u64
+            }
+
+            fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), FormatError> {
+                self.raw_reads.set(self.raw_reads.get() + 1);
+                BytesSource::new(&self.data).read_at(offset, buf)
+            }
+
+            fn read_metadata_at(&self, offset: u64, len: usize) -> Result<Vec<u8>, FormatError> {
+                self.metadata_reads.set(self.metadata_reads.get() + 1);
+                BytesSource::new(&self.data).read_exact_at(offset, len)
+            }
+        }
+
+        let source = TrackingSource {
+            data: build_collection(&[(1, 1, b"hello"), (2, 1, b"world")], 8),
+            metadata_reads: Cell::new(0),
+            raw_reads: Cell::new(0),
+        };
+
+        let coll = GlobalHeapIndex::parse(&source, 0, 8).unwrap();
+
+        assert_eq!(coll.objects.len(), 2);
+        assert!(source.metadata_reads.get() > 0);
+        assert_eq!(source.raw_reads.get(), 0);
     }
 
     #[test]

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -74,7 +74,9 @@ impl FileSource for SourceView<'_> {
 /// This is the `hdf5-pure` analogue of the HDF5 file access property list
 /// settings relevant to read-time memory usage. The metadata cache only affects
 /// streaming opens; in-memory opens already have the whole file in one buffer.
-/// The chunk cache applies to datasets opened from either backend.
+/// The chunk cache is the file-wide default corresponding to HDF5
+/// `H5Pset_cache`'s raw-data chunk-cache settings and applies to datasets
+/// opened from either backend.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct FileAccessOptions {
     metadata_cache: MetadataCacheConfig,
@@ -96,7 +98,8 @@ impl FileAccessOptions {
         self
     }
 
-    /// Configure the per-dataset chunk cache.
+    /// Configure the per-dataset raw chunk cache used by datasets opened from
+    /// this file. This is the `H5Pset_cache`-style file-wide default.
     pub const fn with_chunk_cache(mut self, chunk_cache: ChunkCacheConfig) -> Self {
         self.chunk_cache = chunk_cache;
         self

--- a/src/source.rs
+++ b/src/source.rs
@@ -230,6 +230,14 @@ impl<S: FileSource + ?Sized> FileSource for &S {
     fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), FormatError> {
         (**self).read_at(offset, buf)
     }
+
+    fn read_exact_at(&self, offset: u64, len: usize) -> Result<Vec<u8>, FormatError> {
+        (**self).read_exact_at(offset, len)
+    }
+
+    fn read_metadata_at(&self, offset: u64, len: usize) -> Result<Vec<u8>, FormatError> {
+        (**self).read_metadata_at(offset, len)
+    }
 }
 
 #[cfg(feature = "std")]
@@ -239,6 +247,14 @@ impl<S: FileSource + ?Sized> FileSource for std::boxed::Box<S> {
     }
     fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), FormatError> {
         (**self).read_at(offset, buf)
+    }
+
+    fn read_exact_at(&self, offset: u64, len: usize) -> Result<Vec<u8>, FormatError> {
+        (**self).read_exact_at(offset, len)
+    }
+
+    fn read_metadata_at(&self, offset: u64, len: usize) -> Result<Vec<u8>, FormatError> {
+        (**self).read_metadata_at(offset, len)
     }
 }
 
@@ -590,6 +606,42 @@ mod tests {
         let mut buf = [0u8; 2];
         r.read_at(1, &mut buf).unwrap();
         assert_eq!(buf, [8, 7]);
+    }
+
+    #[test]
+    fn forwarding_through_reference_preserves_metadata_reads() {
+        use core::cell::Cell;
+
+        struct MetadataSource {
+            metadata_reads: Cell<usize>,
+        }
+
+        impl FileSource for MetadataSource {
+            fn len(&self) -> u64 {
+                16
+            }
+
+            fn read_at(&self, _offset: u64, buf: &mut [u8]) -> Result<(), FormatError> {
+                buf.fill(0);
+                Ok(())
+            }
+
+            fn read_metadata_at(&self, _offset: u64, len: usize) -> Result<Vec<u8>, FormatError> {
+                self.metadata_reads.set(self.metadata_reads.get() + 1);
+                Ok(vec![0xAB; len])
+            }
+        }
+
+        fn read_metadata_via_trait<T: FileSource>(source: T) -> Vec<u8> {
+            source.read_metadata_at(4, 3).unwrap()
+        }
+
+        let source = MetadataSource {
+            metadata_reads: Cell::new(0),
+        };
+
+        assert_eq!(read_metadata_via_trait(&source), vec![0xAB; 3]);
+        assert_eq!(source.metadata_reads.get(), 1);
     }
 
     #[cfg(feature = "std")]


### PR DESCRIPTION
## Summary
- add an H5Pset_cache-style constructor for raw chunk cache slot and byte settings
- route global heap collection metadata through metadata reads and preserve metadata-read forwarding through FileSource wrappers
- avoid aligned-buffer allocation when a decompressed chunk cannot be cached
- document the H5Pset_cache mapping in the read access options

Closes #47

## Tests
- cargo test
- cargo check --no-default-features
- cargo clippy --all-targets