### PR TITLE
Add per-dataset chunk cache access options (H5Pset_chunk_cache)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Per-dataset chunk-cache control: `File::dataset_with_options` / `Group::dataset_with_options` take a `DatasetAccessOptions` that overrides the file-wide chunk-cache default for a single dataset, mirroring HDF5's `H5Pset_chunk_cache` access property list. `Dataset::chunk_cache_config()` reports the effective setting ([#48](https://github.com/stephenberry/hdf5-pure/issues/48)).
+
 ### Fixed
 
 - Read dense groups and dense attributes whose link/attribute names are very long (stored as fractal-heap "huge" objects); previously failed with `InvalidObjectHeaderVersion` ([#63](https://github.com/stephenberry/hdf5-pure/pull/63)).

--- a/README.md
+++ b/README.md
@@ -134,6 +134,18 @@ let options = FileAccessOptions::new()
 let file = File::open_streaming_with_options("huge.h5", options).unwrap();
 ```
 
+To override the chunk cache for a single dataset (HDF5's per-dataset access property list, `H5Pset_chunk_cache`), open it with `dataset_with_options`. The override replaces the file-wide default for that one dataset; other datasets keep the default. `Dataset::chunk_cache_config()` reports the effective setting (`H5Pget_chunk_cache`).
+
+```rust
+use hdf5_pure::{ChunkCacheConfig, DatasetAccessOptions, File};
+
+let file = File::open("data.h5").unwrap();
+// This dataset is read once front-to-back: skip caching its decompressed chunks.
+let dapl = DatasetAccessOptions::new().with_chunk_cache(ChunkCacheConfig::disabled());
+let ds = file.dataset_with_options("scan", dapl).unwrap();
+let values = ds.read_f64().unwrap();
+```
+
 ### In-memory (WASM)
 
 ```rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,7 +191,9 @@ pub use error::Error;
 pub use error::FormatError;
 
 #[cfg(feature = "std")]
-pub use reader::{Dataset, File, FileAccessOptions, Group, is_hdf5, is_hdf5_bytes};
+pub use reader::{
+    Dataset, DatasetAccessOptions, File, FileAccessOptions, Group, is_hdf5, is_hdf5_bytes,
+};
 
 pub use chunk_cache::ChunkCacheConfig;
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -116,6 +116,56 @@ impl FileAccessOptions {
     }
 }
 
+/// Dataset-access options applied when opening a single dataset.
+///
+/// This is the `hdf5-pure` analogue of an HDF5 Dataset Access Property List
+/// (DAPL). Its chunk cache corresponds to `H5Pset_chunk_cache`: it overrides,
+/// for this one dataset, the file-wide chunk-cache default configured with
+/// [`FileAccessOptions::with_chunk_cache`] (the `H5Pset_cache` analogue). When
+/// left unset, the dataset inherits that file-wide default — matching the DAPL
+/// default sentinels (`H5D_CHUNK_CACHE_*_DEFAULT`), which also mean "use the
+/// file's setting".
+///
+/// [`ChunkCacheConfig`] maps `H5Pset_chunk_cache`'s `rdcc_nslots` and
+/// `rdcc_nbytes`; its `rdcc_w0` preemption policy is not modeled, because this
+/// read cache uses strict LRU eviction (as noted on
+/// [`ChunkCacheConfig::from_h5p_cache`]).
+///
+/// Pass it to [`File::dataset_with_options`] or [`Group::dataset_with_options`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct DatasetAccessOptions {
+    chunk_cache: Option<ChunkCacheConfig>,
+}
+
+impl DatasetAccessOptions {
+    /// Create options that inherit every file-wide access default.
+    pub const fn new() -> Self {
+        Self { chunk_cache: None }
+    }
+
+    /// Override the raw chunk cache for this one dataset, ignoring the file-wide
+    /// default. This is the `H5Pset_chunk_cache` analogue.
+    pub const fn with_chunk_cache(mut self, chunk_cache: ChunkCacheConfig) -> Self {
+        self.chunk_cache = Some(chunk_cache);
+        self
+    }
+
+    /// Return the chunk-cache override, or `None` when the dataset inherits the
+    /// file-wide default.
+    pub const fn chunk_cache(&self) -> Option<ChunkCacheConfig> {
+        self.chunk_cache
+    }
+
+    /// Resolve the effective chunk-cache config: the per-dataset override if one
+    /// was set, otherwise the file-wide `default`.
+    const fn resolved_chunk_cache(&self, default: ChunkCacheConfig) -> ChunkCacheConfig {
+        match self.chunk_cache {
+            Some(config) => config,
+            None => default,
+        }
+    }
+}
+
 /// Test whether a file looks like an HDF5 file, without reading it whole.
 ///
 /// This is the spelling of the C library's `H5Fis_accessible` /
@@ -435,16 +485,37 @@ impl File {
     }
 
     /// Resolve a path and return a `Dataset` handle.
+    ///
+    /// The dataset uses the file-wide chunk-cache default (configured with
+    /// [`FileAccessOptions::with_chunk_cache`]). To override the cache for this
+    /// one dataset, use [`dataset_with_options`](Self::dataset_with_options).
     pub fn dataset(&self, path: &str) -> Result<Dataset<'_>, Error> {
+        self.dataset_with_options(path, DatasetAccessOptions::new())
+    }
+
+    /// Resolve a path and return a `Dataset` handle, applying per-dataset
+    /// [`DatasetAccessOptions`] that override file-wide access defaults.
+    ///
+    /// This is the dataset-open-with-access-property-list path (HDF5's DAPL):
+    /// the options' chunk cache corresponds to `H5Pset_chunk_cache` and takes
+    /// precedence, for this dataset only, over the `H5Pset_cache`-style
+    /// file-wide default.
+    pub fn dataset_with_options(
+        &self,
+        path: &str,
+        options: DatasetAccessOptions,
+    ) -> Result<Dataset<'_>, Error> {
         let addr = self.resolve_path(path)?;
         let hdr = self.parse_header(addr)?;
         if !has_message(&hdr, MessageType::DataLayout) {
             return Err(Error::NotADataset(path.to_string()));
         }
+        let chunk_cache = options.resolved_chunk_cache(self.access_options.chunk_cache);
         Ok(Dataset {
             file: self,
             header: hdr,
-            chunk_cache: ChunkCache::with_config(self.access_options.chunk_cache),
+            chunk_cache: ChunkCache::with_config(chunk_cache),
+            chunk_cache_config: chunk_cache,
         })
     }
 
@@ -706,7 +777,22 @@ impl<'f> Group<'f> {
     }
 
     /// Get a dataset within this group by name.
+    ///
+    /// The dataset uses the file-wide chunk-cache default. To override the cache
+    /// for this one dataset, use
+    /// [`dataset_with_options`](Self::dataset_with_options).
     pub fn dataset(&self, name: &str) -> Result<Dataset<'f>, Error> {
+        self.dataset_with_options(name, DatasetAccessOptions::new())
+    }
+
+    /// Get a dataset within this group by name, applying per-dataset
+    /// [`DatasetAccessOptions`] that override file-wide access defaults (HDF5's
+    /// DAPL; see `H5Pset_chunk_cache`).
+    pub fn dataset_with_options(
+        &self,
+        name: &str,
+        options: DatasetAccessOptions,
+    ) -> Result<Dataset<'f>, Error> {
         let entries = self.children()?;
         let entry = entries
             .iter()
@@ -716,10 +802,12 @@ impl<'f> Group<'f> {
         if !has_message(&hdr, MessageType::DataLayout) {
             return Err(Error::NotADataset(name.to_string()));
         }
+        let chunk_cache = options.resolved_chunk_cache(self.file.access_options.chunk_cache);
         Ok(Dataset {
             file: self.file,
             header: hdr,
-            chunk_cache: ChunkCache::with_config(self.file.access_options.chunk_cache),
+            chunk_cache: ChunkCache::with_config(chunk_cache),
+            chunk_cache_config: chunk_cache,
         })
     }
 
@@ -753,6 +841,9 @@ pub struct Dataset<'f> {
     // Held per-dataset: the chunk index is keyed only by chunk coordinate, so
     // a file-level cache would alias chunk addresses across datasets.
     chunk_cache: ChunkCache,
+    // The effective chunk-cache config for this dataset: the file-wide default
+    // or a per-dataset DAPL override. Reported by `chunk_cache_config`.
+    chunk_cache_config: ChunkCacheConfig,
 }
 
 impl<'f> std::fmt::Debug for Dataset<'f> {
@@ -764,6 +855,16 @@ impl<'f> std::fmt::Debug for Dataset<'f> {
 }
 
 impl<'f> Dataset<'f> {
+    /// The effective raw chunk-cache configuration for this dataset.
+    ///
+    /// This reflects the per-dataset [`DatasetAccessOptions`] override when one
+    /// was supplied to [`File::dataset_with_options`] /
+    /// [`Group::dataset_with_options`], otherwise the file-wide default. It is
+    /// the read-side analogue of HDF5's `H5Pget_chunk_cache`.
+    pub const fn chunk_cache_config(&self) -> ChunkCacheConfig {
+        self.chunk_cache_config
+    }
+
     /// Returns the shape (dimensions) of the dataset.
     pub fn shape(&self) -> Result<Vec<u64>, Error> {
         let ds = self.dataspace()?;
@@ -1083,4 +1184,70 @@ fn is_group(header: &ObjectHeader) -> bool {
             || m.msg_type == MessageType::Link
             || m.msg_type == MessageType::SymbolTable
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::FileBuilder;
+
+    /// One 256-element i32 dataset, chunked into 32-element chunks, in memory.
+    fn chunked_file_bytes() -> Vec<u8> {
+        let data: Vec<i32> = (0..256).collect();
+        let mut b = FileBuilder::new();
+        b.create_dataset("chunked")
+            .with_i32_data(&data)
+            .with_shape(&[256])
+            .with_chunks(&[32]);
+        b.finish().unwrap()
+    }
+
+    // The DAPL override must drive the *live* `ChunkCache`, not merely the value
+    // reported by `chunk_cache_config()`. These assertions reach the crate's
+    // `#[cfg(test)]` cache introspection (unavailable to integration tests), so
+    // they fail if the resolved config ever stops flowing into the real cache.
+
+    #[test]
+    fn enabled_override_populates_live_cache_over_disabled_file_default() {
+        let file = File::from_bytes_with_options(
+            chunked_file_bytes(),
+            FileAccessOptions::new().with_chunk_cache(ChunkCacheConfig::disabled()),
+        )
+        .unwrap();
+
+        let ds = file
+            .dataset_with_options(
+                "chunked",
+                DatasetAccessOptions::new().with_chunk_cache(ChunkCacheConfig::new()),
+            )
+            .unwrap();
+        assert_eq!(ds.read_i32().unwrap(), (0..256).collect::<Vec<i32>>());
+
+        // The enabled override built the chunk index and retained chunks; the
+        // disabled file default would have left both empty.
+        assert!(ds.chunk_cache.has_index());
+        assert!(ds.chunk_cache.cached_chunk_count() > 0);
+    }
+
+    #[test]
+    fn disabled_override_suppresses_live_cache_over_enabled_file_default() {
+        let file = File::from_bytes_with_options(
+            chunked_file_bytes(),
+            FileAccessOptions::new().with_chunk_cache(ChunkCacheConfig::new()),
+        )
+        .unwrap();
+
+        let ds = file
+            .dataset_with_options(
+                "chunked",
+                DatasetAccessOptions::new().with_chunk_cache(ChunkCacheConfig::disabled()),
+            )
+            .unwrap();
+        assert_eq!(ds.read_i32().unwrap(), (0..256).collect::<Vec<i32>>());
+
+        // The disabled override suppressed the index and chunk retention; the
+        // enabled file default would have populated both.
+        assert!(!ds.chunk_cache.has_index());
+        assert_eq!(ds.chunk_cache.cached_chunk_count(), 0);
+    }
 }

--- a/tests/dataset_access_options.rs
+++ b/tests/dataset_access_options.rs
@@ -1,0 +1,140 @@
+//! Per-dataset access options (DAPL): the `H5Pset_chunk_cache` analogue, which
+//! overrides the file-wide `H5Pset_cache`-style chunk-cache default for a single
+//! dataset. See issue #48.
+
+use hdf5_pure::{ChunkCacheConfig, DatasetAccessOptions, File, FileAccessOptions, FileBuilder};
+
+/// Write a small chunked dataset, plus one nested in a group, and return the
+/// file path (kept alive by the returned `TempDir`).
+fn write_fixture() -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("dapl.h5");
+    let data: Vec<i32> = (0..256).collect();
+    {
+        let mut b = FileBuilder::new();
+        b.create_dataset("chunked")
+            .with_i32_data(&data)
+            .with_shape(&[256])
+            .with_chunks(&[32]);
+        let mut g = b.create_group("grp");
+        g.create_dataset("inner")
+            .with_i32_data(&data)
+            .with_shape(&[256])
+            .with_chunks(&[32]);
+        b.add_group(g.finish());
+        b.write(&path).unwrap();
+    }
+    (dir, path)
+}
+
+#[test]
+fn dataset_without_options_inherits_file_wide_default() {
+    let (_dir, path) = write_fixture();
+    let file_default = ChunkCacheConfig::from_h5p_cache(64, 128 * 1024);
+    let file = File::open_with_options(
+        &path,
+        FileAccessOptions::new().with_chunk_cache(file_default),
+    )
+    .unwrap();
+
+    // `dataset` and `dataset_with_options(new())` both inherit the file default.
+    assert_eq!(
+        file.dataset("chunked").unwrap().chunk_cache_config(),
+        file_default
+    );
+    assert_eq!(
+        file.dataset_with_options("chunked", DatasetAccessOptions::new())
+            .unwrap()
+            .chunk_cache_config(),
+        file_default
+    );
+}
+
+#[test]
+fn per_dataset_override_takes_precedence_over_file_default() {
+    let (_dir, path) = write_fixture();
+    let file_default = ChunkCacheConfig::new();
+    let override_cfg = ChunkCacheConfig::from_h5p_cache(8, 16 * 1024).with_index_cache(false);
+    assert_ne!(file_default, override_cfg);
+
+    let file = File::open_with_options(
+        &path,
+        FileAccessOptions::new().with_chunk_cache(file_default),
+    )
+    .unwrap();
+
+    let options = DatasetAccessOptions::new().with_chunk_cache(override_cfg);
+    assert_eq!(options.chunk_cache(), Some(override_cfg));
+
+    let ds = file.dataset_with_options("chunked", options).unwrap();
+    assert_eq!(ds.chunk_cache_config(), override_cfg);
+
+    // A sibling handle opened without the override still sees the file default,
+    // proving the override is scoped to the one dataset handle.
+    let sibling = file.dataset("chunked").unwrap();
+    assert_eq!(sibling.chunk_cache_config(), file_default);
+}
+
+#[test]
+fn override_with_disabled_cache_still_reads_correct_data() {
+    let (_dir, path) = write_fixture();
+    let expected: Vec<i32> = (0..256).collect();
+    let file = File::open(&path).unwrap();
+
+    let ds = file
+        .dataset_with_options(
+            "chunked",
+            DatasetAccessOptions::new().with_chunk_cache(ChunkCacheConfig::disabled()),
+        )
+        .unwrap();
+    assert_eq!(ds.chunk_cache_config(), ChunkCacheConfig::disabled());
+    // Read twice: with the cache disabled every read re-fetches, and both must
+    // still produce identical, correct data.
+    assert_eq!(ds.read_i32().unwrap(), expected);
+    assert_eq!(ds.read_i32().unwrap(), expected);
+}
+
+#[test]
+fn group_dataset_with_options_overrides_chunk_cache() {
+    let (_dir, path) = write_fixture();
+    let expected: Vec<i32> = (0..256).collect();
+    let override_cfg = ChunkCacheConfig::from_h5p_cache(4, 8 * 1024);
+    let file = File::open(&path).unwrap();
+    let group = file.group("grp").unwrap();
+
+    let inherited = group.dataset("inner").unwrap();
+    assert_eq!(
+        inherited.chunk_cache_config(),
+        file.access_options().chunk_cache()
+    );
+
+    let overridden = group
+        .dataset_with_options("inner", DatasetAccessOptions::new().with_chunk_cache(override_cfg))
+        .unwrap();
+    assert_eq!(overridden.chunk_cache_config(), override_cfg);
+    assert_eq!(overridden.read_i32().unwrap(), expected);
+}
+
+#[test]
+fn streaming_backend_honors_per_dataset_override() {
+    let (_dir, path) = write_fixture();
+    let expected: Vec<i32> = (0..256).collect();
+    let override_cfg = ChunkCacheConfig::disabled();
+    let file = File::open_streaming(&path).unwrap();
+
+    let ds = file
+        .dataset_with_options(
+            "chunked",
+            DatasetAccessOptions::new().with_chunk_cache(override_cfg),
+        )
+        .unwrap();
+    assert_eq!(ds.chunk_cache_config(), override_cfg);
+    assert_eq!(ds.read_i32().unwrap(), expected);
+    assert_eq!(ds.read_i32().unwrap(), expected);
+}
+
+#[test]
+fn default_options_equal_new() {
+    assert_eq!(DatasetAccessOptions::default(), DatasetAccessOptions::new());
+    assert_eq!(DatasetAccessOptions::new().chunk_cache(), None);
+}

--- a/tests/dataset_access_options.rs
+++ b/tests/dataset_access_options.rs
@@ -109,7 +109,10 @@ fn group_dataset_with_options_overrides_chunk_cache() {
     );
 
     let overridden = group
-        .dataset_with_options("inner", DatasetAccessOptions::new().with_chunk_cache(override_cfg))
+        .dataset_with_options(
+            "inner",
+            DatasetAccessOptions::new().with_chunk_cache(override_cfg),
+        )
         .unwrap();
     assert_eq!(overridden.chunk_cache_config(), override_cfg);
     assert_eq!(overridden.read_i32().unwrap(), expected);


### PR DESCRIPTION
## Summary

Adds a Dataset Access Property List (DAPL) analogue so a single dataset can override the file-wide chunk-cache default. Issue #48 asked for `H5Pset_chunk_cache`; the clarifying comment pinned it to per-dataset (`dapl`) support. PR #66 already added the file-wide `H5Pset_cache` analogue (`FileAccessOptions::with_chunk_cache`); this adds the missing per-dataset override that takes precedence over it.

## API

- `DatasetAccessOptions` — the DAPL analogue. Holds `Option<ChunkCacheConfig>`: `None` inherits the file-wide default, `Some` overrides it for that one dataset (mirroring HDF5's `H5D_CHUNK_CACHE_*_DEFAULT` sentinels). Its doc notes that `rdcc_w0` is not modeled (strict-LRU eviction).
- `File::dataset_with_options(path, opts)` / `Group::dataset_with_options(name, opts)` — open a dataset with a DAPL, matching the existing `*_with_options` naming. The plain `dataset()` methods delegate with defaults, so existing behavior is unchanged.
- `Dataset::chunk_cache_config()` — reports the effective setting (`H5Pget_chunk_cache` analogue).
- `DatasetAccessOptions` re-exported from the crate root.

## Tests

- `tests/dataset_access_options.rs` (6 tests): inherit-vs-override, per-handle scoping, disabled-cache reads, `Group::dataset_with_options`, streaming backend, default/new equivalence.
- Unit tests in `src/reader.rs` reach the crate-internal `ChunkCache` to prove the resolved config drives the *live* cache (not just the reported value), in both directions. Verified by applying the regression they target and confirming they fail while the integration tests stay green.

`cargo test` (all green), `cargo clippy --all-targets` (clean), `cargo check --no-default-features` (compiles), and `cargo doc` introduces no new warnings.

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)