### PR TITLE
Add public Dataset::chunk_cache_stats() accessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- `Dataset::chunk_cache_stats()` reports a read-only snapshot of a dataset's chunk-cache occupancy (index loaded, retained chunks, retained bytes), so callers can confirm their chunk-cache tuning is taking effect.
+
 ### Fixed
 
 - Read dense groups and dense attributes whose link/attribute names are very long (stored as fractal-heap "huge" objects); previously failed with `InvalidObjectHeaderVersion` ([#63](https://github.com/stephenberry/hdf5-pure/pull/63)).

--- a/README.md
+++ b/README.md
@@ -134,6 +134,18 @@ let options = FileAccessOptions::new()
 let file = File::open_streaming_with_options("huge.h5", options).unwrap();
 ```
 
+To confirm the cache is behaving as configured, `Dataset::chunk_cache_stats()` reports a read-only snapshot (index loaded, retained chunks, retained bytes) after a read.
+
+```rust
+use hdf5_pure::File;
+
+let file = File::open("data.h5").unwrap();
+let ds = file.dataset("signal").unwrap();
+let _ = ds.read_f64().unwrap();
+let stats = ds.chunk_cache_stats();
+assert!(stats.cached_chunks() > 0); // chunks were retained for reuse
+```
+
 ### In-memory (WASM)
 
 ```rust

--- a/src/chunk_cache.rs
+++ b/src/chunk_cache.rs
@@ -571,7 +571,6 @@ impl ChunkCache {
         inner.current_bytes = 0;
         inner.tick = 0;
     }
-
 }
 
 impl Default for ChunkCache {

--- a/src/chunk_cache.rs
+++ b/src/chunk_cache.rs
@@ -296,6 +296,37 @@ impl Default for ChunkCacheConfig {
     }
 }
 
+/// A read-only snapshot of a dataset's chunk-cache occupancy.
+///
+/// Returned by [`crate::Dataset::chunk_cache_stats`]. Use it to confirm a
+/// chunk-cache configuration is taking effect: after reading a chunked dataset,
+/// an enabled cache reports a loaded index and retained chunks, a disabled one
+/// (or one over its byte/slot budget) reports fewer or none. The counts are a
+/// point-in-time view and change as further reads populate or evict chunks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ChunkCacheStats {
+    index_loaded: bool,
+    cached_chunks: usize,
+    cached_bytes: usize,
+}
+
+impl ChunkCacheStats {
+    /// Whether the parsed chunk index is currently held in memory.
+    pub const fn index_loaded(&self) -> bool {
+        self.index_loaded
+    }
+
+    /// Number of decompressed chunks currently retained.
+    pub const fn cached_chunks(&self) -> usize {
+        self.cached_chunks
+    }
+
+    /// Total bytes of decompressed chunk data currently retained.
+    pub const fn cached_bytes(&self) -> usize {
+        self.cached_bytes
+    }
+}
+
 // ---------------------------------------------------------------------------
 // LRU entry
 // ---------------------------------------------------------------------------
@@ -383,13 +414,22 @@ impl ChunkCache {
         }
     }
 
-    // ----- Index operations -----
-
-    /// Returns `true` if the chunk index has been built.
-    #[cfg(test)]
-    pub fn has_index(&self) -> bool {
-        self.inner.lock().unwrap().index.is_some()
+    /// Snapshot the current chunk-cache occupancy (index loaded, retained
+    /// chunk count, retained bytes).
+    ///
+    /// This is the public, read-only way to observe whether a chunk-cache
+    /// configuration is taking effect. It locks the cache briefly to read a
+    /// consistent snapshot.
+    pub fn stats(&self) -> ChunkCacheStats {
+        let inner = self.inner.lock().unwrap();
+        ChunkCacheStats {
+            index_loaded: inner.index.is_some(),
+            cached_chunks: inner.slots.len(),
+            cached_bytes: inner.current_bytes,
+        }
     }
+
+    // ----- Index operations -----
 
     /// Build the chunk index from a pre-collected list of `ChunkInfo`.
     ///
@@ -532,23 +572,6 @@ impl ChunkCache {
         inner.tick = 0;
     }
 
-    /// Number of decompressed chunks currently cached.
-    ///
-    /// Currently only exercised by unit tests; gated so it is not shipped as
-    /// dead code.
-    #[cfg(test)]
-    pub fn cached_chunk_count(&self) -> usize {
-        self.inner.lock().unwrap().slots.len()
-    }
-
-    /// Total bytes of decompressed data currently cached.
-    ///
-    /// Currently only exercised by unit tests; gated so it is not shipped as
-    /// dead code.
-    #[cfg(test)]
-    pub fn cached_bytes(&self) -> usize {
-        self.inner.lock().unwrap().current_bytes
-    }
 }
 
 impl Default for ChunkCache {
@@ -582,7 +605,7 @@ mod tests {
             make_chunk(vec![10, 0, 0], 0x2000, 80),
         ];
         cache.populate_index(&chunks, 2); // rank=2, truncate to [0,0] and [10,0]
-        assert!(cache.has_index());
+        assert!(cache.stats().index_loaded());
 
         let mut addrs: Vec<u64> = cache
             .all_indexed_chunks()
@@ -608,14 +631,14 @@ mod tests {
 
         cache.put_decompressed(vec![0], vec![1; 10]);
         cache.put_decompressed(vec![1], vec![2; 10]);
-        assert_eq!(cache.cached_chunk_count(), 2);
+        assert_eq!(cache.stats().cached_chunks(), 2);
 
         // Access slot 0 to make it more recent
         cache.get_decompressed(&[0]);
 
         // Insert slot 2 — should evict slot 1 (LRU)
         cache.put_decompressed(vec![2], vec![3; 10]);
-        assert_eq!(cache.cached_chunk_count(), 2);
+        assert_eq!(cache.stats().cached_chunks(), 2);
 
         assert!(cache.get_decompressed(&[0]).is_some());
         assert!(cache.get_decompressed(&[1]).is_none()); // evicted
@@ -628,11 +651,11 @@ mod tests {
 
         cache.put_decompressed(vec![0], vec![0; 20]);
         cache.put_decompressed(vec![1], vec![0; 20]);
-        assert_eq!(cache.cached_bytes(), 40);
+        assert_eq!(cache.stats().cached_bytes(), 40);
 
         // This needs 20 bytes but only 10 free — evict LRU
         cache.put_decompressed(vec![2], vec![0; 20]);
-        assert!(cache.cached_bytes() <= 50);
+        assert!(cache.stats().cached_bytes() <= 50);
         assert!(cache.get_decompressed(&[0]).is_none()); // evicted (LRU)
     }
 
@@ -640,7 +663,7 @@ mod tests {
     fn oversized_chunk_not_cached() {
         let cache = ChunkCache::with_capacity(10, 16);
         cache.put_decompressed(vec![0], vec![0; 100]); // too big
-        assert_eq!(cache.cached_chunk_count(), 0);
+        assert_eq!(cache.stats().cached_chunks(), 0);
     }
 
     #[test]
@@ -648,11 +671,11 @@ mod tests {
         let cache = ChunkCache::with_config(ChunkCacheConfig::disabled());
         let chunks = vec![make_chunk(vec![0, 0], 0x1000, 80)];
         cache.populate_index(&chunks, 1);
-        assert!(!cache.has_index());
+        assert!(!cache.stats().index_loaded());
 
         cache.put_decompressed(vec![0], vec![1, 2, 3]);
-        assert_eq!(cache.cached_chunk_count(), 0);
-        assert_eq!(cache.cached_bytes(), 0);
+        assert_eq!(cache.stats().cached_chunks(), 0);
+        assert_eq!(cache.stats().cached_bytes(), 0);
     }
 
     #[test]
@@ -671,9 +694,9 @@ mod tests {
         cache.put_decompressed(vec![0], vec![1, 2, 3]);
 
         cache.clear();
-        assert!(!cache.has_index());
-        assert_eq!(cache.cached_chunk_count(), 0);
-        assert_eq!(cache.cached_bytes(), 0);
+        assert!(!cache.stats().index_loaded());
+        assert_eq!(cache.stats().cached_chunks(), 0);
+        assert_eq!(cache.stats().cached_bytes(), 0);
     }
 
     #[test]
@@ -681,8 +704,8 @@ mod tests {
         let cache = ChunkCache::new();
         cache.put_decompressed(vec![0], vec![1, 2, 3]);
         cache.put_decompressed(vec![0], vec![1, 2, 3]); // duplicate
-        assert_eq!(cache.cached_chunk_count(), 1);
-        assert_eq!(cache.cached_bytes(), 3);
+        assert_eq!(cache.stats().cached_chunks(), 1);
+        assert_eq!(cache.stats().cached_bytes(), 3);
     }
 
     // --- CacheAlignedBuffer tests ---

--- a/src/chunked_read.rs
+++ b/src/chunked_read.rs
@@ -1800,12 +1800,12 @@ mod tests {
         let datatype = make_f64_type();
         let cache = ChunkCache::new();
 
-        assert!(!cache.has_index());
+        assert!(!cache.stats().index_loaded());
         let raw = read_chunked_data_cached(
             &file_data, &layout, &dataspace, &datatype, None, 8, 8, &cache,
         )
         .unwrap();
-        assert!(cache.has_index());
+        assert!(cache.stats().index_loaded());
         assert_eq!(raw.len(), 20 * 8);
         for i in 0..20 {
             let val = f64::from_le_bytes(raw[i * 8..(i + 1) * 8].try_into().unwrap());
@@ -1825,8 +1825,8 @@ mod tests {
             &file_data, &layout, &dataspace, &datatype, None, 8, 8, &cache,
         )
         .unwrap();
-        assert!(cache.has_index());
-        assert!(cache.cached_chunk_count() > 0);
+        assert!(cache.stats().index_loaded());
+        assert!(cache.stats().cached_chunks() > 0);
 
         // Second read — should hit the decompressed cache
         let raw2 = read_chunked_data_cached(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,7 +193,7 @@ pub use error::FormatError;
 #[cfg(feature = "std")]
 pub use reader::{Dataset, File, FileAccessOptions, Group, is_hdf5, is_hdf5_bytes};
 
-pub use chunk_cache::ChunkCacheConfig;
+pub use chunk_cache::{ChunkCacheConfig, ChunkCacheStats};
 
 pub use source::MetadataCacheConfig;
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::io::{Read, Seek, SeekFrom};
 
 use crate::attribute::extract_attributes_full;
-use crate::chunk_cache::{ChunkCache, ChunkCacheConfig};
+use crate::chunk_cache::{ChunkCache, ChunkCacheConfig, ChunkCacheStats};
 use crate::compound::CompoundType;
 use crate::convert::TryToUsize;
 use crate::data_layout::DataLayout;
@@ -764,6 +764,18 @@ impl<'f> std::fmt::Debug for Dataset<'f> {
 }
 
 impl<'f> Dataset<'f> {
+    /// A point-in-time snapshot of this dataset handle's chunk-cache occupancy.
+    ///
+    /// Lets callers confirm a chunk-cache configuration (set with
+    /// [`FileAccessOptions::with_chunk_cache`]) is taking effect: after a
+    /// chunked read, an enabled cache reports a loaded index and retained
+    /// chunks; a disabled one (or one over its budget) reports fewer or none.
+    /// The cache is per-handle, so a freshly opened [`Dataset`] reports an empty
+    /// snapshot until its first read.
+    pub fn chunk_cache_stats(&self) -> ChunkCacheStats {
+        self.chunk_cache.stats()
+    }
+
     /// Returns the shape (dimensions) of the dataset.
     pub fn shape(&self) -> Result<Vec<u64>, Error> {
         let ds = self.dataspace()?;

--- a/tests/chunk_cache_stats.rs
+++ b/tests/chunk_cache_stats.rs
@@ -1,0 +1,58 @@
+//! Public chunk-cache observability: `Dataset::chunk_cache_stats()` lets a
+//! downstream caller confirm their chunk-cache tuning is taking effect, without
+//! reaching into crate internals.
+
+use hdf5_pure::{ChunkCacheConfig, File, FileAccessOptions, FileBuilder};
+
+fn chunked_file_bytes() -> Vec<u8> {
+    let data: Vec<i32> = (0..256).collect();
+    let mut b = FileBuilder::new();
+    b.create_dataset("chunked")
+        .with_i32_data(&data)
+        .with_shape(&[256])
+        .with_chunks(&[32]);
+    b.finish().unwrap()
+}
+
+#[test]
+fn fresh_handle_reports_empty_stats_before_any_read() {
+    let file = File::from_bytes(chunked_file_bytes()).unwrap();
+    let ds = file.dataset("chunked").unwrap();
+    let stats = ds.chunk_cache_stats();
+    assert!(!stats.index_loaded());
+    assert_eq!(stats.cached_chunks(), 0);
+    assert_eq!(stats.cached_bytes(), 0);
+}
+
+#[test]
+fn enabled_cache_reports_retained_index_and_chunks_after_read() {
+    let file = File::from_bytes_with_options(
+        chunked_file_bytes(),
+        FileAccessOptions::new().with_chunk_cache(ChunkCacheConfig::new()),
+    )
+    .unwrap();
+    let ds = file.dataset("chunked").unwrap();
+    assert_eq!(ds.read_i32().unwrap(), (0..256).collect::<Vec<i32>>());
+
+    let stats = ds.chunk_cache_stats();
+    assert!(stats.index_loaded());
+    assert!(stats.cached_chunks() > 0);
+    assert_eq!(stats.cached_bytes(), stats.cached_chunks() * 32 * 4);
+}
+
+#[test]
+fn disabled_cache_reports_nothing_retained_after_read() {
+    let file = File::from_bytes_with_options(
+        chunked_file_bytes(),
+        FileAccessOptions::new().with_chunk_cache(ChunkCacheConfig::disabled()),
+    )
+    .unwrap();
+    let ds = file.dataset("chunked").unwrap();
+    // Reads still return correct data; the cache simply retains nothing.
+    assert_eq!(ds.read_i32().unwrap(), (0..256).collect::<Vec<i32>>());
+
+    let stats = ds.chunk_cache_stats();
+    assert!(!stats.index_loaded());
+    assert_eq!(stats.cached_chunks(), 0);
+    assert_eq!(stats.cached_bytes(), 0);
+}


### PR DESCRIPTION
## Summary

Adds a public, read-only way to observe a dataset's chunk-cache state, so users can confirm their chunk-cache tuning (file-wide `H5Pset_cache`, and the per-dataset `H5Pset_chunk_cache` from #67) is actually taking effect. This addresses a friction point surfaced while implementing #48: cache occupancy was only observable through `#[cfg(test)]`-gated methods, unreachable by downstream users and integration tests.

## API

- `ChunkCacheStats` — a `Copy` snapshot type with `index_loaded()`, `cached_chunks()`, `cached_bytes()` accessors.
- `ChunkCache::stats()` — public, returns a consistent snapshot.
- `Dataset::chunk_cache_stats()` — per-handle accessor. The cache is per-handle, so a fresh `Dataset` reports an empty snapshot until its first read.
- `ChunkCacheStats` re-exported from the crate root.

## Cleanup

Removes the redundant `#[cfg(test)]` `has_index` / `cached_chunk_count` / `cached_bytes` helpers on `ChunkCache`; the existing unit tests now go through the public `stats()`, making it the single source of truth and removing the same-crate test backdoor.

## Tests

- `tests/chunk_cache_stats.rs`: fresh handle reports empty; enabled cache reports a loaded index and retained chunks/bytes after a read; disabled cache reports nothing retained while still reading correct data.
- Existing `chunk_cache` / `chunked_read` unit tests migrated to `stats()`.

`cargo test` (all green), `cargo clippy --all-targets` (clean), `cargo check --no-default-features` (compiles), `cargo doc` (no new warnings).

Note: independent of #67, but both touch the `Dataset` impl block, so whichever merges second may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)