### PR TITLE
Add generic dataset I/O over the element type (with_data / read)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Generic, type-parameterized dataset I/O: `DatasetBuilder::with_data(&[T])` writes any supported scalar and `Dataset::read::<T>()` reads one back, so you can write code generic over the element type instead of reaching for `with_i64_data` / `read_i64` and friends. Backed by the now feature-independent `H5Element` bound (previously available only with the `ndarray` feature). Both delegate to the existing typed methods, so behavior is unchanged ([#53](https://github.com/stephenberry/hdf5-pure/issues/53)).
 - Per-dataset chunk-cache control: `File::dataset_with_options` / `Group::dataset_with_options` take a `DatasetAccessOptions` that overrides the file-wide chunk-cache default for a single dataset, mirroring HDF5's `H5Pset_chunk_cache` access property list. `Dataset::chunk_cache_config()` reports the effective setting ([#48](https://github.com/stephenberry/hdf5-pure/issues/48)).
 - `Dataset::chunk_cache_stats()` reports a read-only snapshot of a dataset's chunk-cache occupancy (index loaded, retained chunks, retained bytes), so callers can confirm their chunk-cache tuning is taking effect.
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,35 @@ let attrs = file.root().attrs().unwrap();
 println!("version: {:?}", attrs.get("version"));  // Some(I64(2))
 ```
 
+### Generic over the element type
+
+The typed `with_f64_data` / `read_f64` family has a generic counterpart so you
+can write code that works for any supported scalar: `with_data(&[T])` to write
+and `read::<T>()` to read, bounded by the sealed `H5Element` trait (implemented
+for `f32`/`f64` and the 8/16/32/64-bit signed and unsigned integers).
+
+```rust
+use hdf5_pure::{File, FileBuilder, H5Element, Error};
+
+fn store<T: H5Element>(fb: &mut FileBuilder, name: &str, values: &[T]) {
+    fb.create_dataset(name).with_data(values);
+}
+
+fn load<T: H5Element>(file: &File, name: &str) -> Result<Vec<T>, Error> {
+    file.dataset(name)?.read::<T>()
+}
+
+let mut fb = FileBuilder::new();
+store(&mut fb, "counts", &[1u32, 2, 3]);
+let file = File::from_bytes(fb.finish().unwrap()).unwrap();
+
+let counts: Vec<u32> = load(&file, "counts").unwrap();  // [1, 2, 3]
+```
+
+`read::<T>()` requests delivery as `T` (coercing like `read_f64`); it is not an
+assertion about the stored datatype, so pick `T` to match the stored type for a
+lossless read. For N-dimensional arrays see the `ndarray` feature below.
+
 ### Editing in place
 
 `EditSession` opens an existing file and adds, deletes, or copies objects, or edits compact group attributes without reading it all in and rewriting it. New data and the rebuilt object headers are appended at the end of the file and the superblock is repointed last, so the cost is proportional to what changes and a failed commit leaves the file valid.
@@ -247,6 +276,7 @@ Supported subset: one unlimited dimension, chunked, unfiltered (no compression o
 
 | Method | HDF5 type |
 |---|---|
+| `with_data` (generic, any scalar below) | Inferred from the element type |
 | `with_f64_data` | IEEE 64-bit float |
 | `with_f32_data` | IEEE 32-bit float |
 | `with_i8_data` / `with_i16_data` / `with_i32_data` / `with_i64_data` | Signed integers |

--- a/src/element.rs
+++ b/src/element.rs
@@ -1,0 +1,150 @@
+//! Generic, type-parameterized dataset I/O.
+//!
+//! The [`H5Element`] trait is the element bound that lets you read and write
+//! datasets generically over the scalar type, instead of reaching for a
+//! type-specific method like [`DatasetBuilder::with_i64_data`] or
+//! [`Dataset::read_i64`](crate::Dataset::read_i64). It powers two entry points:
+//!
+//! * [`DatasetBuilder::with_data`] — write a flat slice of any supported scalar,
+//!   inferring the datatype and shape from the slice.
+//! * [`Dataset::read`](crate::Dataset::read) — read a dataset back into a
+//!   `Vec<T>` for any supported scalar `T`.
+//!
+//! Both dispatch to the existing per-type methods, so a generic read or write
+//! has exactly the same datatype, endianness, and conversion behavior as the
+//! corresponding `with_*_data` / `read_*` call.
+//!
+//! # Example
+//!
+//! ```
+//! use hdf5_pure::{Dataset, Error, FileBuilder, H5Element};
+//!
+//! // A function generic over the element type — not possible with the
+//! // type-specific `with_*_data` / `read_*` methods.
+//! fn round_trip<T: H5Element + PartialEq + std::fmt::Debug>(name: &str, values: &[T]) {
+//!     let mut fb = FileBuilder::new();
+//!     fb.create_dataset(name).with_data(values);
+//!     let bytes = fb.finish().unwrap();
+//!
+//!     let file = hdf5_pure::File::from_bytes(bytes).unwrap();
+//!     let back: Vec<T> = file.dataset(name).unwrap().read().unwrap();
+//!     assert_eq!(values, back.as_slice());
+//! }
+//!
+//! round_trip("ints", &[1i64, 2, 3]);
+//! round_trip("floats", &[1.0f32, 2.5, -3.0]);
+//! ```
+
+use crate::error::Error;
+use crate::reader::Dataset;
+use crate::type_builders::DatasetBuilder;
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// A Rust scalar type that can be stored as an HDF5 dataset element.
+///
+/// This trait is sealed: it is implemented for the fixed set of scalar types
+/// the crate's reader and writer support (`f32`, `f64`, the signed integers
+/// `i8`/`i16`/`i32`/`i64`, and the unsigned integers `u8`/`u16`/`u32`/`u64`)
+/// and cannot be implemented for other types. It is the element bound for the
+/// generic [`DatasetBuilder::with_data`] / [`Dataset::read`](crate::Dataset::read)
+/// helpers (and, with the `ndarray` feature, the
+/// [`with_ndarray`](crate::FileBuilder)/[`read_array`](crate::Dataset::read_array)
+/// family), and dispatches to the existing per-type reader/writer methods, so a
+/// generic read or write has exactly the same datatype, endianness, and
+/// conversion behavior as the corresponding
+/// [`Dataset::read_f64`](crate::Dataset::read_f64) /
+/// [`DatasetBuilder::with_f64_data`] call.
+pub trait H5Element: sealed::Sealed + Copy {
+    /// Read every element of `ds` as `Self`, in row-major order.
+    #[doc(hidden)]
+    fn read_from(ds: &Dataset<'_>) -> Result<Vec<Self>, Error>;
+
+    /// Set `builder`'s data and datatype from a flat row-major slice.
+    #[doc(hidden)]
+    fn write_into(builder: &mut DatasetBuilder, data: &[Self]);
+}
+
+macro_rules! impl_h5_element {
+    ($ty:ty, $read:ident, $write:ident) => {
+        impl sealed::Sealed for $ty {}
+        impl H5Element for $ty {
+            fn read_from(ds: &Dataset<'_>) -> Result<Vec<Self>, Error> {
+                ds.$read()
+            }
+            fn write_into(builder: &mut DatasetBuilder, data: &[Self]) {
+                builder.$write(data);
+            }
+        }
+    };
+}
+
+impl_h5_element!(f32, read_f32, with_f32_data);
+impl_h5_element!(f64, read_f64, with_f64_data);
+impl_h5_element!(i8, read_i8, with_i8_data);
+impl_h5_element!(i16, read_i16, with_i16_data);
+impl_h5_element!(i32, read_i32, with_i32_data);
+impl_h5_element!(i64, read_i64, with_i64_data);
+impl_h5_element!(u8, read_u8, with_u8_data);
+impl_h5_element!(u16, read_u16, with_u16_data);
+impl_h5_element!(u32, read_u32, with_u32_data);
+impl_h5_element!(u64, read_u64, with_u64_data);
+
+impl DatasetBuilder {
+    /// Set the dataset's data and datatype from a flat slice of any supported
+    /// scalar type.
+    ///
+    /// This is the generic counterpart of the type-specific `with_*_data`
+    /// methods (e.g. [`with_f64_data`](Self::with_f64_data)): it infers the
+    /// datatype from `T` and, unless [`with_shape`](Self::with_shape) has
+    /// already set one, takes the shape to be the 1-D `[data.len()]`. The
+    /// builder is returned so chunking, compression, and attributes can be
+    /// chained.
+    ///
+    /// Because the element type is a generic parameter, you can write code that
+    /// is generic over the stored type:
+    ///
+    /// ```
+    /// use hdf5_pure::{FileBuilder, H5Element};
+    ///
+    /// fn store<T: H5Element>(fb: &mut FileBuilder, name: &str, values: &[T]) {
+    ///     fb.create_dataset(name).with_data(values);
+    /// }
+    /// ```
+    ///
+    /// For N-dimensional arrays, see
+    /// [`with_ndarray`](crate::FileBuilder) (the `ndarray` feature).
+    pub fn with_data<T: H5Element>(&mut self, data: &[T]) -> &mut Self {
+        T::write_into(self, data);
+        self
+    }
+}
+
+impl Dataset<'_> {
+    /// Read the dataset into a `Vec<T>` for any supported scalar type, in
+    /// row-major order.
+    ///
+    /// This is the generic counterpart of the type-specific `read_*` methods
+    /// (e.g. [`read_f64`](Self::read_f64)). The element type is usually inferred
+    /// from the binding, so a call site reads as
+    /// `let v: Vec<f64> = ds.read()?;`, or you can name it with turbofish:
+    /// `ds.read::<i32>()?`.
+    ///
+    /// `T` is the type you want the elements *delivered as*, not an assertion
+    /// about the dataset's stored type. The stored bytes are coerced into `T`
+    /// using the same rules as [`read_f64`](Self::read_f64) and its siblings, so
+    /// the conversion can be lossy: reading an `f64` dataset as `i32` truncates,
+    /// and reading an `i32` dataset as `f64` widens. There is no check that `T`
+    /// matches the on-disk datatype, so pick `T` to match the stored type when
+    /// you need an exact, lossless read.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from the underlying typed read (see
+    /// [`read_f64`](Self::read_f64)).
+    pub fn read<T: H5Element>(&self) -> Result<Vec<T>, Error> {
+        T::read_from(self)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,27 @@
 //! let values = ds.read_f64().unwrap();
 //! ```
 //!
+//! # Generic over the element type
+//!
+//! The typed `with_*_data` / `read_*` methods have generic counterparts bounded
+//! by [`H5Element`]: [`DatasetBuilder::with_data`] writes a flat slice of any
+//! supported scalar and [`Dataset::read`] reads one back, so you can write code
+//! generic over the stored type.
+//!
+//! ```rust
+//! use hdf5_pure::{File, FileBuilder, H5Element};
+//!
+//! fn store<T: H5Element>(fb: &mut FileBuilder, name: &str, values: &[T]) {
+//!     fb.create_dataset(name).with_data(values);
+//! }
+//!
+//! let mut fb = FileBuilder::new();
+//! store(&mut fb, "counts", &[1u32, 2, 3]);
+//! let file = File::from_bytes(fb.finish().unwrap()).unwrap();
+//! let counts: Vec<u32> = file.dataset("counts").unwrap().read().unwrap();
+//! assert_eq!(counts, vec![1, 2, 3]);
+//! ```
+//!
 //! # Editing files in place
 //!
 //! [`EditSession`] opens an existing file and adds, deletes, or copies objects
@@ -179,6 +200,9 @@ pub(crate) mod writer;
 #[cfg(feature = "std")]
 pub mod mat;
 
+#[cfg(feature = "std")]
+pub(crate) mod element;
+
 #[cfg(feature = "ndarray")]
 pub(crate) mod ndarray_support;
 
@@ -222,8 +246,8 @@ pub use edit::EditSession;
 #[cfg(feature = "std")]
 pub use repack::{RepackOptions, repack};
 
-#[cfg(feature = "ndarray")]
-pub use ndarray_support::H5Element;
+#[cfg(feature = "std")]
+pub use element::H5Element;
 
 pub use scaleoffset::ScaleOffset;
 

--- a/src/ndarray_support.rs
+++ b/src/ndarray_support.rs
@@ -39,59 +39,10 @@
 use ndarray::{Array, ArrayBase, ArrayD, Data, Dimension, IxDyn};
 
 use crate::convert::TryToUsize;
+use crate::element::H5Element;
 use crate::error::Error;
 use crate::reader::Dataset;
 use crate::type_builders::DatasetBuilder;
-
-mod sealed {
-    pub trait Sealed {}
-}
-
-/// A Rust scalar type that can be stored as an HDF5 dataset element.
-///
-/// This trait is sealed: it is implemented for the fixed set of scalar types
-/// the crate's reader and writer support (`f32`, `f64`, the signed integers
-/// `i8`/`i16`/`i32`/`i64`, and the unsigned integers `u8`/`u16`/`u32`/`u64`)
-/// and cannot be implemented for other types. It is the element bound for the
-/// [`ndarray`] read/write helpers and dispatches to the existing per-type
-/// reader/writer methods, so an `ndarray` read or write has exactly the same
-/// datatype, endianness, and conversion behavior as the corresponding
-/// [`Dataset::read_f64`](crate::Dataset::read_f64) /
-/// [`DatasetBuilder::with_f64_data`] family.
-pub trait H5Element: sealed::Sealed + Copy {
-    /// Read every element of `ds` as `Self`, in row-major order.
-    #[doc(hidden)]
-    fn read_from(ds: &Dataset<'_>) -> Result<Vec<Self>, Error>;
-
-    /// Set `builder`'s data and datatype from a flat row-major slice.
-    #[doc(hidden)]
-    fn write_into(builder: &mut DatasetBuilder, data: &[Self]);
-}
-
-macro_rules! impl_h5_element {
-    ($ty:ty, $read:ident, $write:ident) => {
-        impl sealed::Sealed for $ty {}
-        impl H5Element for $ty {
-            fn read_from(ds: &Dataset<'_>) -> Result<Vec<Self>, Error> {
-                ds.$read()
-            }
-            fn write_into(builder: &mut DatasetBuilder, data: &[Self]) {
-                builder.$write(data);
-            }
-        }
-    };
-}
-
-impl_h5_element!(f32, read_f32, with_f32_data);
-impl_h5_element!(f64, read_f64, with_f64_data);
-impl_h5_element!(i8, read_i8, with_i8_data);
-impl_h5_element!(i16, read_i16, with_i16_data);
-impl_h5_element!(i32, read_i32, with_i32_data);
-impl_h5_element!(i64, read_i64, with_i64_data);
-impl_h5_element!(u8, read_u8, with_u8_data);
-impl_h5_element!(u16, read_u16, with_u16_data);
-impl_h5_element!(u32, read_u32, with_u32_data);
-impl_h5_element!(u64, read_u64, with_u64_data);
 
 impl Dataset<'_> {
     /// Read the dataset into a statically-ranked [`ndarray::Array`].

--- a/tests/generic_element.rs
+++ b/tests/generic_element.rs
@@ -1,0 +1,134 @@
+//! Generic, type-parameterized dataset I/O via the `H5Element` bound:
+//! `DatasetBuilder::with_data` and `Dataset::read`. See issue #53.
+//!
+//! These exercise the generic path on default features (no `ndarray`), so they
+//! also prove the trait is available independently of that feature.
+
+use hdf5_pure::{Dataset, Error, File, FileBuilder, H5Element};
+
+/// Round-trip a flat slice through the *generic* write/read entry points and
+/// assert the values come back unchanged. The function is itself generic over
+/// the element type, which is the capability issue #53 asks for.
+fn assert_round_trip<T>(name: &str, values: &[T])
+where
+    T: H5Element + PartialEq + std::fmt::Debug,
+{
+    let mut fb = FileBuilder::new();
+    fb.create_dataset(name).with_data(values);
+    let bytes = fb.finish().unwrap();
+
+    let file = File::from_bytes(bytes).unwrap();
+    let back: Vec<T> = file.dataset(name).unwrap().read().unwrap();
+    assert_eq!(values, back.as_slice(), "round trip mismatch for {name}");
+}
+
+#[test]
+fn round_trips_every_supported_scalar() {
+    assert_round_trip("f32", &[1.0f32, -2.5, 3.25, f32::MIN, f32::MAX]);
+    assert_round_trip("f64", &[1.0f64, -2.5, 3.25, f64::MIN, f64::MAX]);
+    assert_round_trip("i8", &[i8::MIN, -1, 0, 1, i8::MAX]);
+    assert_round_trip("i16", &[i16::MIN, -1, 0, 1, i16::MAX]);
+    assert_round_trip("i32", &[i32::MIN, -1, 0, 1, i32::MAX]);
+    assert_round_trip("i64", &[i64::MIN, -1, 0, 1, i64::MAX]);
+    assert_round_trip("u8", &[0u8, 1, 128, u8::MAX]);
+    assert_round_trip("u16", &[0u16, 1, 128, u16::MAX]);
+    assert_round_trip("u32", &[0u32, 1, 128, u32::MAX]);
+    assert_round_trip("u64", &[0u64, 1, 128, u64::MAX]);
+}
+
+#[test]
+fn generic_write_matches_type_specific_method() {
+    // `with_data` must produce a byte-identical dataset to the hand-written
+    // `with_i64_data`, since the generic path is meant to be a drop-in.
+    let values: Vec<i64> = (-100..100).collect();
+
+    let mut generic = FileBuilder::new();
+    generic.create_dataset("d").with_data(&values);
+    let a = generic.finish().unwrap();
+
+    let mut specific = FileBuilder::new();
+    specific.create_dataset("d").with_i64_data(&values);
+    let b = specific.finish().unwrap();
+
+    assert_eq!(a, b, "with_data must match with_i64_data byte-for-byte");
+}
+
+#[test]
+fn read_is_type_inferred_and_turbofished() {
+    let mut fb = FileBuilder::new();
+    fb.create_dataset("v").with_data(&[10.0f64, 20.0, 30.0]);
+    let file = File::from_bytes(fb.finish().unwrap()).unwrap();
+    let ds = file.dataset("v").unwrap();
+
+    // Inferred from the binding...
+    let inferred: Vec<f64> = ds.read().unwrap();
+    // ...or named with turbofish.
+    let turbofished = ds.read::<f64>().unwrap();
+    assert_eq!(inferred, vec![10.0, 20.0, 30.0]);
+    assert_eq!(inferred, turbofished);
+}
+
+#[test]
+fn with_data_preserves_an_explicit_multidimensional_shape() {
+    // `with_data` only defaults the shape when none is set, so a chained
+    // `with_shape` wins and the flat read returns row-major order.
+    let values: Vec<i32> = (0..6).collect();
+    let mut fb = FileBuilder::new();
+    fb.create_dataset("m")
+        .with_data(&values)
+        .with_shape(&[2, 3]);
+    let file = File::from_bytes(fb.finish().unwrap()).unwrap();
+    let ds = file.dataset("m").unwrap();
+
+    assert_eq!(ds.shape().unwrap(), vec![2, 3]);
+    assert_eq!(ds.read::<i32>().unwrap(), values);
+}
+
+#[test]
+fn read_coerces_across_types_like_the_typed_methods() {
+    // `read::<T>` requests delivery as `T`; it does not assert the stored type.
+    // An i32 dataset read as f64 widens exactly as `read_f64` would.
+    let mut fb = FileBuilder::new();
+    fb.create_dataset("ints").with_data(&[1i32, 2, 3]);
+    let file = File::from_bytes(fb.finish().unwrap()).unwrap();
+    let ds = file.dataset("ints").unwrap();
+
+    let as_f64: Vec<f64> = ds.read().unwrap();
+    assert_eq!(as_f64, ds.read_f64().unwrap());
+    assert_eq!(as_f64, vec![1.0, 2.0, 3.0]);
+}
+
+#[test]
+fn generic_helpers_compose_into_user_code() {
+    // The end-to-end scenario from the issue: one helper writes any scalar
+    // type, another reads it back, both generic.
+    fn store<T: H5Element>(fb: &mut FileBuilder, name: &str, values: &[T]) {
+        fb.create_dataset(name).with_data(values);
+    }
+    fn load<T: H5Element>(file: &File, name: &str) -> Result<Vec<T>, Error> {
+        file.dataset(name)?.read::<T>()
+    }
+
+    let mut fb = FileBuilder::new();
+    store(&mut fb, "a", &[1u16, 2, 3]);
+    let mut g = fb.create_group("grp");
+    store_group(&mut g, "b", &[4.0f32, 5.0]);
+    fb.add_group(g.finish());
+    let file = File::from_bytes(fb.finish().unwrap()).unwrap();
+
+    assert_eq!(load::<u16>(&file, "a").unwrap(), vec![1, 2, 3]);
+    assert_eq!(load::<f32>(&file, "grp/b").unwrap(), vec![4.0, 5.0]);
+}
+
+/// Helper proving `with_data` is also reachable on datasets created inside a
+/// group builder, not just at the file root.
+fn store_group<T: H5Element>(g: &mut hdf5_pure::GroupBuilder, name: &str, values: &[T]) {
+    g.create_dataset(name).with_data(values);
+}
+
+/// `_ = Dataset::read` keeps the import used even if the inherent method is
+/// renamed; serves as a compile-time signature check.
+#[allow(dead_code)]
+fn signature_check(ds: &Dataset<'_>) -> Result<Vec<u8>, Error> {
+    ds.read::<u8>()
+}


### PR DESCRIPTION
Closes #53.

## Problem

Datasets could only be written and read through the hardcoded per-type methods (`with_i64_data`, `with_f64_data`, `read_i64`, `read_f64`, …), so it was impossible to write code generic over the stored element type.

## Change

Adds generic counterparts bounded by the `H5Element` trait:

```rust
fn store<T: H5Element>(fb: &mut FileBuilder, name: &str, v: &[T]) {
    fb.create_dataset(name).with_data(v);
}
fn load<T: H5Element>(ds: &Dataset) -> Result<Vec<T>, Error> {
    ds.read::<T>()
}
```

- `DatasetBuilder::with_data::<T>(&[T])` — write a flat slice of any supported scalar
- `Dataset::read::<T>() -> Vec<T>` — read one back

The sealed `H5Element` trait already existed but was gated behind the `ndarray` feature and used only internally by `with_ndarray`/`read_array`. This promotes it into a new feature-independent module (`src/element.rs`, `std`-gated like the rest of the reader/writer API) and re-exports it at the crate root. `ndarray_support` now imports the shared trait instead of redefining it (net −49 lines there).

## Notes

- **Non-breaking and additive.** All existing `with_*_data` / `read_*` methods stay; the generic methods delegate to them, so datatype, endianness, and (possibly lossy) conversion behavior are unchanged. A test asserts `with_data` is byte-identical to `with_i64_data`, and that `read::<f64>()` coerces exactly like `read_f64()`.
- `read::<T>()` requests delivery as `T`; it does not assert the on-disk datatype (same coercion rules as `read_f64`), so pick `T` to match the stored type for a lossless read.
- Implemented for `f32`/`f64` and the 8/16/32/64-bit signed and unsigned integers. For N-D arrays, `with_ndarray`/`read_array` (the `ndarray` feature) build on the same trait.

## Tests

New `tests/generic_element.rs` (6 tests, run on default features to prove the API no longer needs `ndarray`):
- round-trips every supported scalar
- `with_data` matches `with_i64_data` byte-for-byte
- type inference and turbofish on `read`
- explicit multidimensional shape preserved
- cross-type coercion matches the typed methods
- end-to-end generic helpers, including a dataset inside a group

Verified locally: full default suite plus `--features ndarray`/`serde`/`zfp`, `cargo fmt --check`, strict clippy (`--features "serde ndarray" --all-targets -D warnings`), `--no-default-features`, and doctests (zero new rustdoc warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)