### PR TITLE
Add a gallery of runnable examples (#54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Generic, type-parameterized dataset I/O: `DatasetBuilder::with_data(&[T])` writes any supported scalar and `Dataset::read::<T>()` reads one back, so you can write code generic over the element type instead of reaching for `with_i64_data` / `read_i64` and friends. Backed by the now feature-independent `H5Element` bound (previously available only with the `ndarray` feature). Both delegate to the existing typed methods, so behavior is unchanged ([#53](https://github.com/stephenberry/hdf5-pure/issues/53)).
 - Per-dataset chunk-cache control: `File::dataset_with_options` / `Group::dataset_with_options` take a `DatasetAccessOptions` that overrides the file-wide chunk-cache default for a single dataset, mirroring HDF5's `H5Pset_chunk_cache` access property list. `Dataset::chunk_cache_config()` reports the effective setting ([#48](https://github.com/stephenberry/hdf5-pure/issues/48)).
 - `Dataset::chunk_cache_stats()` reports a read-only snapshot of a dataset's chunk-cache occupancy (index loaded, retained chunks, retained bytes), so callers can confirm their chunk-cache tuning is taking effect.
+- A gallery of runnable, self-checking examples in `examples/` covering the core API: write/read, generic element I/O, groups & attributes, compression, compound & complex types, ndarray, in-place editing, repack, SWMR, and file-space strategy. Run any with `cargo run --example <name>` ([#54](https://github.com/stephenberry/hdf5-pure/issues/54)).
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,10 @@ hdf5 = { package = "hdf5-metno", version = "0.12", features = ["static", "zlib"]
 name = "matlab_fixtures"
 required-features = ["serde"]
 
+[[example]]
+name = "ndarray_io"
+required-features = ["ndarray"]
+
 # Style-preference clippy lints muted crate-wide. The remaining clippy
 # surface is still on (`-D warnings` in CI), so genuinely problematic
 # patterns continue to fail the build.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,25 @@ Pure-Rust HDF5 reader, writer, and in-place editor. No C dependencies, no build 
 - Compound types, enumerations, array types
 - Complex number datasets (as compound `{real, imag}`)
 
+## Examples
+
+Runnable, self-checking examples live in [`examples/`](examples). Run any with `cargo run --example <name>`:
+
+| Example | What it shows |
+|---|---|
+| `quickstart` | Build a file in memory and read it back |
+| `generic_io` | Read/write generically over the element type (`with_data` / `read::<T>`) |
+| `groups_and_attributes` | Nested groups and attributes of several types |
+| `compression` | Deflate, shuffle, and scale-offset filters |
+| `compound_types` | Compound (struct-like) records and complex numbers |
+| `ndarray_io` | N-dimensional array I/O (needs `--features ndarray`) |
+| `edit_in_place` | Add, copy, and delete objects with `EditSession` |
+| `repack` | Shrink a file and drop objects with `repack` |
+| `swmr` | Single-writer / multiple-reader append and refresh |
+| `file_space` | File-space strategy and persistent free-space tracking |
+
+The `matlab_fixtures` example (run with `--features serde`) writes `.mat` v7.3 files for verification in MATLAB/Octave.
+
 ## Quick start
 
 ### Writing

--- a/examples/compound_types.rs
+++ b/examples/compound_types.rs
@@ -1,0 +1,77 @@
+//! Compound (struct-like) datasets and complex numbers.
+//!
+//! A compound dataset stores a record of named fields per element, like a C
+//! struct or an HDF5 `H5Tcreate(H5T_COMPOUND)` type. Complex numbers are a
+//! special case stored as a `{real, imag}` compound.
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo run --example compound_types
+//! ```
+
+use hdf5_pure::{File, FileBuilder};
+
+fn main() {
+    // ---- Numeric tuples as compound records -----------------------------
+    // Fields are encoded one at a time, so the on-disk layout does not depend
+    // on Rust's tuple layout. The element type is `(i8, u64, f32)`.
+    let records = [(1i8, 20u64, 3.5f32), (2, 30, 4.5), (3, 40, 5.5)];
+
+    let mut builder = FileBuilder::new();
+    builder
+        .create_dataset("records")
+        .with_compound_values(&records)
+        .expect("encode compound");
+
+    // ---- Complex numbers ------------------------------------------------
+    // Stored as a compound `{real: f64, imag: f64}`, the convention MATLAB and
+    // h5py use.
+    let waveform = [(1.0f64, 0.0f64), (0.0, 1.0), (-1.0, 0.0)];
+    builder
+        .create_dataset("waveform")
+        .with_complex64_data(&waveform);
+
+    let file = File::from_bytes(builder.finish().unwrap()).unwrap();
+
+    // Read compound records straight back into the matching tuple type. Tuple
+    // fields are matched by position-derived names ("0", "1", ...), which is how
+    // `with_compound_values` writes them.
+    let back = file
+        .dataset("records")
+        .unwrap()
+        .read_compound::<(i8, u64, f32)>()
+        .unwrap();
+    println!("records: {back:?}");
+    assert_eq!(back, records);
+
+    // The on-disk datatype carries the field names and exact byte offsets.
+    let dtype = file.dataset("records").unwrap().dtype().unwrap();
+    println!("records datatype: {dtype:?}");
+
+    // Reading complex back is a rough edge worth knowing about: the fields are
+    // named `real`/`imag`, not the tuple names `read_compound::<(f64, f64)>()`
+    // expects, and there is no `read_complex64` convenience yet. The portable
+    // path is to read the raw record bytes and decode the little-endian pairs
+    // yourself (this is exactly what the crate's MATLAB reader does).
+    let dtype = file.dataset("waveform").unwrap().dtype().unwrap();
+    println!("waveform datatype: {dtype:?}");
+    let raw = file.dataset("waveform").unwrap().read_raw().unwrap();
+    let back_wave = decode_complex64(&raw);
+    println!("waveform (real, imag): {back_wave:?}");
+    assert_eq!(back_wave, waveform);
+
+    println!("\ncompound and complex round-trips verified");
+}
+
+/// Decode a `{real: f64, imag: f64}` compound dataset's raw record bytes into
+/// `(real, imag)` pairs (16 little-endian bytes per element).
+fn decode_complex64(raw: &[u8]) -> Vec<(f64, f64)> {
+    raw.chunks_exact(16)
+        .map(|rec| {
+            let re = f64::from_le_bytes(rec[0..8].try_into().unwrap());
+            let im = f64::from_le_bytes(rec[8..16].try_into().unwrap());
+            (re, im)
+        })
+        .collect()
+}

--- a/examples/compression.rs
+++ b/examples/compression.rs
@@ -1,0 +1,115 @@
+//! Compressing dataset storage with deflate, shuffle, and scale-offset.
+//!
+//! Every filter here is a built-in HDF5 filter, so the files stay readable by
+//! the reference C library, h5py, and MATLAB. Compression is transparent on
+//! read: the same `read_*` call returns the decoded data regardless of how it
+//! was stored.
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo run --example compression
+//! ```
+
+use hdf5_pure::{File, FileBuilder, ScaleOffset};
+
+fn main() {
+    // A compressible signal: a smooth ramp with mild structure. Real data
+    // compresses to varying degrees; this is just enough to be illustrative.
+    let n = 10_000usize;
+    let signal: Vec<f64> = (0..n).map(|i| (i as f64 / 50.0).sin() * 1000.0).collect();
+    let counts: Vec<i32> = (0..n as i32).map(|i| 1000 + (i % 7)).collect();
+
+    // Filters apply per chunk, so a chunked layout is required to compress.
+    let chunk = &[1000u64];
+
+    let uncompressed = build(|b| {
+        b.create_dataset("signal").with_f64_data(&signal);
+    });
+
+    let deflated = build(|b| {
+        b.create_dataset("signal")
+            .with_f64_data(&signal)
+            .with_chunks(chunk)
+            .with_deflate(6);
+    });
+
+    // Shuffle reorders bytes so like-significance bytes sit together, which
+    // usually helps the following deflate pass.
+    let shuffled = build(|b| {
+        b.create_dataset("signal")
+            .with_f64_data(&signal)
+            .with_chunks(chunk)
+            .with_shuffle()
+            .with_deflate(6);
+    });
+
+    // Scale-offset in integer mode is lossless: each chunk's values are stored
+    // as offsets from its minimum, packed into the fewest bits the range needs.
+    let scale_offset_int = build(|b| {
+        b.create_dataset("counts")
+            .with_i32_data(&counts)
+            .with_chunks(chunk)
+            .with_scale_offset(ScaleOffset::Integer(0)); // 0 = pick bit width per chunk
+    });
+
+    println!("dataset storage (whole-file bytes, lower is better):");
+    report("f64 uncompressed", uncompressed.len());
+    report("f64 deflate(6)", deflated.len());
+    report("f64 shuffle+deflate(6)", shuffled.len());
+    report("i32 scale-offset (lossless)", scale_offset_int.len());
+
+    // Reads are identical regardless of filtering, and the lossless paths
+    // reproduce the input exactly.
+    let back = File::from_bytes(shuffled)
+        .unwrap()
+        .dataset("signal")
+        .unwrap()
+        .read_f64()
+        .unwrap();
+    assert_eq!(back, signal);
+
+    let back_counts = File::from_bytes(scale_offset_int)
+        .unwrap()
+        .dataset("counts")
+        .unwrap()
+        .read_i32()
+        .unwrap();
+    assert_eq!(back_counts, counts);
+
+    // Float D-scale is the lossy mode: values are rounded to N decimal digits
+    // before packing, so the read-back is close but not exact.
+    let dscale = build(|b| {
+        b.create_dataset("signal")
+            .with_f64_data(&signal)
+            .with_chunks(chunk)
+            .with_scale_offset(ScaleOffset::FloatDScale(2)) // keep 2 decimal digits
+            .with_deflate(6);
+    });
+    report("\nf64 D-scale(2)+deflate (lossy)", dscale.len());
+    let lossy = File::from_bytes(dscale)
+        .unwrap()
+        .dataset("signal")
+        .unwrap()
+        .read_f64()
+        .unwrap();
+    let max_err = signal
+        .iter()
+        .zip(&lossy)
+        .map(|(a, b)| (a - b).abs())
+        .fold(0.0f64, f64::max);
+    println!("D-scale(2) max abs error: {max_err:.4} (bounded by the kept digits)");
+
+    println!("\nlossless filters verified to reproduce the input exactly");
+}
+
+/// Build a file from a configuring closure and return its bytes.
+fn build(configure: impl FnOnce(&mut FileBuilder)) -> Vec<u8> {
+    let mut b = FileBuilder::new();
+    configure(&mut b);
+    b.finish().unwrap()
+}
+
+fn report(label: &str, bytes: usize) {
+    println!("  {label:<32} {bytes:>8} bytes");
+}

--- a/examples/edit_in_place.rs
+++ b/examples/edit_in_place.rs
@@ -1,0 +1,69 @@
+//! Editing an existing file in place with `EditSession`: add, copy, and delete
+//! objects, and edit group attributes, without reading the whole file in and
+//! rewriting it.
+//!
+//! New data and rebuilt object headers are appended at end-of-file and the
+//! superblock is repointed last, so a failed commit leaves the original file
+//! valid and the cost is proportional to what changes.
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo run --example edit_in_place
+//! ```
+
+use hdf5_pure::{AttrValue, EditSession, File, FileBuilder};
+
+fn main() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = dir.path().join("data.h5");
+
+    // ---- Start from an existing file ------------------------------------
+    let mut builder = FileBuilder::new();
+    builder
+        .create_dataset("temperature")
+        .with_f64_data(&[22.5, 23.1, 21.8]);
+    let mut sensors = builder.create_group("sensors");
+    sensors.create_dataset("pressure").with_f32_data(&[101.3]);
+    builder.add_group(sensors.finish());
+    builder.write(&path).expect("write initial file");
+    let original_len = std::fs::metadata(&path).unwrap().len();
+
+    // ---- Edit it in place -----------------------------------------------
+    let mut session = EditSession::open(&path).expect("open for editing");
+    session.create_group("run2");
+    session.set_group_attr("run2", "kind", AttrValue::AsciiString("trial".into()));
+    session
+        .create_dataset("run2/signal")
+        .with_f64_data(&[1.0, 2.0, 3.0]);
+    session.copy("temperature", "temperature_backup"); // H5Ocopy
+    session.delete("sensors/pressure"); // H5Ldelete
+    session.commit().expect("commit edits");
+
+    // ---- Verify ---------------------------------------------------------
+    let file = File::open(&path).expect("reopen");
+    let signal = file.dataset("run2/signal").unwrap().read_f64().unwrap();
+    let backup = file
+        .dataset("temperature_backup")
+        .unwrap()
+        .read_f64()
+        .unwrap();
+    let run2_attrs = file.group("run2").unwrap().attrs().unwrap();
+
+    println!("added   run2/signal       = {signal:?}");
+    println!("copied  temperature_backup = {backup:?}");
+    println!("group   run2.kind          = {:?}", run2_attrs.get("kind"));
+    println!(
+        "deleted sensors/pressure   -> {:?}",
+        file.dataset("sensors/pressure").is_err()
+    );
+    println!(
+        "\nfile grew from {original_len} to {} bytes",
+        std::fs::metadata(&path).unwrap().len()
+    );
+
+    assert_eq!(signal, vec![1.0, 2.0, 3.0]);
+    assert_eq!(backup, vec![22.5, 23.1, 21.8]);
+    assert!(file.dataset("sensors/pressure").is_err());
+    println!("in-place edits verified");
+}

--- a/examples/file_space.rs
+++ b/examples/file_space.rs
@@ -1,0 +1,61 @@
+//! File-space strategy and persistent free-space tracking.
+//!
+//! Mirroring `H5Pset_file_space_strategy` / `H5Pset_file_space_page_size`, a
+//! written file can record how it manages free space. With `persist = true`,
+//! the regions an `EditSession` frees are recorded in on-disk free-space-manager
+//! blocks so that later sessions (this crate's and the reference C library's)
+//! recover and reuse them rather than only ever growing the file.
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo run --example file_space
+//! ```
+
+use hdf5_pure::{EditSession, File, FileBuilder, FileSpaceStrategy};
+
+fn main() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = dir.path().join("managed.h5");
+
+    // Record a paged file-space strategy and persist freed space across reopen.
+    let mut builder = FileBuilder::new();
+    builder.create_dataset("keep").with_i32_data(&[1, 2, 3]);
+    builder
+        .with_file_space_strategy(FileSpaceStrategy::Page, true, 1) // strategy, persist, threshold
+        .with_file_space_page_size(4096);
+    builder.write(&path).expect("write file");
+
+    // The strategy is stored in a superblock-extension message and survives a
+    // reopen (the reference C library observes it too).
+    let strategy = File::open(&path).unwrap().file_space_strategy();
+    println!("recorded strategy: {strategy:?}");
+    assert_eq!(strategy, Some(FileSpaceStrategy::Page));
+
+    // Create then delete a dataset. Because the file persists free space, the
+    // freed region is recorded on disk rather than discarded.
+    let mut session = EditSession::open(&path).expect("open for editing");
+    session
+        .create_dataset("scratch")
+        .with_f64_data(&vec![0.0; 4096]);
+    session.commit().unwrap();
+
+    let mut session = EditSession::open(&path).expect("reopen for editing");
+    session.delete("scratch");
+    session.commit().unwrap();
+
+    // Later sessions seed their free list from these regions, so add/delete
+    // churn reuses space instead of only growing the file.
+    let file = File::open(&path).unwrap();
+    let free = file.persisted_free_space();
+    let total_free: u64 = free.iter().map(|&(_, len)| len).sum();
+    println!("persisted free regions: {}", free.len());
+    println!("total persisted free bytes: {total_free}");
+
+    // The kept data is unaffected by the free-space bookkeeping.
+    assert_eq!(
+        file.dataset("keep").unwrap().read_i32().unwrap(),
+        vec![1, 2, 3]
+    );
+    println!("\nfile-space strategy persisted and free space tracked");
+}

--- a/examples/generic_io.rs
+++ b/examples/generic_io.rs
@@ -1,0 +1,55 @@
+//! Reading and writing datasets generically over the element type, without
+//! reaching for the per-type `with_f64_data` / `read_f64` family.
+//!
+//! The [`H5Element`] bound is implemented for `f32`/`f64` and the 8/16/32/64-bit
+//! signed and unsigned integers, so one function can serve every scalar type.
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo run --example generic_io
+//! ```
+
+use hdf5_pure::{Error, File, FileBuilder, H5Element};
+
+/// Store a flat slice of any supported scalar. The datatype is inferred from
+/// `T`, so the caller never names it.
+fn store<T: H5Element>(builder: &mut FileBuilder, name: &str, values: &[T]) {
+    builder.create_dataset(name).with_data(values);
+}
+
+/// Load a dataset back as `Vec<T>`. `T` is the type you want delivered, not an
+/// assertion about the stored type (it coerces like `read_f64`), so pick `T` to
+/// match the stored type for a lossless read.
+fn load<T: H5Element>(file: &File, name: &str) -> Result<Vec<T>, Error> {
+    file.dataset(name)?.read::<T>()
+}
+
+fn main() {
+    let mut builder = FileBuilder::new();
+    store(&mut builder, "u32s", &[1u32, 2, 3]);
+    store(&mut builder, "i16s", &[-1i16, 0, 7]);
+    store(&mut builder, "f64s", &[1.5f64, 2.5, 3.5]);
+
+    let file = File::from_bytes(builder.finish().unwrap()).unwrap();
+
+    // The element type is usually inferred from the binding...
+    let counts: Vec<u32> = load(&file, "u32s").unwrap();
+    let offsets: Vec<i16> = load(&file, "i16s").unwrap();
+    // ...or named with turbofish.
+    let readings = file.dataset("f64s").unwrap().read::<f64>().unwrap();
+
+    println!("u32s: {counts:?}");
+    println!("i16s: {offsets:?}");
+    println!("f64s: {readings:?}");
+
+    assert_eq!(counts, vec![1, 2, 3]);
+    assert_eq!(offsets, vec![-1, 0, 7]);
+    assert_eq!(readings, vec![1.5, 2.5, 3.5]);
+
+    // Cross-type coercion: an i16 dataset requested as f64 widens, exactly like
+    // `read_f64` on the same dataset would.
+    let widened: Vec<f64> = load(&file, "i16s").unwrap();
+    assert_eq!(widened, vec![-1.0, 0.0, 7.0]);
+    println!("\ngeneric round-trip verified (including i16 -> f64 widening)");
+}

--- a/examples/groups_and_attributes.rs
+++ b/examples/groups_and_attributes.rs
@@ -1,0 +1,86 @@
+//! Building a nested group hierarchy with attributes of several types, then
+//! walking it back: listing child groups and datasets and reading attributes.
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo run --example groups_and_attributes
+//! ```
+
+use hdf5_pure::{AttrValue, File, FileBuilder};
+
+fn main() {
+    let mut builder = FileBuilder::new();
+
+    // Root-level metadata. Attributes come in many flavors; a representative
+    // spread is shown here.
+    builder.set_attr("title", AttrValue::String("experiment 7".into()));
+    builder.set_attr("run", AttrValue::I64(7));
+    builder.set_attr("calibration", AttrValue::F64Array(vec![0.1, 0.2, 0.3]));
+
+    // A group with its own datasets and attributes.
+    let mut sensors = builder.create_group("sensors");
+    sensors.set_attr("location", AttrValue::AsciiString("lab_a".into()));
+    sensors.set_attr("channels", AttrValue::I64Array(vec![0, 1, 2]));
+    sensors
+        .create_dataset("pressure")
+        .with_f32_data(&[101.3, 101.5, 101.4]);
+    sensors
+        .create_dataset("humidity")
+        .with_f32_data(&[40.0, 41.5]);
+
+    // A nested sub-group. Build it, finish it, and attach it to its parent.
+    let mut imu = sensors.create_group("imu");
+    imu.set_attr("model", AttrValue::String("MPU-9250".into()));
+    imu.create_dataset("accel").with_f64_data(&[0.0, 0.0, 9.81]);
+    sensors.add_group(imu.finish());
+
+    builder.add_group(sensors.finish());
+
+    let file = File::from_bytes(builder.finish().unwrap()).unwrap();
+
+    // ---- Walk the hierarchy --------------------------------------------
+    let root = file.root();
+    println!("root attributes:");
+    print_attrs(&root.attrs().unwrap());
+
+    let sensors = file.group("sensors").unwrap();
+    println!("\n/sensors");
+    println!("  child groups:   {:?}", sorted(sensors.groups().unwrap()));
+    println!(
+        "  datasets:       {:?}",
+        sorted(sensors.datasets().unwrap())
+    );
+    println!("  attributes:");
+    print_attrs_indented(&sensors.attrs().unwrap(), "    ");
+
+    // Datasets are addressable by full path from the file, or by name from
+    // their parent group.
+    let accel = file.dataset("sensors/imu/accel").unwrap();
+    println!("\n/sensors/imu/accel = {:?}", accel.read_f64().unwrap());
+
+    assert_eq!(
+        sorted(sensors.datasets().unwrap()),
+        ["humidity", "pressure"]
+    );
+    assert_eq!(sensors.groups().unwrap(), ["imu"]);
+    assert_eq!(accel.read_f64().unwrap(), vec![0.0, 0.0, 9.81]);
+    println!("\nhierarchy verified");
+}
+
+fn sorted(mut v: Vec<String>) -> Vec<String> {
+    v.sort();
+    v
+}
+
+fn print_attrs(attrs: &std::collections::HashMap<String, AttrValue>) {
+    print_attrs_indented(attrs, "  ");
+}
+
+fn print_attrs_indented(attrs: &std::collections::HashMap<String, AttrValue>, indent: &str) {
+    let mut names: Vec<_> = attrs.keys().collect();
+    names.sort();
+    for name in names {
+        println!("{indent}{name} = {:?}", attrs[name]);
+    }
+}

--- a/examples/ndarray_io.rs
+++ b/examples/ndarray_io.rs
@@ -1,0 +1,44 @@
+//! N-dimensional array I/O via the `ndarray` crate (the `ndarray` feature).
+//!
+//! Shape and datatype are taken from the array, and data is stored row-major
+//! (C order), matching HDF5, so reads and writes are a flat copy with no
+//! transpose.
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo run --example ndarray_io --features ndarray
+//! ```
+
+use hdf5_pure::{File, FileBuilder};
+use ndarray::{Array2, ArrayD, array};
+
+fn main() {
+    let m: Array2<f64> = array![[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]];
+
+    let mut builder = FileBuilder::new();
+    builder.create_dataset("m").with_ndarray(&m); // shape [2, 3], f64
+    let file = File::from_bytes(builder.finish().unwrap()).unwrap();
+
+    // Read back at a statically known rank: the dimensionality is inferred from
+    // the binding's type.
+    let back: Array2<f64> = file.dataset("m").unwrap().read_array().unwrap();
+    println!("matrix:\n{back}");
+    assert_eq!(back, m);
+
+    // Or read at a rank only known at runtime.
+    let dynamic: ArrayD<f64> = file.dataset("m").unwrap().read_array_dyn().unwrap();
+    println!("runtime rank: {}", dynamic.ndim());
+    assert_eq!(dynamic.shape(), &[2, 3]);
+
+    // Non-standard layouts (here a transposed view) are repacked to row-major
+    // on write, so what you read back matches the logical array you passed in.
+    let mut builder = FileBuilder::new();
+    builder.create_dataset("mt").with_ndarray(&m.t());
+    let file = File::from_bytes(builder.finish().unwrap()).unwrap();
+    let transposed: Array2<f64> = file.dataset("mt").unwrap().read_array().unwrap();
+    assert_eq!(transposed, m.t());
+    println!("transposed view stored as shape {:?}", transposed.dim());
+
+    println!("\nndarray round-trips verified");
+}

--- a/examples/quickstart.rs
+++ b/examples/quickstart.rs
@@ -1,0 +1,47 @@
+//! The shortest path through `hdf5-pure`: build a file in memory, then read it
+//! back. No filesystem and no C library are involved.
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo run --example quickstart
+//! ```
+
+use hdf5_pure::{AttrValue, File, FileBuilder};
+
+fn main() {
+    // ---- Write ----------------------------------------------------------
+    let mut builder = FileBuilder::new();
+
+    // A dataset. The shape defaults to `[len]`, so `with_shape` is optional
+    // for a flat 1-D array; it is shown here for clarity.
+    builder
+        .create_dataset("temperature")
+        .with_f64_data(&[22.5, 23.1, 21.8])
+        .with_shape(&[3])
+        .set_attr("unit", AttrValue::AsciiString("degC".into()));
+
+    // An attribute on the root group.
+    builder.set_attr("version", AttrValue::I64(2));
+
+    // `finish` returns the file image as bytes; `write(path)` would instead
+    // put them on disk. The in-memory form is what makes this WASM-friendly.
+    let bytes = builder.finish().expect("serialize file");
+    println!("wrote {} bytes", bytes.len());
+
+    // ---- Read -----------------------------------------------------------
+    let file = File::from_bytes(bytes).expect("parse file");
+
+    let ds = file.dataset("temperature").expect("open dataset");
+    println!("shape: {:?}", ds.shape().unwrap());
+    println!("data:  {:?}", ds.read_f64().unwrap());
+    println!("unit:  {:?}", ds.attrs().unwrap().get("unit"));
+
+    let root_attrs = file.root().attrs().unwrap();
+    println!("version: {:?}", root_attrs.get("version"));
+
+    // The example doubles as a self-check.
+    assert_eq!(ds.read_f64().unwrap(), vec![22.5, 23.1, 21.8]);
+    assert_eq!(root_attrs.get("version"), Some(&AttrValue::I64(2)));
+    println!("\nround-trip verified");
+}

--- a/examples/repack.rs
+++ b/examples/repack.rs
@@ -1,0 +1,62 @@
+//! Reclaiming space and dropping objects with `repack`.
+//!
+//! Deleting an object inside an `EditSession` reuses the freed space within that
+//! session, but a single delete cannot shrink a file whose freed region is not
+//! at the very end (the same reason the HDF5 C library ships `h5repack`).
+//! `repack` reads every surviving object and rewrites the whole file compact,
+//! optionally dropping objects along the way.
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo run --example repack
+//! ```
+
+use hdf5_pure::{File, FileBuilder, RepackOptions, repack};
+
+fn main() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let input = dir.path().join("input.h5");
+    let output = dir.path().join("compact.h5");
+
+    // A file with a large "scratch" dataset we no longer need, a whole group
+    // subtree to drop, and the data we want to keep.
+    let mut builder = FileBuilder::new();
+    builder
+        .create_dataset("keep")
+        .with_f64_data(&[1.0, 2.0, 3.0]);
+    builder
+        .create_dataset("scratch")
+        .with_f64_data(&vec![0.0; 50_000]);
+    let mut aborted = builder.create_group("runs");
+    aborted
+        .create_dataset("aborted")
+        .with_f64_data(&vec![0.0; 50_000]);
+    builder.add_group(aborted.finish());
+    builder.write(&input).expect("write input");
+
+    let before = std::fs::metadata(&input).unwrap().len();
+
+    // Rewrite compact, dropping a dataset and a whole subtree.
+    let options = RepackOptions::new().drop_path("scratch").drop_path("runs");
+    repack(&input, &output, &options).expect("repack");
+
+    let after = std::fs::metadata(&output).unwrap().len();
+    println!("input:  {before:>8} bytes");
+    println!("output: {after:>8} bytes (scratch + runs dropped)");
+
+    // Surviving data is reproduced exactly; dropped objects are gone.
+    let file = File::open(&output).unwrap();
+    let keep = file.dataset("keep").unwrap().read_f64().unwrap();
+    println!("kept 'keep' = {keep:?}");
+    println!(
+        "'scratch' present after repack: {}",
+        file.dataset("scratch").is_ok()
+    );
+
+    assert_eq!(keep, vec![1.0, 2.0, 3.0]);
+    assert!(file.dataset("scratch").is_err());
+    assert!(file.group("runs").is_err());
+    assert!(after < before);
+    println!("\nrepack shrank the file and preserved the kept data");
+}

--- a/examples/swmr.rs
+++ b/examples/swmr.rs
@@ -1,0 +1,56 @@
+//! SWMR (single writer, multiple readers): append to an unlimited dataset in
+//! place while a reader follows the growing file.
+//!
+//! The writer appends chunks and flushes durably so readers only ever observe a
+//! consistent prefix; a reader calls `refresh()` to pick up new data. This
+//! interoperates with the reference HDF5 C library and h5py in both directions.
+//! This single-process example writes and then reads to show the mechanics; in
+//! practice the writer and reader are separate processes.
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo run --example swmr
+//! ```
+
+use hdf5_pure::{File, FileBuilder, SwmrWriter};
+
+fn main() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = dir.path().join("stream.h5");
+
+    // The dataset must have one unlimited dimension and be chunked. The latest
+    // format indexes it with an Extensible Array automatically.
+    let mut builder = FileBuilder::new();
+    builder
+        .create_dataset("log")
+        .with_i32_data(&[0, 1, 2]) // initial rows
+        .with_shape(&[3])
+        .with_maxshape(&[u64::MAX]) // one unlimited dimension
+        .with_chunks(&[1]);
+    builder.write(&path).expect("write initial file");
+
+    // A reader opens the file before the appends happen.
+    let mut reader = File::open_swmr(&path).expect("open reader");
+    let rows_before = reader.dataset("log").unwrap().shape().unwrap()[0];
+    println!("reader sees {rows_before} rows initially");
+
+    // The writer appends in place. Each call flushes durably, leaving the file
+    // valid for the concurrent reader throughout.
+    let mut writer = SwmrWriter::open(&path).expect("open writer");
+    writer.append_i32("log", &[3, 4, 5]).unwrap();
+    writer.append_i32("log", &[6, 7]).unwrap();
+    writer.close().unwrap(); // clears the SWMR flag; dropping the writer also works
+
+    // The reader refreshes to observe the appended data.
+    reader.refresh().unwrap();
+    let ds = reader.dataset("log").unwrap();
+    let rows_after = ds.shape().unwrap()[0];
+    let values = ds.read_i32().unwrap();
+    println!("after refresh: {rows_after} rows = {values:?}");
+
+    assert_eq!(rows_before, 3);
+    assert_eq!(rows_after, 8);
+    assert_eq!(values, vec![0, 1, 2, 3, 4, 5, 6, 7]);
+    println!("\nSWMR append + refresh verified");
+}


### PR DESCRIPTION
Closes #54.

The only example was the special-purpose `matlab_fixtures`; nothing demonstrated the general read/write/edit API a new user starts with. This adds ten self-checking examples under `examples/`, one per major feature area.

## Examples

| Example | Covers |
|---|---|
| `quickstart` | In-memory write → read, dataset + attributes |
| `generic_io` | `with_data` / `read::<T>()` generic over the element type (#53) |
| `groups_and_attributes` | Nested hierarchy, varied `AttrValue` types, walking it back |
| `compression` | deflate, shuffle+deflate, scale-offset (lossless int + lossy D-scale), with byte-size comparison |
| `compound_types` | `with_compound_values`/`read_compound` tuples + complex numbers |
| `ndarray_io` | `with_ndarray`/`read_array`/`read_array_dyn` incl. transpose repack (`ndarray` feature) |
| `edit_in_place` | `EditSession` add/copy/delete + group attributes |
| `repack` | shrink a file and drop objects |
| `swmr` | append + reader `refresh()` |
| `file_space` | `FileSpaceStrategy::Page` + persisted free-space tracking |

Each example round-trips its data and asserts the result, so they double as smoke tests. CI's `cargo test` and clippy `--all-targets` compile them, so they can't bit-rot. The std-only examples don't touch the wasm/no-std `cargo check` jobs (those don't build examples). README gains an **Examples** section, the CHANGELOG gets a one-line entry, and `ndarray_io` is registered with its required feature.

## Friction points surfaced

Writing the examples surfaced two API rough edges (the issue's stated goal):

1. **No typed read-back for complex datasets.** `with_complex64_data` writes a `{real, imag}` compound, but there's no `read_complex64`, and `read_compound::<(f64, f64)>()` fails because complex fields are named `real`/`imag` rather than the positional `"0"`/`"1"` the tuple reader expects. The portable path is `read_raw()` + manual little-endian decode; `compound_types` demonstrates it and flags the gap in a comment.
2. **Group building is verbose.** Every (sub)group needs an explicit `.finish()` + `add_group(...)`, even when nesting.

These are noted for follow-up, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)