### PR TITLE
Replace 32-bit cast ratchet with a per-site #[expect] gate (#72)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,55 +187,44 @@ jobs:
           cargo clippy --locked --target i686-unknown-linux-gnu --lib
           --features "serde zfp provenance parallel ndarray" -- -D warnings
 
-  # Ratchet for pointer-width-aware cast lints. On i686 clippy flags every
-  # potential `u64 as usize`-style narrowing; hundreds are benign (bounded
-  # counts/sizes) so we cannot `-D` them yet. Instead we cap the COUNT so a PR
-  # cannot introduce *new* narrowing casts. Drive CAST_BASELINE down over time
-  # (fix real ones; annotate benign ones with
-  # `#[expect(clippy::cast_possible_truncation, reason = "...")]`). When it
-  # reaches 0, replace this with `-D clippy::cast_possible_truncation`.
-  cast-ratchet-32bit:
-    name: 32-bit cast ratchet (i686)
+  # 32-bit narrowing-cast gate (issue #72). On i686 clippy flags every potential
+  # `u64 as usize`-style narrowing. Each such cast in the library is either
+  # routed through `crate::convert` (`to_usize`/`slice_range`/`u32_from`, which
+  # errors instead of truncating) or annotated at its site with
+  # `#[expect(clippy::cast_possible_truncation | cast_possible_wrap, reason = "...")]`
+  # stating why it cannot lose information. This job denies both lints, so a PR
+  # cannot introduce an unannotated narrowing cast, and denies
+  # `unfulfilled_lint_expectations`, so an `#[expect]` left behind after its cast
+  # is fixed or removed also fails — the annotations are self-cleaning.
+  #
+  # This replaces the earlier count-based ratchet, which a genuinely new cast
+  # could slip past as long as an unrelated one was removed in the same PR.
+  cast-deny-32bit:
+    name: 32-bit narrowing-cast gate (i686)
     runs-on: ubuntu-latest
-    env:
-      # Adjust DOWNWARD only, never upward. Measured on the pinned toolchain
-      # below; a different clippy version may report a slightly different count,
-      # in which case re-measure once and reset this.
-      CAST_BASELINE: 268
     steps:
       - uses: actions/checkout@v4
-      # Pinned so the baseline is stable against clippy-version drift.
+      # Pinned so the set of flagged casts is stable against clippy-version
+      # drift; bump deliberately and re-check the annotations when raising it.
       - uses: dtolnay/rust-toolchain@1.96.0
         with:
           components: clippy
           targets: i686-unknown-linux-gnu
       - uses: Swatinem/rust-cache@v2
         with:
-          key: cast-ratchet-i686
-      - name: Count 32-bit narrowing-cast warnings
+          key: cast-deny-i686
+      - name: Deny 32-bit narrowing casts
         run: |
           set -euo pipefail
           # Force a fresh compile of OUR crate for the i686 target so clippy
-          # actually re-emits the lints (a cached build emits nothing);
-          # dependencies stay cached. The clean must be target-scoped.
+          # re-evaluates the lints (a cached build emits nothing, which would let
+          # a new cast slip through); dependencies stay cached. Target-scoped.
           cargo clean -p hdf5-pure --target i686-unknown-linux-gnu
-          # JSON is the only format that reliably carries the lint name per
-          # diagnostic (`--message-format=short` drops it).
           cargo clippy --locked --target i686-unknown-linux-gnu --lib \
             --features "serde zfp provenance parallel ndarray" \
-            --message-format=json \
-            -- -W clippy::cast_possible_truncation \
-               -W clippy::cast_possible_wrap > clippy.json
-          count=$(jq -r 'select(.reason == "compiler-message") | .message.code.code // empty' clippy.json \
-                  | grep -cE '^clippy::cast_possible_(truncation|wrap)$' || true)
-          echo "32-bit narrowing-cast warnings: $count (baseline ${CAST_BASELINE})"
-          if [ "$count" -gt "${CAST_BASELINE}" ]; then
-            echo "::error::32-bit narrowing-cast count rose to $count (> ${CAST_BASELINE}). A new u64-as-usize-style cast was added; route it through crate::convert (to_usize / slice_range / u32_from), or, if it is provably bounded, annotate it with #[expect(clippy::cast_possible_truncation, reason = \"...\")]."
-            exit 1
-          fi
-          if [ "$count" -lt "${CAST_BASELINE}" ]; then
-            echo "::notice::Cast count dropped to $count; lower CAST_BASELINE in ci.yml to lock it in."
-          fi
+            -- -D clippy::cast_possible_truncation \
+               -D clippy::cast_possible_wrap \
+               -D unfulfilled_lint_expectations
 
   # Real 32-bit execution under QEMU. The reference HDF5 C library
   # (`hdf5-metno`) is a 64-bit-only dev-dependency, so the C-crosscheck tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `Dataset::chunk_cache_stats()` reports a read-only snapshot of a dataset's chunk-cache occupancy (index loaded, retained chunks, retained bytes), so callers can confirm their chunk-cache tuning is taking effect.
 - A gallery of runnable, self-checking examples in `examples/` covering the core API: write/read, generic element I/O, groups & attributes, compression, compound & complex types, ndarray, in-place editing, repack, SWMR, and file-space strategy. Run any with `cargo run --example <name>` ([#54](https://github.com/stephenberry/hdf5-pure/issues/54)).
 
+### Changed
+
+- 32-bit / WASM hardening: the chunked-data and MATLAB matrix readers now return an error instead of silently truncating when a file-derived dimension or element count exceeds the platform's pointer width. Every remaining narrowing `as` cast in the library is now either a checked conversion or carries an `#[expect(…, reason = "…")]` justifying why it is bounded, enforced by a hard deny of the narrowing-cast lints on a 32-bit CI target — replacing the previous count-based ratchet, which a new cast could slip past by removing an unrelated one ([#72](https://github.com/stephenberry/hdf5-pure/issues/72)).
+
 ### Fixed
 
 - Read dense groups and dense attributes whose link/attribute names are very long (stored as fractal-heap "huge" objects); previously failed with `InvalidObjectHeaderVersion` ([#63](https://github.com/stephenberry/hdf5-pure/pull/63)).

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -185,8 +185,20 @@ impl AttributeMessage {
         let mut buf = Vec::new();
         buf.push(version);
         buf.push(0); // flags
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "attribute name length is written into the 2-byte name-size field of the attribute message"
+        )]
         buf.extend_from_slice(&(name_bytes.len() as u16).to_le_bytes());
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "serialized datatype length is written into the 2-byte datatype-size field of the attribute message"
+        )]
         buf.extend_from_slice(&(dt_bytes.len() as u16).to_le_bytes());
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "serialized dataspace length is written into the 2-byte dataspace-size field of the attribute message"
+        )]
         buf.extend_from_slice(&(ds_bytes.len() as u16).to_le_bytes());
         if version >= 3 {
             buf.push(0x00); // character set encoding: ASCII

--- a/src/btree_v2.rs
+++ b/src/btree_v2.rs
@@ -398,6 +398,13 @@ fn parse_internal_child_pointers(
     for _ in 0..num_children {
         let addr = read_offset(node, pos, offset_size)?;
         pos += offset_size as usize;
+        // `read_var_uint` returns a value spanning `nrec_width` bytes, and
+        // `max_nrec_size` is sized to the node's record capacity, which the v2
+        // b-tree format keeps within a 2-byte field — so the count fits `u16`.
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "records-per-node fits max_nrec_size (<= 2 bytes for valid files)"
+        )]
         let child_nrec = read_var_uint(node, pos, nrec_width)? as u16;
         pos += nrec_width;
         pos += total_nrec_width; // skip total-records-in-subtree

--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -64,6 +64,11 @@ fn read_u32_le(data: &[u8], offset: usize) -> u32 {
 
 fn hashlittle(data: &[u8], initval: u32) -> u32 {
     let length = data.len();
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "lookup3 seeds the mix with length mod 2^32 by definition; matching the \
+                  reference (uint32_t) cast keeps checksums identical to the HDF5 C library"
+    )]
     let mut a: u32 = 0xdeadbeefu32
         .wrapping_add(length as u32)
         .wrapping_add(initval);

--- a/src/chunked_read.rs
+++ b/src/chunked_read.rs
@@ -368,6 +368,11 @@ pub fn generate_implicit_chunks(
     }
     let total_chunks: u64 = num_chunks_per_dim.iter().product();
 
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "with_capacity hint only; total_chunks is bounded by the dataset's chunk \
+                  grid and a truncated hint merely under-reserves (the Vec still grows)"
+    )]
     let mut chunks = Vec::with_capacity(total_chunks as usize);
     for linear_idx in 0..total_chunks {
         let mut offsets = vec![0u64; rank];
@@ -379,6 +384,11 @@ pub fn generate_implicit_chunks(
             offsets[d] = chunk_idx * chunk_dimensions[d] as u64;
         }
 
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "chunk byte size is stored in the 32-bit ChunkInfo.chunk_size field \
+                      (HDF5 caps a chunk at 4 GiB)"
+        )]
         chunks.push(ChunkInfo {
             chunk_size: chunk_byte_size as u32,
             filter_mask: 0,
@@ -443,7 +453,11 @@ pub fn read_chunked_data(
         .map(|&d| d as usize)
         .collect();
 
-    let ds_dims: Vec<usize> = dataspace.dimensions.iter().map(|&d| d as usize).collect();
+    let ds_dims: Vec<usize> = dataspace
+        .dimensions
+        .iter()
+        .map(|&d| d.to_usize())
+        .collect::<Result<_, _>>()?;
     if ds_dims.len() != rank {
         return Err(FormatError::ChunkedReadError(format!(
             "rank mismatch: dataspace has {} dims, layout has {} chunk dims (rank={})",
@@ -454,6 +468,11 @@ pub fn read_chunked_data(
     }
 
     // Collect chunks based on version and index type
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "chunk byte sizes and the datatype element size are encoded into 32-bit \
+                  chunk-info fields; both stay well below u32::MAX (HDF5 caps a chunk at 4 GiB)"
+    )]
     let chunks = match (version, chunk_index_type) {
         (3, _) => {
             let ndims = chunk_dimensions.len(); // rank+1
@@ -530,7 +549,7 @@ pub fn read_chunked_data(
     let ctx = ChunkContext::from_datatype(&chunk_dims_u64, datatype);
     let decompressed_chunks = decompress_all_chunks(file_data, &chunks, pipeline, ctx)?;
 
-    let total_bytes = (dataspace.num_elements() as usize) * elem_size;
+    let total_bytes = dataspace.num_elements().to_usize()? * elem_size;
     Ok(assemble_chunks(
         &chunks,
         &decompressed_chunks,
@@ -906,6 +925,10 @@ fn assemble_chunks(
 
     for (chunk_info, decompressed) in chunks.iter().zip(decompressed.iter()) {
         // B-tree v1 (v3) offsets have rank+1 dims; v4 index offsets have rank dims
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "chunk coordinate offsets are bounded by ds_dims, which already fit usize"
+        )]
         let chunk_offsets: Vec<usize> = chunk_info
             .offsets
             .iter()
@@ -990,7 +1013,11 @@ pub fn read_chunked_data_cached(
         .map(|&d| d as usize)
         .collect();
 
-    let ds_dims: Vec<usize> = dataspace.dimensions.iter().map(|&d| d as usize).collect();
+    let ds_dims: Vec<usize> = dataspace
+        .dimensions
+        .iter()
+        .map(|&d| d.to_usize())
+        .collect::<Result<_, _>>()?;
     if ds_dims.len() != rank {
         return Err(FormatError::ChunkedReadError(format!(
             "rank mismatch: dataspace has {} dims, layout has {} chunk dims (rank={})",
@@ -1000,6 +1027,11 @@ pub fn read_chunked_data_cached(
         )));
     }
 
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "chunk byte sizes and the datatype element size are encoded into 32-bit \
+                  chunk-info fields; both stay well below u32::MAX (HDF5 caps a chunk at 4 GiB)"
+    )]
     let chunks = if let Some(chunks) = cache.all_indexed_chunks() {
         chunks
     } else {
@@ -1071,7 +1103,7 @@ pub fn read_chunked_data_cached(
     };
 
     // Assemble output
-    let total_elements = dataspace.num_elements() as usize;
+    let total_elements = dataspace.num_elements().to_usize()?;
     let total_bytes = total_elements * elem_size;
     let mut output = vec![0u8; total_bytes];
 
@@ -1117,6 +1149,10 @@ pub fn read_chunked_data_cached(
             dec
         };
 
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "chunk coordinate offsets are bounded by ds_dims, which already fit usize"
+        )]
         let chunk_offsets: Vec<usize> = chunk_info
             .offsets
             .iter()

--- a/src/chunked_write.rs
+++ b/src/chunked_write.rs
@@ -244,17 +244,35 @@ pub fn split_into_chunks(
     // Dataset strides (row-major)
     let mut ds_strides = vec![1usize; rank];
     for i in (0..rank.saturating_sub(1)).rev() {
-        ds_strides[i] = ds_strides[i + 1] * shape[i + 1] as usize;
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "dataset dimension derived from the in-memory write request; bounded by addressable memory"
+        )]
+        let dim = shape[i + 1] as usize;
+        ds_strides[i] = ds_strides[i + 1] * dim;
     }
 
     // Chunk strides
     let mut chunk_strides = vec![1usize; rank];
     for i in (0..rank.saturating_sub(1)).rev() {
-        chunk_strides[i] = chunk_strides[i + 1] * chunk_dims[i + 1] as usize;
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "chunk dimension derived from the in-memory write request; bounded by addressable memory"
+        )]
+        let dim = chunk_dims[i + 1] as usize;
+        chunk_strides[i] = chunk_strides[i + 1] * dim;
     }
 
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "chunk dimensions derived from the in-memory write request; bounded by addressable memory"
+    )]
     let chunk_total_elements: usize = chunk_dims.iter().map(|&d| d as usize).product();
 
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "total_chunks derived from the in-memory write request; bounded by addressable memory"
+    )]
     let mut result = Vec::with_capacity(total_chunks as usize);
 
     for linear_idx in 0..total_chunks {
@@ -283,8 +301,17 @@ pub fn split_into_chunks(
                 let coord_in_chunk = remaining_idx / chunk_strides[d];
                 remaining_idx %= chunk_strides[d];
 
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "chunk offset derived from the in-memory write request; bounded by addressable memory"
+                )]
                 let global_coord = offsets[d] as usize + coord_in_chunk;
-                if global_coord >= shape[d] as usize {
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "dataset dimension derived from the in-memory write request; bounded by addressable memory"
+                )]
+                let dim_extent = shape[d] as usize;
+                if global_coord >= dim_extent {
                     out_of_bounds = true;
                     break;
                 }
@@ -329,6 +356,10 @@ fn serialize_v4_single_chunk(
     buf.push(flags);
 
     // dimensionality = rank + 1 (chunk dims + element size dim)
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "rank written into the 1-byte dimensionality field selected for this file"
+    )]
     let ndims = chunk_dims.len() as u8 + 1;
     buf.push(ndims);
 
@@ -351,6 +382,10 @@ fn serialize_v4_single_chunk(
 
     // dimension sizes (chunk dims + element size)
     for &d in chunk_dims {
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "dimension written into the on-disk encoding width selected for this file"
+        )]
         match dim_encoded_len {
             1 => buf.push(d as u8),
             2 => buf.extend_from_slice(&(d as u16).to_le_bytes()),
@@ -359,6 +394,10 @@ fn serialize_v4_single_chunk(
         }
     }
     // Element size dimension
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "element size written into the on-disk encoding width selected for this file"
+    )]
     match dim_encoded_len {
         1 => buf.push(element_size as u8),
         2 => buf.extend_from_slice(&(element_size as u16).to_le_bytes()),
@@ -377,6 +416,10 @@ fn serialize_v4_single_chunk(
     }
 
     // chunk address
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "chunk address written into the on-disk offset width selected for this file"
+    )]
     match offset_size {
         4 => buf.extend_from_slice(&(chunk_address as u32).to_le_bytes()),
         8 => buf.extend_from_slice(&chunk_address.to_le_bytes()),
@@ -401,6 +444,10 @@ fn serialize_v4_fixed_array(
     let flags: u8 = 0x00;
     buf.push(flags);
 
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "rank written into the 1-byte dimensionality field selected for this file"
+    )]
     let ndims = chunk_dims.len() as u8 + 1;
     buf.push(ndims);
 
@@ -420,6 +467,10 @@ fn serialize_v4_fixed_array(
     buf.push(dim_encoded_len);
 
     for &d in chunk_dims {
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "dimension written into the on-disk encoding width selected for this file"
+        )]
         match dim_encoded_len {
             1 => buf.push(d as u8),
             2 => buf.extend_from_slice(&(d as u16).to_le_bytes()),
@@ -427,6 +478,10 @@ fn serialize_v4_fixed_array(
             _ => {}
         }
     }
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "element size written into the on-disk encoding width selected for this file"
+    )]
     match dim_encoded_len {
         1 => buf.push(element_size as u8),
         2 => buf.extend_from_slice(&(element_size as u16).to_le_bytes()),
@@ -441,6 +496,10 @@ fn serialize_v4_fixed_array(
     buf.push(max_bits);
 
     // Fixed Array header address
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "fixed array header address written into the on-disk offset width selected for this file"
+    )]
     match offset_size {
         4 => buf.extend_from_slice(&(fixed_array_address as u32).to_le_bytes()),
         8 => buf.extend_from_slice(&fixed_array_address.to_le_bytes()),
@@ -496,17 +555,29 @@ pub fn build_fixed_array_at(
     fahd.extend_from_slice(b"FAHD");
     fahd.push(0); // version
     fahd.push(client_id);
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "element record size written into the 1-byte FAHD field selected for this file"
+    )]
     fahd.push(elem_size as u8);
 
     let max_bits = FIXED_ARRAY_PAGE_BITS;
     fahd.push(max_bits);
 
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "element count written into the on-disk length width selected for this file"
+    )]
     match length_size {
         4 => fahd.extend_from_slice(&(num_elements as u32).to_le_bytes()),
         8 => fahd.extend_from_slice(&(num_elements as u64).to_le_bytes()),
         _ => fahd.extend_from_slice(&(num_elements as u64).to_le_bytes()),
     }
 
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "FADB address written into the on-disk offset width selected for this file"
+    )]
     match offset_size {
         4 => fahd.extend_from_slice(&(fadb_address as u32).to_le_bytes()),
         8 => fahd.extend_from_slice(&fadb_address.to_le_bytes()),
@@ -521,6 +592,10 @@ pub fn build_fixed_array_at(
 
     // Append one element record (chunk address, plus filtered size + mask).
     let write_element = |buf: &mut Vec<u8>, chunk: &WrittenChunk| {
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "chunk address written into the on-disk offset width selected for this file"
+        )]
         match offset_size {
             4 => buf.extend_from_slice(&(chunk.address as u32).to_le_bytes()),
             _ => buf.extend_from_slice(&chunk.address.to_le_bytes()),
@@ -538,6 +613,10 @@ pub fn build_fixed_array_at(
     fadb.extend_from_slice(b"FADB");
     fadb.push(0); // version
     fadb.push(client_id);
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "fixed array base address written into the on-disk offset width selected for this file"
+    )]
     match offset_size {
         4 => fadb.extend_from_slice(&(fa_base_address as u32).to_le_bytes()),
         _ => fadb.extend_from_slice(&fa_base_address.to_le_bytes()),
@@ -596,6 +675,10 @@ fn serialize_v4_extensible_array(
     buf.push(2); // class = chunked
     buf.push(0x00); // flags
 
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "rank written into the 1-byte dimensionality field selected for this file"
+    )]
     let ndims = chunk_dims.len() as u8 + 1;
     buf.push(ndims);
 
@@ -615,6 +698,10 @@ fn serialize_v4_extensible_array(
     buf.push(dim_encoded_len);
 
     for &d in chunk_dims {
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "dimension written into the on-disk encoding width selected for this file"
+        )]
         match dim_encoded_len {
             1 => buf.push(d as u8),
             2 => buf.extend_from_slice(&(d as u16).to_le_bytes()),
@@ -622,6 +709,10 @@ fn serialize_v4_extensible_array(
             _ => {}
         }
     }
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "element size written into the on-disk encoding width selected for this file"
+    )]
     match dim_encoded_len {
         1 => buf.push(element_size as u8),
         2 => buf.extend_from_slice(&(element_size as u16).to_le_bytes()),
@@ -640,6 +731,10 @@ fn serialize_v4_extensible_array(
     buf.push(10); // max_dblk_page_nelmts_bits
 
     // EA header address
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "extensible array header address written into the on-disk offset width selected for this file"
+    )]
     match offset_size {
         4 => buf.extend_from_slice(&(ea_address as u32).to_le_bytes()),
         8 => buf.extend_from_slice(&ea_address.to_le_bytes()),
@@ -651,6 +746,10 @@ fn serialize_v4_extensible_array(
 
 /// Write an offset-sized address (little-endian) to `buf`.
 pub(crate) fn write_ea_addr(buf: &mut Vec<u8>, val: u64, offset_size: u8) {
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "address written into the on-disk offset width selected for this file"
+    )]
     match offset_size {
         4 => buf.extend_from_slice(&(val as u32).to_le_bytes()),
         _ => buf.extend_from_slice(&val.to_le_bytes()),
@@ -806,7 +905,12 @@ pub(crate) fn eadb_size(
 ) -> u64 {
     let prefix = 4 + 1 + 1 + offset_size as usize + blk_off_size;
     if dblk_nelmts <= page_nelmts {
-        (prefix + dblk_nelmts as usize * elem_size + 4) as u64
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "data block element count derived from the in-memory write request; bounded by addressable memory"
+        )]
+        let nelmts = dblk_nelmts as usize;
+        (prefix + nelmts * elem_size + 4) as u64
     } else {
         // Paged: header carries its own checksum, then full pages follow.
         let npages = dblk_nelmts / page_nelmts;
@@ -825,13 +929,22 @@ pub(crate) fn aesb_size(
     blk_off_size: usize,
 ) -> u64 {
     let os = offset_size as usize;
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "data block and page counts derived from the in-memory write request; bounded by addressable memory"
+    )]
     let bitmap = if dblk_nelmts > page_nelmts {
         let npages = dblk_nelmts / page_nelmts;
         ndblks as usize * npages.div_ceil(8) as usize
     } else {
         0
     };
-    (4 + 1 + 1 + os + blk_off_size + bitmap + ndblks as usize * os + 4) as u64
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "data block count derived from the in-memory write request; bounded by addressable memory"
+    )]
+    let ndblks_usize = ndblks as usize;
+    (4 + 1 + 1 + os + blk_off_size + bitmap + ndblks_usize * os + 4) as u64
 }
 
 /// Compute the six Extensible Array header statistics for an array holding
@@ -937,6 +1050,10 @@ pub fn build_extensible_array_at(
 
     // Derive the block-size geometry from the shared helper (single source of
     // truth shared with the reader).
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "element record size written into the 1-byte EA header field selected for this file"
+    )]
     let geom_header = ExtensibleArrayHeader {
         client_id,
         element_size: elem_size as u8,
@@ -1109,6 +1226,10 @@ pub fn build_extensible_array_at(
     }
 
     // ---- Build the header (EAHD) ------------------------------------------
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "statistic written into the on-disk length width selected for this file"
+    )]
     let write_length = |buf: &mut Vec<u8>, val: u64| match length_size {
         4 => buf.extend_from_slice(&(val as u32).to_le_bytes()),
         _ => buf.extend_from_slice(&val.to_le_bytes()),
@@ -1118,6 +1239,10 @@ pub fn build_extensible_array_at(
     aehd.extend_from_slice(b"EAHD");
     aehd.push(0); // version
     aehd.push(client_id);
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "element record size written into the 1-byte EA header field selected for this file"
+    )]
     aehd.push(elem_size as u8);
     aehd.push(max_nelmts_bits);
     aehd.push(idx_blk_elmts);
@@ -1188,6 +1313,10 @@ fn write_chunk_element(
     has_filters: bool,
     chunk_size_bytes: usize,
 ) {
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "chunk address written into the on-disk offset width selected for this file"
+    )]
     match offset_size {
         4 => buf.extend_from_slice(&(chunk.address as u32).to_le_bytes()),
         8 => buf.extend_from_slice(&chunk.address.to_le_bytes()),
@@ -1271,6 +1400,10 @@ pub fn build_chunked_data_at_ext(
         });
     }
 
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "chunk dimensions written into the on-disk u32 dimension fields selected for this file"
+    )]
     let chunk_dims_u32: Vec<u32> = chunk_dims.iter().map(|&d| d as u32).collect();
     let offset_size: u8 = 8;
     let length_size: u8 = 8;
@@ -1284,6 +1417,10 @@ pub fn build_chunked_data_at_ext(
         data_buf.resize(aligned_idx, 0u8);
     }
 
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "element size written into the on-disk u32 dimension field selected for this file"
+    )]
     let layout_message = if use_extensible {
         let ea_address = base_address + data_buf.len() as u64;
 

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -22,10 +22,19 @@
 //! or size, a heap or collection size, `num_elements`, an element count, or any
 //! arithmetic on those that becomes a slice index or allocation size.
 //!
-//! Leave a plain `as` cast in place only when the source is **provably small on
-//! every supported target** (e.g. a `u8` "size of offsets" field that is 2/4/8,
-//! a version/flags byte, a `u16` message size capped at 64 KiB, or a small loop
+//! A narrowing `as` cast is acceptable only when the source is **provably
+//! bounded on every supported target** (e.g. a `u8` "size of offsets" field that
+//! is 2/4/8, a version/flags byte, a `u16` message size capped at 64 KiB, a
+//! match arm keyed on the on-disk field width it casts to, or a small loop
 //! counter). A `u8`/`u16` widening to `usize` never narrows and needs no guard.
+//!
+//! When you keep such a cast, annotate it at the site with
+//! `#[expect(clippy::cast_possible_truncation /* or cast_possible_wrap */,
+//! reason = "…")]`, where the `reason` states the bound that makes it safe. The
+//! 32-bit CI gate (the `cast-deny-32bit` job) denies both lints, so every
+//! narrowing cast must be either converted through the helpers above or
+//! explicitly accounted for this way; a leftover `#[expect]` whose cast was
+//! later removed fails the gate too, keeping the annotations honest.
 
 #[cfg(not(feature = "std"))]
 use core::ops::Range;

--- a/src/data_read.rs
+++ b/src/data_read.rs
@@ -425,6 +425,10 @@ pub fn read_as_f32(raw: &[u8], datatype: &Datatype) -> Result<Vec<f32>, FormatEr
                 result.push(read_f32_bytes(chunk, &order));
             }
             Datatype::FloatingPoint { size: 8, .. } => {
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "read_as_f32 narrows stored f64 values to the requested f32"
+                )]
                 result.push(read_f64_bytes(chunk, &order) as f32);
             }
             Datatype::FixedPoint {
@@ -466,6 +470,10 @@ pub fn read_as_i32(raw: &[u8], datatype: &Datatype) -> Result<Vec<i32>, FormatEr
     for i in 0..count {
         let chunk = &raw[i * elem_size..(i + 1) * elem_size];
         let v = read_signed_int(chunk, elem_size, &order);
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "read_as_i32 narrows each stored signed value to the requested i32"
+        )]
         result.push(v as i32);
     }
     Ok(result)
@@ -572,6 +580,11 @@ fn read_unsigned_int(bytes: &[u8], size: usize, order: &DatatypeByteOrder) -> u6
     }
 }
 
+#[expect(
+    clippy::cast_possible_wrap,
+    reason = "reinterprets raw bytes as a signed integer; sign reinterpretation and \
+              sign-extension are the intended operations"
+)]
 fn read_signed_int(bytes: &[u8], size: usize, order: &DatatypeByteOrder) -> i64 {
     let buf = reorder_bytes(bytes, order);
     match size {

--- a/src/dataspace.rs
+++ b/src/dataspace.rs
@@ -159,6 +159,10 @@ impl Dataspace {
     }
 
     fn write_length(buf: &mut Vec<u8>, val: u64, size: u8) {
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "size is the length byte width chosen to hold val, so each arm casts to a width that fits by construction"
+        )]
         match size {
             2 => buf.extend_from_slice(&(val as u16).to_le_bytes()),
             4 => buf.extend_from_slice(&(val as u32).to_le_bytes()),

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -601,6 +601,10 @@ impl Datatype {
                     _ => {}
                 }
                 // bf[1] = sign bit location (bit position of sign in the value)
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "size is an element byte size; *8-1 is a bit index that fits in a u8 (at most 63 for an 8-byte element)"
+                )]
                 let bf1 = (*size * 8 - 1) as u8;
                 let mut buf = Self::build_header(1, 1, [bf0, bf1, 0], *size);
                 buf.extend_from_slice(&bit_offset.to_le_bytes());
@@ -657,6 +661,10 @@ impl Datatype {
                 buf
             }
             Datatype::Compound { size, members } => {
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "compound member count is written into the 2-byte member-count field of the datatype message"
+                )]
                 let num = members.len() as u16;
                 let bf0 = (num & 0xFF) as u8;
                 let bf1 = ((num >> 8) & 0xFF) as u8;
@@ -667,6 +675,10 @@ impl Datatype {
                     buf.extend_from_slice(m.name.as_bytes());
                     buf.push(0);
                     // Byte offset (variable-width)
+                    #[expect(
+                        clippy::cast_possible_truncation,
+                        reason = "ob is the offset-byte width chosen to hold byte_offset, so each arm casts to a width that fits by construction"
+                    )]
                     match ob {
                         1 => buf.push(m.byte_offset as u8),
                         2 => buf.extend_from_slice(&(m.byte_offset as u16).to_le_bytes()),
@@ -682,6 +694,10 @@ impl Datatype {
                 base_type,
                 members,
             } => {
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "enumeration member count is written into the 2-byte member-count field of the datatype message"
+                )]
                 let num = members.len() as u16;
                 let bf0 = (num & 0xFF) as u8;
                 let bf1 = ((num >> 8) & 0xFF) as u8;
@@ -704,6 +720,10 @@ impl Datatype {
                 dimensions,
             } => {
                 let mut buf = Self::build_header(10, 3, [0, 0, 0], self.type_size());
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "array rank is written into the 1-byte dimensionality field; HDF5 caps array rank well below 255"
+                )]
                 buf.push(dimensions.len() as u8);
                 for &d in dimensions {
                     buf.extend_from_slice(&d.to_le_bytes());
@@ -747,6 +767,10 @@ impl Datatype {
             Datatype::Opaque { size, tag } => {
                 // bf0 carries the ASCII tag length; the tag is padded with zero
                 // bytes to a multiple of 8, mirroring `parse`.
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "opaque tag length is written into the 1-byte tag-length bit field (bf0)"
+                )]
                 let bf0 = tag.len() as u8;
                 let mut buf = Self::build_header(5, 1, [bf0, 0, 0], *size);
                 buf.extend_from_slice(tag);

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -722,6 +722,11 @@ impl EditSession {
 
             // Deep-copy each source subtree and link its root into this group.
             for (leaf, src_addr) in copies {
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "src_addr is an offset into self.data, the in-memory file image \
+                              (a Vec<u8>), so it always fits usize on the running target"
+                )]
                 let root = self.perform_copy(src_addr as usize, 0)?;
                 region.extend_from_slice(&encode_link_message(&leaf, root));
             }
@@ -816,6 +821,11 @@ impl EditSession {
         // could advertise an end-of-file past the actual file length.
         if let Some(cut) = trunc_to {
             self.handle.set_len(cut).map_err(Error::Io)?;
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "cut is a shrink target <= the current file length, which equals \
+                          self.data.len() (a usize)"
+            )]
             self.data.truncate(cut as usize);
             self.handle.sync_all().map_err(Error::Io)?;
         }
@@ -1183,7 +1193,16 @@ impl EditSession {
                 }
                 // Re-wrap the attribute message body (it is self-describing) in a
                 // v2 message record.
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "message type ids are a small enum that fits the 1-byte v2 type field"
+                )]
                 region.push(MessageType::Attribute.to_u16() as u8);
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "attribute body length fits the 2-byte message-size field (oversized \
+                              bodies are rejected above)"
+                )]
                 region.extend_from_slice(&(m.data.len() as u16).to_le_bytes());
                 region.push(0); // message flags
                 region.extend_from_slice(&m.data);
@@ -1742,6 +1761,10 @@ fn flatten_dataset(db: DatasetBuilder) -> Result<FlatDataset, Error> {
         } else {
             DataspaceType::Simple
         },
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "dataspace rank fits the 1-byte dimensionality field (HDF5 caps rank at 32)"
+        )]
         rank: shape.len() as u8,
         dimensions: shape,
         max_dimensions: None,
@@ -1775,7 +1798,15 @@ const GROUP_INFO_BODY: [u8; 2] = [0, 0];
 /// bodies are fixed and short.
 fn region_message(msg_type: MessageType, body: &[u8]) -> Vec<u8> {
     let mut m = Vec::with_capacity(4 + body.len());
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "message type ids are a small enum that fits the 1-byte v2 type field"
+    )]
     m.push(msg_type.to_u16() as u8);
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "callers pass bodies that fit the 2-byte message-size field (see doc comment)"
+    )]
     m.extend_from_slice(&(body.len() as u16).to_le_bytes());
     m.push(0); // message flags
     m.extend_from_slice(body);
@@ -2069,6 +2100,10 @@ fn build_v2_object_header(region: &[u8]) -> Vec<u8> {
     buf.extend_from_slice(b"OHDR");
     buf.push(2); // version
     buf.push(flags);
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "width was selected just above to be the smallest field that holds total"
+    )]
     match width {
         1 => buf.push(total as u8),
         2 => buf.extend_from_slice(&(total as u16).to_le_bytes()),
@@ -2081,6 +2116,11 @@ fn build_v2_object_header(region: &[u8]) -> Vec<u8> {
 }
 
 /// Read a little-endian unsigned integer of `bytes.len()` (≤ 8) bytes.
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "callers parse in-file sizes/offsets bounded by the in-memory image; downstream \
+              slicing is length-checked, so a malformed oversized field errors rather than reads OOB"
+)]
 fn read_le(bytes: &[u8]) -> usize {
     let mut v = 0u64;
     for (i, &b) in bytes.iter().enumerate() {

--- a/src/extensible_array.rs
+++ b/src/extensible_array.rs
@@ -227,6 +227,12 @@ impl EaGeometry {
         } else {
             min_dblk.trailing_zeros() as u64
         };
+        // `max_nelmts_bits` is a bit-count header field, so the difference is a
+        // small super-block count that always fits `usize`.
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "max_nelmts_bits is a bit count (<= 64); the super-block count fits usize"
+        )]
         let nsblks = (h.max_nelmts_bits as u64).saturating_sub(log2_min) as usize + 1;
 
         let mut sblks = Vec::with_capacity(nsblks);

--- a/src/file_writer.rs
+++ b/src/file_writer.rs
@@ -209,6 +209,11 @@ pub(crate) fn build_dense_attrs(attrs: &[AttributeMessage], base_address: u64) -
     let dblock_addr = frhp_addr + frhp_size as u64;
     let btree_addr = dblock_addr + starting_block_size;
 
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "starting_block_size is a fractal-heap direct-block size (KiB-scale heap \
+                  geometry), so it fits usize on every supported target"
+    )]
     let data_space = starting_block_size as usize - dblock_header_size;
     let free_space = data_space - total_data_size;
 
@@ -219,6 +224,11 @@ pub(crate) fn build_dense_attrs(attrs: &[AttributeMessage], base_address: u64) -
     frhp.extend_from_slice(&heap_id_length.to_le_bytes());
     frhp.extend_from_slice(&0u16.to_le_bytes()); // io_filter_encoded_length
     frhp.push(0x02); // flags: bit 1 = checksum direct blocks
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "max_direct_block_size and the header size are KiB-scale heap geometry that \
+                  fit the 4-byte max-managed-object-size field"
+    )]
     let max_managed = max_direct_block_size as u32 - dblock_header_size as u32;
     frhp.extend_from_slice(&max_managed.to_le_bytes());
     write_length(&mut frhp, 0, LENGTH_SIZE); // next_huge_object_id
@@ -246,6 +256,10 @@ pub(crate) fn build_dense_attrs(attrs: &[AttributeMessage], base_address: u64) -
     debug_assert_eq!(frhp.len(), frhp_size);
 
     // Build direct block: header (with checksum) + data + padding
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "starting_block_size is a KiB-scale heap direct-block size that fits usize"
+    )]
     let mut dblock = Vec::with_capacity(starting_block_size as usize);
     dblock.extend_from_slice(b"FHDB");
     dblock.push(0); // version
@@ -264,12 +278,16 @@ pub(crate) fn build_dense_attrs(attrs: &[AttributeMessage], base_address: u64) -
     }
 
     // Pad to full block size
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "starting_block_size is a KiB-scale heap direct-block size that fits usize"
+    )]
     dblock.resize(starting_block_size as usize, 0);
 
     // Checksum: computed over entire block with checksum field zeroed
     let dblock_checksum = crate::checksum::jenkins_lookup3(&dblock);
     dblock[cksum_pos..cksum_pos + 4].copy_from_slice(&dblock_checksum.to_le_bytes());
-    debug_assert_eq!(dblock.len(), starting_block_size as usize);
+    debug_assert_eq!(dblock.len() as u64, starting_block_size);
 
     // Build heap IDs
     let heap_ids: Vec<Vec<u8>> = attr_offsets
@@ -280,6 +298,10 @@ pub(crate) fn build_dense_attrs(attrs: &[AttributeMessage], base_address: u64) -
     // Build B-tree v2 type 8 records (17 bytes each)
     let record_size: u16 = heap_id_length + 1 + 4 + 4;
     let mut records: Vec<(u32, u32, Vec<u8>)> = Vec::with_capacity(attrs.len());
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "i is an attribute index bounded by the attribute count, far below u32::MAX"
+    )]
     for (i, heap_id) in heap_ids.iter().enumerate() {
         let mut rec = Vec::with_capacity(record_size as usize);
         rec.extend_from_slice(heap_id);
@@ -293,6 +315,11 @@ pub(crate) fn build_dense_attrs(attrs: &[AttributeMessage], base_address: u64) -
     let bthd_size = 4 + 1 + 1 + 4 + 2 + 2 + 1 + 1 + os + 2 + ls + 4;
     let num_records = attrs.len();
     let btlf_size = 4 + 1 + 1 + (num_records * record_size as usize) + 4;
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "b-tree leaf node size is a small power of two (>= 512) written into the \
+                  4-byte node-size field"
+    )]
     let node_size = btlf_size.next_power_of_two().max(512) as u32;
 
     let bthd_addr = btree_addr;
@@ -308,6 +335,10 @@ pub(crate) fn build_dense_attrs(attrs: &[AttributeMessage], base_address: u64) -
     bthd.push(100); // split_percent
     bthd.push(40); // merge_percent
     write_offset(&mut bthd, btlf_addr, OFFSET_SIZE);
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "record count is written into the 2-byte number-of-records field"
+    )]
     bthd.extend_from_slice(&(num_records as u16).to_le_bytes());
     write_length(&mut bthd, num_records as u64, LENGTH_SIZE);
     let bthd_checksum = crate::checksum::jenkins_lookup3(&bthd);
@@ -363,6 +394,10 @@ fn serialize_attribute_info(fh_addr: u64, btree_name_addr: u64) -> Vec<u8> {
 }
 
 fn write_offset(buf: &mut Vec<u8>, val: u64, offset_size: u8) {
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "each arm narrows to offset_size, the on-disk address width chosen for this file"
+    )]
     match offset_size {
         2 => buf.extend_from_slice(&(val as u16).to_le_bytes()),
         4 => buf.extend_from_slice(&(val as u32).to_le_bytes()),
@@ -594,6 +629,10 @@ impl FileWriter {
             if !is_empty && elem_size > 0 {
                 let expected = shape.iter().product::<u64>().saturating_mul(elem_size);
                 if raw.len() as u64 != expected {
+                    #[expect(
+                        clippy::cast_possible_truncation,
+                        reason = "byte counts reported in a shape-mismatch error; display-only"
+                    )]
                     return Err(FormatError::ShapeDataMismatch {
                         expected: expected as usize,
                         actual: raw.len(),
@@ -608,6 +647,11 @@ impl FileWriter {
                 } else {
                     DataspaceType::Simple
                 },
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "dataspace rank fits the 1-byte dimensionality field (HDF5 caps \
+                              rank at 32)"
+                )]
                 rank: shape.len() as u8,
                 dimensions: shape,
                 max_dimensions,
@@ -833,6 +877,11 @@ impl FileWriter {
         // Pass 2: compute real addresses.
         // All addresses stored in the file are relative to base_address.
         // base_address = userblock_size. cursor2 tracks relative positions.
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "userblock_size is a small power-of-two header size used as an in-memory \
+                      buffer offset; it fits usize on every supported target"
+        )]
         let ub = self.userblock_size as usize;
         let root_group_addr = SUPERBLOCK_SIZE as u64;
         let mut cursor2 = SUPERBLOCK_SIZE + root_oh_size;
@@ -1016,7 +1065,14 @@ impl FileWriter {
                     gcol_cursor += patch.collection_bytes.len() as u64;
                 }
             }
-            gcol_total_size = (gcol_cursor - cursor2 as u64) as usize;
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "global-heap total size is an in-memory output span bounded by \
+                          addressable memory on the target"
+            )]
+            {
+                gcol_total_size = (gcol_cursor - cursor2 as u64) as usize;
+            }
         }
 
         // Build dataset OHs now that attrs are patched.
@@ -1059,6 +1115,11 @@ impl FileWriter {
 
         // eof_address is absolute file size (includes userblock + GCOLs + ext)
         let eof_addr2 = (ub + cursor2 + gcol_total_size + ext_len) as u64;
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "capacity for the output buffer; eof_addr2 is the size of a file being \
+                      built in memory, so it fits usize on the running target"
+        )]
         let mut buf = Vec::with_capacity(eof_addr2 as usize);
 
         // Userblock: prepend zeros
@@ -1155,8 +1216,8 @@ impl FileWriter {
         // Superblock extension (File Space Info), at the address recorded above.
         if let Some(bytes) = &ext_oh {
             debug_assert_eq!(
-                buf.len(),
-                ub + ext_addr.unwrap() as usize,
+                buf.len() as u64,
+                ub as u64 + ext_addr.unwrap(),
                 "extension header must land at its recorded base-relative address"
             );
             buf.extend_from_slice(bytes);

--- a/src/filter_pipeline.rs
+++ b/src/filter_pipeline.rs
@@ -199,6 +199,10 @@ impl FilterPipeline {
     fn serialize_v1(&self) -> Vec<u8> {
         let mut buf = Vec::new();
         buf.push(1); // version
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "filter count is written into the 1-byte number-of-filters field of the v1 pipeline message"
+        )]
         buf.push(self.filters.len() as u8);
         buf.extend_from_slice(&[0u8; 6]); // reserved
 
@@ -213,9 +217,17 @@ impl FilterPipeline {
                 }
                 None => Vec::new(),
             };
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "filter name length is written into the 2-byte name-length field of the v1 pipeline message"
+            )]
             let name_length = name_bytes.len() as u16;
             buf.extend_from_slice(&name_length.to_le_bytes());
             buf.extend_from_slice(&f.flags.to_le_bytes());
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "client-data value count is written into the 2-byte client-data-values field of the v1 pipeline message"
+            )]
             buf.extend_from_slice(&(f.client_data.len() as u16).to_le_bytes());
 
             if !name_bytes.is_empty() {
@@ -242,6 +254,10 @@ impl FilterPipeline {
     fn serialize_v2(&self) -> Vec<u8> {
         let mut buf = Vec::new();
         buf.push(2); // version
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "filter count is written into the 1-byte number-of-filters field of the v2 pipeline message"
+        )]
         buf.push(self.filters.len() as u8);
 
         for f in &self.filters {
@@ -256,12 +272,24 @@ impl FilterPipeline {
                     }
                     None => vec![0],
                 };
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "filter name length is written into the 2-byte name-length field of the v2 pipeline message"
+                )]
                 buf.extend_from_slice(&(name_bytes.len() as u16).to_le_bytes());
                 buf.extend_from_slice(&f.flags.to_le_bytes());
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "client-data value count is written into the 2-byte client-data-values field of the v2 pipeline message"
+                )]
                 buf.extend_from_slice(&(f.client_data.len() as u16).to_le_bytes());
                 buf.extend_from_slice(&name_bytes);
             } else {
                 buf.extend_from_slice(&f.flags.to_le_bytes());
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "client-data value count is written into the 2-byte client-data-values field of the v2 pipeline message"
+                )]
                 buf.extend_from_slice(&(f.client_data.len() as u16).to_le_bytes());
             }
 

--- a/src/fractal_heap.rs
+++ b/src/fractal_heap.rs
@@ -411,6 +411,10 @@ impl FractalHeapHeader {
         };
         let heap_offset = combined & offset_mask;
 
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "payload is a single managed-object heap entry; its bit length fits u32"
+        )]
         let total_payload_bits = (payload.len() as u32) * 8;
         let length_bits = total_payload_bits.saturating_sub(offset_bits);
         let length_val = if length_bits == 0 {
@@ -645,6 +649,11 @@ impl FractalHeapHeader {
                 if !is_undefined(child_addr, offset_size) {
                     let block_end = current_heap_offset.saturating_add(total_child_space);
                     if target_offset >= current_heap_offset && target_offset < block_end {
+                        #[expect(
+                            clippy::cast_possible_truncation,
+                            reason = "fractal-heap row count is log-scale (bounded by \
+                                      max_heap_size bits), so it fits u16"
+                        )]
                         return Ok(Some(HeapChild::Indirect {
                             addr: child_addr,
                             nrows: child_nrows as u16,

--- a/src/lane_partition.rs
+++ b/src/lane_partition.rs
@@ -58,6 +58,10 @@ pub fn partition(num_items: usize, num_lanes: usize, seed: u64) -> Vec<Vec<usize
 
     for idx in 0..num_items {
         let h = fxhash_combine(seed, idx as u64);
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "h % num_lanes is in 0..num_lanes, which is itself a usize"
+        )]
         let lane = (h % num_lanes as u64) as usize;
         lanes[lane].push(idx);
     }

--- a/src/link_message.rs
+++ b/src/link_message.rs
@@ -135,6 +135,13 @@ impl LinkMessage {
             });
         }
 
+        // `name_size_width` was chosen above (1/2/4 bytes) to be the smallest
+        // field that holds `name_len`, so each arm's narrowing matches a width
+        // already proven to fit the value.
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "name_size_width selected above to fit name_len"
+        )]
         match name_size_width {
             1 => buf.push(name_len as u8),
             2 => buf.extend_from_slice(&(name_len as u16).to_le_bytes()),
@@ -146,14 +153,27 @@ impl LinkMessage {
         match &self.link_target {
             LinkTarget::Hard {
                 object_header_address,
-            } => match offset_size {
-                2 => buf.extend_from_slice(&(*object_header_address as u16).to_le_bytes()),
-                4 => buf.extend_from_slice(&(*object_header_address as u32).to_le_bytes()),
-                8 => buf.extend_from_slice(&object_header_address.to_le_bytes()),
-                _ => {}
-            },
+            } =>
+            {
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "offset_size is the file's on-disk address width; each arm \
+                              narrows to the width chosen to hold object header addresses"
+                )]
+                match offset_size {
+                    2 => buf.extend_from_slice(&(*object_header_address as u16).to_le_bytes()),
+                    4 => buf.extend_from_slice(&(*object_header_address as u32).to_le_bytes()),
+                    8 => buf.extend_from_slice(&object_header_address.to_le_bytes()),
+                    _ => {}
+                }
+            }
             LinkTarget::Soft { target_path } => {
                 let path_bytes = target_path.as_bytes();
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "soft-link length prefix is a 2-byte on-disk field; target \
+                              paths are bounded by that HDF5 format limit"
+                )]
                 buf.extend_from_slice(&(path_bytes.len() as u16).to_le_bytes());
                 buf.extend_from_slice(path_bytes);
             }
@@ -167,6 +187,11 @@ impl LinkMessage {
                 ext_data.push(0);
                 ext_data.extend_from_slice(object_path.as_bytes());
                 ext_data.push(0);
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "external-link length prefix is a 2-byte on-disk field; the \
+                              filename + object path are bounded by that HDF5 format limit"
+                )]
                 buf.extend_from_slice(&(ext_data.len() as u16).to_le_bytes());
                 buf.extend_from_slice(&ext_data);
             }

--- a/src/mat/builder.rs
+++ b/src/mat/builder.rs
@@ -554,6 +554,10 @@ impl MatBuilder {
 
         // 2. Register the payload path; the resulting object id is 1-based.
         self.string_object_payload_paths.push(payload_path);
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "1-based object id written into a 4-byte on-disk field; a MAT file never registers more than u32::MAX string objects"
+        )]
         let object_id = self.string_object_payload_paths.len() as u32;
 
         // 3. Emit the parent metadata dataset at the current scope.

--- a/src/mat/de/reader.rs
+++ b/src/mat/de/reader.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 
+use crate::convert::TryToUsize;
 use crate::file_writer::AttrValue;
 use crate::mat::class::MatClass;
 use crate::mat::error::MatError;
@@ -57,7 +58,7 @@ fn read_dataset(ds: &Dataset<'_>) -> Result<MatValue, MatError> {
         // `Matrix<Complex*>` round-trips back to a 0×0 complex matrix
         // rather than collapsing to a numeric empty vec.
         if matches!(class, MatClass::Double | MatClass::Single) && is_complex_dtype(&dtype) {
-            return Ok(empty_complex_value(class, &shape));
+            return empty_complex_value(class, &shape);
         }
         // Empty numeric/char: produce an empty 1-D vec of the correct tag.
         return Ok(empty_value_for_class(class));
@@ -126,9 +127,9 @@ fn is_empty_attr(attrs: &HashMap<String, AttrValue>) -> bool {
 /// Build an empty `ComplexMatrix*` whose `(rows, cols)` matches the dataspace
 /// shape, so deserializing into `Matrix<Complex*>` recovers the original
 /// shape (0×0, 0×N, N×0) instead of collapsing to 1×0.
-fn empty_complex_value(class: MatClass, shape: &[u64]) -> MatValue {
-    let (rows, cols, _total) = shape_decomposition(shape);
-    match class {
+fn empty_complex_value(class: MatClass, shape: &[u64]) -> Result<MatValue, MatError> {
+    let (rows, cols, _total) = shape_decomposition(shape)?;
+    Ok(match class {
         MatClass::Double => MatValue::ComplexMatrix64 {
             rows,
             cols,
@@ -140,7 +141,7 @@ fn empty_complex_value(class: MatClass, shape: &[u64]) -> MatValue {
             pairs: Vec::new(),
         },
         _ => unreachable!("empty_complex_value called with non-float class"),
-    }
+    })
 }
 
 fn empty_value_for_class(class: MatClass) -> MatValue {
@@ -199,7 +200,7 @@ fn is_complex_dtype(dtype: &DType) -> bool {
 // ---------------------------------------------------------------------------
 
 fn read_numeric(ds: &Dataset<'_>, shape: &[u64], class: MatClass) -> Result<MatValue, MatError> {
-    let (rows, cols, total) = shape_decomposition(shape);
+    let (rows, cols, total) = shape_decomposition(shape)?;
 
     // For a single-element dataset we emit a Scalar of the appropriate class.
     if total == 1 {
@@ -234,25 +235,33 @@ fn read_numeric(ds: &Dataset<'_>, shape: &[u64], class: MatClass) -> Result<MatV
     })
 }
 
-fn shape_decomposition(shape: &[u64]) -> (usize, usize, usize) {
+fn shape_decomposition(shape: &[u64]) -> Result<(usize, usize, usize), MatError> {
     // HDF5 shape for MATLAB data is [cols, rows] (column-major storage of a
     // [rows, cols] matrix). For a 1-D variant like [1, N] or [N, 1], treat as
-    // a vector of length N.
-    match shape.len() {
+    // a vector of length N. The dimensions come from the file, so each is
+    // narrowed to `usize` through the checked conversion that errors (rather
+    // than truncating) if a dimension exceeds the platform's pointer width.
+    Ok(match shape.len() {
         0 => (1, 1, 1),
-        1 => (1, shape[0] as usize, shape[0] as usize),
+        1 => {
+            let n = shape[0].to_usize()?;
+            (1, n, n)
+        }
         2 => {
-            let cols_hdf5 = shape[0] as usize;
-            let rows_hdf5 = shape[1] as usize;
+            let cols_hdf5 = shape[0].to_usize()?;
+            let rows_hdf5 = shape[1].to_usize()?;
             // MATLAB matrix has rows = rows_hdf5, cols = cols_hdf5.
             let total = cols_hdf5 * rows_hdf5;
             (rows_hdf5, cols_hdf5, total)
         }
         _ => {
-            let total: usize = shape.iter().map(|&d| d as usize).product();
+            let mut total: usize = 1;
+            for &d in shape {
+                total *= d.to_usize()?;
+            }
             (1, total, total)
         }
-    }
+    })
 }
 
 fn read_all_elements(ds: &Dataset<'_>, class: MatClass) -> Result<NumVec, MatError> {
@@ -329,7 +338,7 @@ fn transpose_col_major_to_row_major(
 // ---------------------------------------------------------------------------
 
 fn read_complex(ds: &Dataset<'_>, shape: &[u64], class: MatClass) -> Result<MatValue, MatError> {
-    let (rows, cols, total) = shape_decomposition(shape);
+    let (rows, cols, total) = shape_decomposition(shape)?;
     let bytes = ds.read_u8().map_err(MatError::Hdf5)?;
 
     match class {

--- a/src/mat/de/value_de.rs
+++ b/src/mat/de/value_de.rs
@@ -49,14 +49,26 @@ impl<'de> Deserializer<'de> for MatValueDeserializer {
 
     fn deserialize_i8<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, MatError> {
         let v = to_i64(self.value, "i8")?;
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "deserialize_i8 narrows the MAT scalar to the i8 the visitor requested; lossy by the serde contract"
+        )]
         visitor.visit_i8(v as i8)
     }
     fn deserialize_i16<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, MatError> {
         let v = to_i64(self.value, "i16")?;
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "deserialize_i16 narrows the MAT scalar to the i16 the visitor requested; lossy by the serde contract"
+        )]
         visitor.visit_i16(v as i16)
     }
     fn deserialize_i32<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, MatError> {
         let v = to_i64(self.value, "i32")?;
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "deserialize_i32 narrows the MAT scalar to the i32 the visitor requested; lossy by the serde contract"
+        )]
         visitor.visit_i32(v as i32)
     }
     fn deserialize_i64<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, MatError> {
@@ -65,14 +77,26 @@ impl<'de> Deserializer<'de> for MatValueDeserializer {
     }
     fn deserialize_u8<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, MatError> {
         let v = to_u64(self.value, "u8")?;
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "deserialize_u8 narrows the MAT scalar to the u8 the visitor requested; lossy by the serde contract"
+        )]
         visitor.visit_u8(v as u8)
     }
     fn deserialize_u16<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, MatError> {
         let v = to_u64(self.value, "u16")?;
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "deserialize_u16 narrows the MAT scalar to the u16 the visitor requested; lossy by the serde contract"
+        )]
         visitor.visit_u16(v as u16)
     }
     fn deserialize_u32<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, MatError> {
         let v = to_u64(self.value, "u32")?;
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "deserialize_u32 narrows the MAT scalar to the u32 the visitor requested; lossy by the serde contract"
+        )]
         visitor.visit_u32(v as u32)
     }
     fn deserialize_u64<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, MatError> {
@@ -81,6 +105,10 @@ impl<'de> Deserializer<'de> for MatValueDeserializer {
     }
     fn deserialize_f32<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, MatError> {
         let v = to_f64(self.value, "f32")?;
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "deserialize_f32 narrows the MAT scalar to the f32 the visitor requested; lossy by the serde contract"
+        )]
         visitor.visit_f32(v as f32)
     }
     fn deserialize_f64<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, MatError> {
@@ -421,8 +449,20 @@ fn to_i64(v: MatValue, expected: &'static str) -> Result<i64, MatError> {
         MatValue::Scalar(ScalarNum::U8(x)) => Ok(x as i64),
         MatValue::Scalar(ScalarNum::U16(x)) => Ok(x as i64),
         MatValue::Scalar(ScalarNum::U32(x)) => Ok(x as i64),
+        #[expect(
+            clippy::cast_possible_wrap,
+            reason = "the `x <= i64::MAX` guard keeps the U64 in i64 range, so `x as i64` cannot wrap"
+        )]
         MatValue::Scalar(ScalarNum::U64(x)) if x <= i64::MAX as u64 => Ok(x as i64),
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "coercing a MAT F64 scalar to the requested i64; float->int truncation is the intended numeric conversion"
+        )]
         MatValue::Scalar(ScalarNum::F64(x)) => Ok(x as i64),
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "coercing a MAT F32 scalar to the requested i64; float->int truncation is the intended numeric conversion"
+        )]
         MatValue::Scalar(ScalarNum::F32(x)) => Ok(x as i64),
         MatValue::Scalar(ScalarNum::Bool(b)) => Ok(i64::from(b)),
         other => mismatch(expected, other),
@@ -439,7 +479,15 @@ fn to_u64(v: MatValue, expected: &'static str) -> Result<u64, MatError> {
         MatValue::Scalar(ScalarNum::I16(x)) if x >= 0 => Ok(x as u64),
         MatValue::Scalar(ScalarNum::I32(x)) if x >= 0 => Ok(x as u64),
         MatValue::Scalar(ScalarNum::I64(x)) if x >= 0 => Ok(x as u64),
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "the `x >= 0.0` guard keeps the F64 non-negative; float->int truncation to u64 is the intended numeric conversion"
+        )]
         MatValue::Scalar(ScalarNum::F64(x)) if x >= 0.0 => Ok(x as u64),
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "the `x >= 0.0` guard keeps the F32 non-negative; float->int truncation to u64 is the intended numeric conversion"
+        )]
         MatValue::Scalar(ScalarNum::F32(x)) if x >= 0.0 => Ok(x as u64),
         MatValue::Scalar(ScalarNum::Bool(b)) => Ok(u64::from(b)),
         other => mismatch(expected, other),

--- a/src/mat/ser/value_ser.rs
+++ b/src/mat/ser/value_ser.rs
@@ -647,8 +647,16 @@ fn matrix_from_fields(fields: MatrixFields, kind: MatrixKind) -> Result<MatValue
 
 fn expect_usize(v: MatValue, field: &str) -> Result<usize, MatError> {
     match v {
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "serde scalar accessor; conversion of a user-level MAT scalar (e.g. a Matrix rows/cols field) to usize, not a file-derived size"
+        )]
         MatValue::Scalar(ScalarNum::U64(x)) => Ok(x as usize),
         MatValue::Scalar(ScalarNum::U32(x)) => Ok(x as usize),
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "the `x >= 0` guard keeps the I64 non-negative; serde scalar accessor converting a user-level MAT scalar to usize, not a file-derived size"
+        )]
         MatValue::Scalar(ScalarNum::I64(x)) if x >= 0 => Ok(x as usize),
         MatValue::Scalar(ScalarNum::I32(x)) if x >= 0 => Ok(x as usize),
         MatValue::Scalar(ScalarNum::U16(x)) => Ok(x as usize),
@@ -674,6 +682,10 @@ fn expect_f64(v: MatValue) -> Result<f64, MatError> {
 fn expect_f32(v: MatValue) -> Result<f32, MatError> {
     match v {
         MatValue::Scalar(ScalarNum::F32(x)) => Ok(x),
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "coercing a user-supplied F64 complex field to the requested f32; lossy float narrowing is the intended conversion"
+        )]
         MatValue::Scalar(ScalarNum::F64(x)) => Ok(x as f32),
         other => Err(MatError::Custom(format!(
             "Complex field must be f32, got {}",

--- a/src/mat/string_object.rs
+++ b/src/mat/string_object.rs
@@ -113,12 +113,20 @@ pub fn build_string_filewrapper_metadata(object_count: usize) -> Vec<u8> {
     let mut saveobj_metadata = Vec::with_capacity(2 + object_count * 4);
     saveobj_metadata.extend_from_slice(&[0, 0]);
     for idx in 0..object_count {
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "object index written into a 4-byte on-disk saveobj field; MAT files never hold more than u32::MAX objects"
+        )]
         saveobj_metadata.extend_from_slice(&[1, 1, 1, idx as u32]);
     }
     let saveobj_metadata = u32_bytes(&saveobj_metadata);
 
     let mut object_id_metadata = Vec::with_capacity(6 + object_count * 6);
     object_id_metadata.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "object count bounds a 4-byte on-disk object-id field; MAT files never hold more than u32::MAX objects"
+    )]
     for id in 1..=object_count as u32 {
         object_id_metadata.extend_from_slice(&[1, 0, 0, id, 0, id]);
     }
@@ -136,22 +144,31 @@ pub fn build_string_filewrapper_metadata(object_count: usize) -> Vec<u8> {
     let region6 = Vec::new();
     let region7 = vec![0u8; 8];
 
-    let mut offset = 40u32 + names_bytes.len() as u32;
-    region_offsets[0] = offset;
-    offset += class_id_metadata.len() as u32;
-    region_offsets[1] = offset;
-    offset += saveobj_metadata.len() as u32;
-    region_offsets[2] = offset;
-    offset += object_id_metadata.len() as u32;
-    region_offsets[3] = offset;
-    offset += nobj_metadata.len() as u32;
-    region_offsets[4] = offset;
-    offset += dynprop_metadata.len() as u32;
-    region_offsets[5] = offset;
-    offset += region6.len() as u32;
-    region_offsets[6] = offset;
-    offset += region7.len() as u32;
-    region_offsets[7] = offset;
+    // Accumulate each metadata region's length into the 4-byte filewrapper
+    // offsets. Every metadata region is far smaller than u32::MAX.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "region lengths accumulated into 4-byte on-disk filewrapper offsets; \
+                  metadata regions are far smaller than u32::MAX"
+    )]
+    {
+        let mut offset = 40u32 + names_bytes.len() as u32;
+        region_offsets[0] = offset;
+        offset += class_id_metadata.len() as u32;
+        region_offsets[1] = offset;
+        offset += saveobj_metadata.len() as u32;
+        region_offsets[2] = offset;
+        offset += object_id_metadata.len() as u32;
+        region_offsets[3] = offset;
+        offset += nobj_metadata.len() as u32;
+        region_offsets[4] = offset;
+        offset += dynprop_metadata.len() as u32;
+        region_offsets[5] = offset;
+        offset += region6.len() as u32;
+        region_offsets[6] = offset;
+        offset += region7.len() as u32;
+        region_offsets[7] = offset;
+    }
 
     regions.extend_from_slice(&version);
     regions.extend_from_slice(&num_names);

--- a/src/mat/userblock.rs
+++ b/src/mat/userblock.rs
@@ -18,7 +18,7 @@ pub const DEFAULT_DESCRIPTION: &str = "MATLAB 7.3 MAT-file, Platform: hdf5-pure 
 /// untouched (zeros from `FileBuilder::with_userblock(512)`).
 pub fn write_header(file_bytes: &mut [u8], description: &str) {
     assert!(
-        file_bytes.len() >= USERBLOCK_SIZE as usize,
+        file_bytes.len() as u64 >= USERBLOCK_SIZE,
         "userblock requires at least 512 bytes, got {}",
         file_bytes.len()
     );
@@ -52,7 +52,7 @@ pub fn write_header(file_bytes: &mut [u8], description: &str) {
 /// Verify the bytes look like a MATLAB v7.3 userblock. Returns `Ok(())` on
 /// success.
 pub fn verify_header(file_bytes: &[u8]) -> Result<(), &'static str> {
-    if file_bytes.len() < USERBLOCK_SIZE as usize {
+    if (file_bytes.len() as u64) < USERBLOCK_SIZE {
         return Err("file too short for MAT v7.3 userblock");
     }
     if !file_bytes[..6].eq_ignore_ascii_case(b"MATLAB") {

--- a/src/object_header_writer.rs
+++ b/src/object_header_writer.rs
@@ -56,6 +56,10 @@ impl ObjectHeaderWriter {
         // flags
         buf.push(flags);
         // chunk0 size
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "chunk_size_width is the byte width chosen to hold msg_bytes_total, so each arm casts to a width that fits by construction"
+        )]
         match chunk_size_width {
             1 => buf.push(msg_bytes_total as u8),
             2 => buf.extend_from_slice(&(msg_bytes_total as u16).to_le_bytes()),
@@ -65,7 +69,15 @@ impl ObjectHeaderWriter {
 
         // Messages
         for (msg_type, data, msg_flags) in &self.messages {
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "message type id is a small enum value written into the 1-byte message-type field of the v2 object header"
+            )]
             buf.push(msg_type.to_u16() as u8); // type (1 byte in v2)
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "message data length is written into the 2-byte message-size field of the v2 object header"
+            )]
             buf.extend_from_slice(&(data.len() as u16).to_le_bytes()); // size (2 bytes)
             buf.push(*msg_flags); // flags
             buf.extend_from_slice(data);

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -930,12 +930,20 @@ impl<'f> Dataset<'f> {
     }
 
     /// Read all data as `i8` values.
+    #[expect(
+        clippy::cast_possible_wrap,
+        reason = "read_i8 reinterprets each stored byte as the signed i8 the caller requested"
+    )]
     pub fn read_i8(&self) -> Result<Vec<i8>, Error> {
         let raw = self.read_raw()?;
         Ok(raw.iter().map(|&b| b as i8).collect())
     }
 
     /// Read all data as `i16` values.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "read_i16 narrows each stored value to the i16 element type the caller requested"
+    )]
     pub fn read_i16(&self) -> Result<Vec<i16>, Error> {
         let raw = self.read_raw()?;
         let dt = self.datatype()?;
@@ -944,6 +952,10 @@ impl<'f> Dataset<'f> {
     }
 
     /// Read all data as `u16` values.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "read_u16 narrows each stored value to the u16 element type the caller requested"
+    )]
     pub fn read_u16(&self) -> Result<Vec<u16>, Error> {
         let raw = self.read_raw()?;
         let dt = self.datatype()?;
@@ -952,6 +964,10 @@ impl<'f> Dataset<'f> {
     }
 
     /// Read all data as `u32` values.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "read_u32 narrows each stored value to the u32 element type the caller requested"
+    )]
     pub fn read_u32(&self) -> Result<Vec<u32>, Error> {
         let raw = self.read_raw()?;
         let dt = self.datatype()?;

--- a/src/scaleoffset.rs
+++ b/src/scaleoffset.rs
@@ -197,6 +197,10 @@ pub(crate) fn scale_offset_mode(cd_values: &[u32]) -> Option<ScaleOffset> {
     }
     match scale_type {
         SO_INT => Some(ScaleOffset::Integer(scale_factor)),
+        #[expect(
+            clippy::cast_possible_wrap,
+            reason = "scale_factor is a small decimal scale factor (D-scale parameter); the reference treats it as a signed int"
+        )]
         SO_FLOAT_DSCALE => Some(ScaleOffset::FloatDScale(scale_factor as i32)),
         // SO_FLOAT_ESCALE (and anything unrecognized) is never written by this
         // crate and cannot be reproduced.
@@ -245,6 +249,10 @@ impl Parms {
                 "scaleoffset: bad byte order".to_string(),
             ));
         }
+        #[expect(
+            clippy::cast_possible_wrap,
+            reason = "scale_factor is a small filter parameter (decimal scale factor or bit width); the reference stores it in a signed int"
+        )]
         Ok(Parms {
             scale_type: cd[PARM_SCALETYPE],
             scale_factor: cd[PARM_SCALEFACTOR] as i32,
@@ -278,6 +286,10 @@ pub fn decompress(input: &[u8], filter: &FilterDescription) -> Result<Vec<u8>, F
         ));
     }
 
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "p.size is validated to 1..=8, so p.size * 8 is 8..=64 and fits in u32"
+    )]
     let full_bits = (p.size * 8) as u32;
     // `nelmts` is file-derived; `nelmts * size` is an allocation size and a
     // slice bound. The product is computed in `u64` (it cannot overflow there:
@@ -287,6 +299,10 @@ pub fn decompress(input: &[u8], filter: &FilterDescription) -> Result<Vec<u8>, F
 
     // No-op mode: integer (non-DSCALE) datasets created with scale_factor equal
     // to the full bit width store the chunk verbatim, with no header.
+    #[expect(
+        clippy::cast_possible_wrap,
+        reason = "full_bits is 8..=64 (p.size is 1..=8), so it fits in a non-negative i32"
+    )]
     if p.scale_type != SO_FLOAT_DSCALE && p.scale_factor == full_bits as i32 {
         return Ok(input.to_vec());
     }
@@ -402,6 +418,10 @@ pub fn compress(input: &[u8], filter: &FilterDescription) -> Result<Vec<u8>, For
     }
 
     let signed = cd[PARM_SIGN] == SGN_2;
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "p.size is validated to 1..=8, so p.size * 8 is 8..=64 and fits in u32"
+    )]
     let full_bits = (p.size * 8) as u32;
 
     let (minbits, minval, offsets) = if p.class == CLS_INTEGER {
@@ -452,6 +472,10 @@ fn precompress_integer(input: &[u8], p: &Parms, signed: bool) -> (u32, u64, Vec<
     // a Vec<i128>. The intermediate dominated cache pressure on large chunks
     // (16 B/element vs the source's 1-8 B/element); two cache-warm passes
     // come out ahead.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "p.size is validated to 1..=8, so p.size * 8 is 8..=64 and fits in u32"
+    )]
     let full_bits = (p.size * 8) as u32;
     let read_as_i128 = |i: usize| -> i128 {
         let bits = read_value(&input[i * p.size..(i + 1) * p.size], p.size, p.order);
@@ -474,6 +498,10 @@ fn precompress_integer(input: &[u8], p: &Parms, signed: bool) -> (u32, u64, Vec<
         }
     }
 
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "min is an element value read from at most 8 bytes (p.size 1..=8), so it fits in i64/u64 despite the i128 accumulator type"
+    )]
     let minval = if signed {
         (min as i64) as u64
     } else {
@@ -488,11 +516,19 @@ fn precompress_integer(input: &[u8], p: &Parms, signed: bool) -> (u32, u64, Vec<
         return (full_bits, minval, Vec::new());
     }
 
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "the guard above returns early unless spread <= width_max - 2, and width_max <= u64::MAX, so spread fits in u64"
+    )]
     let minbits = ceil_log2((spread as u64) + 1);
     if minbits >= full_bits {
         return (full_bits, minval, Vec::new());
     }
 
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "each offset (value - min) is at most spread <= width_max <= u64::MAX, so it fits in u64"
+    )]
     let offsets = (0..p.nelmts)
         .map(|i| (read_as_i128(i) - min) as u64)
         .collect();
@@ -520,10 +556,18 @@ fn reconstruct_float(
     // loop-invariant. The compiler won't hoist the inner `match p.size`
     // across both branches by itself.
     if p.size == 4 {
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "size == 4 branch: minval holds a 4-byte f32 bit pattern in its low 32 bits, so narrowing to u32 reconstructs that pattern"
+        )]
         let min = f32::from_bits(minval as u32);
         let pow = pow10_f32(decimals);
         for _ in 0..p.nelmts {
             let d = reader.read(minbits);
+            #[expect(
+                clippy::cast_possible_wrap,
+                reason = "d is a minbits-wide offset (minbits < full_bits <= 64); reinterpreting it as i64 matches the reference's signed reconstruction"
+            )]
             let bits = if let Some(fv) = filval.filter(|_| d == sentinel) {
                 fv
             } else {
@@ -536,6 +580,10 @@ fn reconstruct_float(
         let pow = pow10_f64(decimals);
         for _ in 0..p.nelmts {
             let d = reader.read(minbits);
+            #[expect(
+                clippy::cast_possible_wrap,
+                reason = "d is a minbits-wide offset (minbits < full_bits <= 64); reinterpreting it as i64 matches the reference's signed reconstruction"
+            )]
             let bits = if let Some(fv) = filval.filter(|_| d == sentinel) {
                 fv
             } else {
@@ -553,8 +601,16 @@ fn precompress_float(input: &[u8], p: &Parms) -> (u32, u64, Vec<u64>) {
     // out of the per-element loop so we don't recompute the same product N
     // times — bit-identical to the previous `v * pow - min * pow`.
     let decimals = p.scale_factor;
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "p.size is validated to 1..=8, so p.size * 8 is 8..=64 and fits in u32"
+    )]
     let full_bits = (p.size * 8) as u32;
     if p.size == 4 {
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "read_value with size 4 returns a u64 whose meaningful bits are the low 32, so narrowing to u32 reconstructs the f32 bit pattern"
+        )]
         let read_f32 = |i: usize| -> f32 {
             f32::from_bits(read_value(&input[i * 4..i * 4 + 4], 4, p.order) as u32)
         };
@@ -691,15 +747,31 @@ fn pack_offsets(offsets: &[u64], minbits: u32, nelmts: usize) -> Result<Vec<u8>,
         let combined = ((acc as u128) << minbits) | (v & mask) as u128;
         let total = nbits + minbits;
         if total <= 64 {
-            acc = combined as u64;
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "this branch is guarded by total <= 64, and combined occupies exactly `total` bits, so it fits in u64"
+            )]
+            {
+                acc = combined as u64;
+            }
             nbits = total;
         } else {
             // The merged value spans more than a u64; emit 8 bytes from the
             // top and keep the spillover (always 1..=7 bits) for next round.
             let drop = total - 64;
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "combined >> drop keeps the high 64 bits of a (64 + drop)-bit value, which fits in u64"
+            )]
             let top = (combined >> drop) as u64;
             buf.extend_from_slice(&top.to_be_bytes());
-            acc = (combined & ((1u128 << drop) - 1)) as u64;
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "combined & ((1 << drop) - 1) masks to the low `drop` bits (drop is 1..=7 here), which fits in u64"
+            )]
+            {
+                acc = (combined & ((1u128 << drop) - 1)) as u64;
+            }
             nbits = drop;
         }
     }
@@ -743,6 +815,10 @@ impl<'a> BitReader<'a> {
     fn read(&mut self, minbits: u32) -> u64 {
         debug_assert!((1..=64).contains(&minbits));
         let byte = self.bit_pos >> 3;
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "bit_pos & 7 masks to 0..=7, which trivially fits in u32"
+        )]
         let off = (self.bit_pos & 7) as u32;
 
         // Load a 72-bit window at `byte`. Hot path: payload has ≥ 9 bytes
@@ -815,6 +891,10 @@ fn write_value(out: &mut Vec<u8>, bits: u64, size: usize, order: u32) {
     }
 }
 
+#[expect(
+    clippy::cast_possible_wrap,
+    reason = "size >= 8: reinterpreting all 64 stored bits as i64 is the intentional sign reinterpretation of a full-width value; size < 8: ((bits << shift) as i64) >> shift sign-extends the `size`-byte value, an intentional wrap"
+)]
 fn sign_extend(bits: u64, size: usize) -> i64 {
     if size >= 8 {
         bits as i64
@@ -868,12 +948,20 @@ fn pow10_f64(exp: i32) -> f64 {
 }
 
 /// `10^exp` as `f32` (computed in `f64` for accuracy, then narrowed).
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "narrowing 10^exp from f64 to f32 is the intended value conversion; out-of-range magnitudes saturate to +/-inf, matching the C reference"
+)]
 fn pow10_f32(exp: i32) -> f32 {
     pow10_f64(exp) as f32
 }
 
 /// Round half away from zero to the nearest integer, matching C `llround`.
 /// Float-to-int `as` casts saturate in Rust, so out-of-range inputs are safe.
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "float-to-int `as` saturates in Rust, so rounding x +/- 0.5 to i64 is safe even for out-of-range inputs (matches C llround)"
+)]
 fn round_half_away_f64(x: f64) -> i64 {
     if x >= 0.0 {
         (x + 0.5) as i64
@@ -883,6 +971,10 @@ fn round_half_away_f64(x: f64) -> i64 {
 }
 
 /// `f32` counterpart of [`round_half_away_f64`] (matches C `lroundf`).
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "float-to-int `as` saturates in Rust, so rounding x +/- 0.5 to i64 is safe even for out-of-range inputs (matches C lroundf)"
+)]
 fn round_half_away_f32(x: f32) -> i64 {
     if x >= 0.0 {
         (x + 0.5) as i64

--- a/src/superblock.rs
+++ b/src/superblock.rs
@@ -98,6 +98,10 @@ impl Superblock {
         buf.push(self.version);
         buf.push(self.offset_size);
         buf.push(self.length_size);
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "consistency flags occupy the 1-byte file-consistency-flags field of the superblock"
+        )]
         buf.push(self.consistency_flags as u8);
         // base_address
         Self::write_offset(&mut buf, self.base_address, self.offset_size);
@@ -115,6 +119,10 @@ impl Superblock {
     }
 
     fn write_offset(buf: &mut Vec<u8>, val: u64, size: u8) {
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "size is the offset byte width chosen to hold val, so each arm casts to a width that fits by construction"
+        )]
         match size {
             2 => buf.extend_from_slice(&(val as u16).to_le_bytes()),
             4 => buf.extend_from_slice(&(val as u32).to_le_bytes()),

--- a/src/swmr_writer.rs
+++ b/src/swmr_writer.rs
@@ -942,6 +942,10 @@ impl SwmrWriter {
     }
 
     fn write_addr_at(&mut self, offset: usize, addr: u64) -> Result<(), Error> {
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "the 4-byte arm is taken only when this file's offset_size is 4 bytes"
+        )]
         match self.offset_size {
             4 => self.write_at(offset, &(addr as u32).to_le_bytes()),
             _ => self.write_at(offset, &addr.to_le_bytes()),
@@ -949,6 +953,10 @@ impl SwmrWriter {
     }
 
     fn write_length_at(&mut self, offset: usize, val: u64) -> Result<(), Error> {
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "the 4-byte arm is taken only when this file's length_size is 4 bytes"
+        )]
         match self.length_size {
             4 => self.write_at(offset, &(val as u32).to_le_bytes()),
             _ => self.write_at(offset, &val.to_le_bytes()),
@@ -1024,6 +1032,12 @@ fn locate_data_block(geom: &EaGeometry, idx_blk_elmts: u64, e: u64) -> DataBlock
         if e < elem + span {
             let sb_block_offset = elem - idx_blk_elmts;
             let within = e - elem;
+            // within/dn is a data-block index inside this super block, bounded by
+            // its data-block count (ndblks), which is small.
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "within/dn is a data-block index bounded by ndblks (small)"
+            )]
             let dblk_local = (within / dn) as usize;
             let db_start = elem + dblk_local as u64 * dn;
             return DataBlockLoc {

--- a/src/type_builders.rs
+++ b/src/type_builders.rs
@@ -205,6 +205,10 @@ impl CompoundTypeBuilder {
             offset += sz as u64;
         }
         Datatype::Compound {
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "accumulated compound size is stored in the 4-byte datatype size field"
+            )]
             size: offset as u32,
             members,
         }
@@ -461,6 +465,10 @@ pub(crate) fn build_attr_message(name: &str, value: &AttrValue) -> AttributeMess
             AttributeMessage {
                 name: name.to_string(),
                 datatype: Datatype::String {
+                    #[expect(
+                        clippy::cast_possible_truncation,
+                        reason = "string byte length is stored in the 4-byte fixed-string datatype size field"
+                    )]
                     size: bytes.len() as u32,
                     padding: StringPadding::NullPad,
                     charset: CharacterSet::Utf8,
@@ -480,6 +488,10 @@ pub(crate) fn build_attr_message(name: &str, value: &AttrValue) -> AttributeMess
             AttributeMessage {
                 name: name.to_string(),
                 datatype: Datatype::String {
+                    #[expect(
+                        clippy::cast_possible_truncation,
+                        reason = "max string byte length is stored in the 4-byte fixed-string datatype size field"
+                    )]
                     size: max_len as u32,
                     padding: StringPadding::NullPad,
                     charset: CharacterSet::Utf8,
@@ -493,6 +505,10 @@ pub(crate) fn build_attr_message(name: &str, value: &AttrValue) -> AttributeMess
             AttributeMessage {
                 name: name.to_string(),
                 datatype: Datatype::String {
+                    #[expect(
+                        clippy::cast_possible_truncation,
+                        reason = "string byte length is stored in the 4-byte fixed-string datatype size field"
+                    )]
                     size: bytes.len() as u32,
                     padding: StringPadding::NullPad,
                     charset: CharacterSet::Ascii,
@@ -512,6 +528,10 @@ pub(crate) fn build_attr_message(name: &str, value: &AttrValue) -> AttributeMess
             AttributeMessage {
                 name: name.to_string(),
                 datatype: Datatype::String {
+                    #[expect(
+                        clippy::cast_possible_truncation,
+                        reason = "max string byte length is stored in the 4-byte fixed-string datatype size field"
+                    )]
                     size: max_len as u32,
                     padding: StringPadding::NullPad,
                     charset: CharacterSet::Ascii,
@@ -532,8 +552,16 @@ pub(crate) fn build_attr_message(name: &str, value: &AttrValue) -> AttributeMess
             let vl_ref_size = 16usize; // 4 + 8 + 4 for offset_size=8
             let mut raw = Vec::with_capacity(strings.len() * vl_ref_size);
             for (i, s) in strings.iter().enumerate() {
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "VLEN string length is written into the 4-byte length prefix of the variable-length reference"
+                )]
                 raw.extend_from_slice(&(s.len() as u32).to_le_bytes());
                 raw.extend_from_slice(&0u64.to_le_bytes()); // patched later
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "1-based heap object index is written into the 4-byte object-index field of the variable-length reference"
+                )]
                 raw.extend_from_slice(&((i + 1) as u32).to_le_bytes());
             }
             AttributeMessage {
@@ -583,6 +611,10 @@ pub(crate) fn build_global_heap_collection(strings: &[&str]) -> Vec<u8> {
 
     // Objects (1-based indices)
     for (i, s) in strings.iter().enumerate() {
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "1-based heap object index is written into the 2-byte heap-object index field"
+        )]
         let index = (i + 1) as u16;
         buf.extend_from_slice(&index.to_le_bytes());
         buf.extend_from_slice(&1u16.to_le_bytes()); // ref_count

--- a/src/types.rs
+++ b/src/types.rs
@@ -199,6 +199,11 @@ fn decode_attr_value(
                 Some(AttrValue::U64(vals[0]))
             } else {
                 // No U64Array variant, store as I64Array
+                #[expect(
+                    clippy::cast_possible_wrap,
+                    reason = "no U64Array AttrValue variant; values above i64::MAX are \
+                              reinterpreted as i64 by design (bit pattern preserved)"
+                )]
                 let i64_vals: Vec<i64> = vals.iter().map(|&v| v as i64).collect();
                 Some(AttrValue::I64Array(i64_vals))
             }
@@ -301,6 +306,11 @@ fn rebase_vl_refs(raw_data: &[u8], offset_size: u8, base_address: u64) -> Vec<u8
         };
         if !is_undef && addr != 0 {
             let new_addr = addr + base_address;
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "each arm narrows to offset_size, the on-disk address width this \
+                          file uses to store the address being relocated"
+            )]
             match offset_size {
                 2 => out[addr_start..addr_end].copy_from_slice(&(new_addr as u16).to_le_bytes()),
                 4 => out[addr_start..addr_end].copy_from_slice(&(new_addr as u32).to_le_bytes()),

--- a/src/zfp.rs
+++ b/src/zfp.rs
@@ -366,6 +366,10 @@ fn fwd_cast_f32_slice(vals: &[f32], coeffs: &mut [i32]) -> u32 {
     debug_assert_eq!(vals.len(), coeffs.len());
     let mut ieee_max: i32 = 0;
     for &v in vals {
+        #[expect(
+            clippy::cast_possible_wrap,
+            reason = "8-bit IEEE-754 f32 exponent field (0..=255) cast to i32 never wraps"
+        )]
         let e = ((v.to_bits() >> 23) & 0xFF) as i32;
         if e > ieee_max {
             ieee_max = e;
@@ -381,7 +385,13 @@ fn fwd_cast_f32_slice(vals: &[f32], coeffs: &mut [i32]) -> u32 {
     let scale_exp = 30 + EBIAS_F32 - 1 - ieee_max;
     let scale = pow2_f64(scale_exp);
     for i in 0..vals.len() {
-        coeffs[i] = (vals[i] as f64 * scale) as i32;
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "scaled block coefficient is bounded to |x| <= 2^30 by construction, fits i32"
+        )]
+        {
+            coeffs[i] = (vals[i] as f64 * scale) as i32;
+        }
     }
     emax_biased
 }
@@ -406,13 +416,23 @@ fn inv_cast_f32_slice(emax_biased: u32, coeffs: &[i32], out: &mut [f32]) {
     if emax_biased == 0 {
         return;
     }
+    #[expect(
+        clippy::cast_possible_wrap,
+        reason = "emax_biased is a stored 8-bit f32 exponent (0..=255); cast to i32 never wraps"
+    )]
     let exp = emax_biased as i32 - EBIAS_F32 - 30;
     let scale = pow2_f64(exp);
     for (i, &c) in coeffs.iter().enumerate() {
         if c == 0 {
             continue;
         }
-        out[i] = ((c as f64) * scale) as f32;
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "dequantized value is the original f32 magnitude, in range by construction"
+        )]
+        {
+            out[i] = ((c as f64) * scale) as f32;
+        }
     }
 }
 
@@ -446,7 +466,13 @@ fn fwd_cast_f64_slice(vals: &[f64], coeffs: &mut [i64]) -> u64 {
     let emax_biased = (ieee_max + 1) as u64;
     let scale = pow2_f64_wide(1084 - ieee_max);
     for i in 0..vals.len() {
-        coeffs[i] = (vals[i] * scale) as i64;
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "scaled block coefficient is bounded to |x| <= 2^62 by construction, fits i64"
+        )]
+        {
+            coeffs[i] = (vals[i] * scale) as i64;
+        }
     }
     emax_biased
 }
@@ -466,6 +492,10 @@ fn inv_cast_f64_slice(emax_biased: u64, coeffs: &[i64], out: &mut [f64]) {
     if emax_biased == 0 {
         return;
     }
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "emax_biased is a stored 11-bit f64 exponent (0..=2047), so it fits i32"
+    )]
     let exp = emax_biased as i32 - EBIAS_F64 - 62;
     let scale = pow2_f64_wide(exp);
     for (i, &c) in coeffs.iter().enumerate() {
@@ -821,6 +851,10 @@ fn int2uint_i32(x: i32) -> u32 {
     ((x as u32).wrapping_add(NBMASK_U32)) ^ NBMASK_U32
 }
 #[inline]
+#[expect(
+    clippy::cast_possible_wrap,
+    reason = "negabinary-to-signed conversion: the u32 bit pattern is reinterpreted as i32 by design"
+)]
 fn uint2int_i32(x: u32) -> i32 {
     ((x ^ NBMASK_U32).wrapping_sub(NBMASK_U32)) as i32
 }
@@ -829,6 +863,10 @@ fn int2uint_i64(x: i64) -> u64 {
     ((x as u64).wrapping_add(NBMASK_U64)) ^ NBMASK_U64
 }
 #[inline]
+#[expect(
+    clippy::cast_possible_wrap,
+    reason = "negabinary-to-signed conversion: the u64 bit pattern is reinterpreted as i64 by design"
+)]
 fn uint2int_i64(x: u64) -> i64 {
     ((x ^ NBMASK_U64).wrapping_sub(NBMASK_U64)) as i64
 }
@@ -882,6 +920,10 @@ macro_rules! impl_few_ints {
                 let m = n.min(bits);
                 bits -= m;
                 if m > 0 {
+                    #[expect(
+                        clippy::cast_possible_truncation,
+                        reason = "m is a bit count <= n <= size <= 64, fits u32"
+                    )]
                     w.write(m as u32, x);
                     x >>= m;
                 }
@@ -928,6 +970,10 @@ macro_rules! impl_few_ints {
                 k -= 1;
                 let m = n.min(bits);
                 bits -= m;
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "m is a bit count <= n <= size <= 64, fits u32"
+                )]
                 let mut x: u64 = if m > 0 { r.read(m as u32) } else { 0 };
                 while bits > 0 && n < size {
                     bits -= 1;
@@ -1129,6 +1175,10 @@ fn decode_block_f32(
     if !nonempty {
         // Skip remaining bits
         let remaining = maxbits.saturating_sub(1);
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "min(64) caps the bit count at 64, well within u32"
+        )]
         r.read(remaining.min(64) as u32);
         if remaining > 64 {
             skip_bits(r, remaining - 64);
@@ -1137,6 +1187,10 @@ fn decode_block_f32(
     }
 
     // Read exponent — the stored value is `emax + 1` (see encode_block_f32).
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "r.read(EBITS_F32) yields an 8-bit value (returned as u64); fits u32"
+    )]
     let emax_biased = r.read(EBITS_F32) as u32;
 
     // Decode coefficients
@@ -1191,6 +1245,10 @@ fn decode_block_f64(
     let nonempty = r.read_bit();
     if !nonempty {
         let remaining = maxbits.saturating_sub(1);
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "min(64) caps the bit count at 64, well within u32"
+        )]
         r.read(remaining.min(64) as u32);
         if remaining > 64 {
             skip_bits(r, remaining - 64);
@@ -1314,6 +1372,14 @@ macro_rules! impl_float_block_nd {
                 skip_bits(r, remaining);
                 return Ok([$zero; $bs]);
             }
+            // `#[allow]`, not `#[expect]`: `$emax_ty` is `u64` for f64 blocks
+            // (the cast is identity, so the lint never fires) and `u32` for f32
+            // blocks (a safe narrowing of an 8-bit exponent). An `#[expect]`
+            // would be unfulfilled in the u64 expansions.
+            #[allow(
+                clippy::cast_possible_truncation,
+                reason = "exponent occupies $ebits (8 or 11) bits, so it fits the narrower $emax_ty"
+            )]
             let emax_biased: $emax_ty = r.read($ebits) as $emax_ty;
             let header_bits = 1 + ($ebits as usize);
             let coeff_bits = maxbits.saturating_sub(header_bits);
@@ -1600,6 +1666,10 @@ fn pad_bits(w: &mut BitWriter, n: usize) {
         remaining -= 64;
     }
     if remaining > 0 {
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "loop above drains multiples of 64, so remaining is < 64 here; fits u32"
+        )]
         w.write(remaining as u32, 0);
     }
 }
@@ -1612,6 +1682,10 @@ fn skip_bits(r: &mut BitReader<'_>, n: usize) {
         remaining -= 64;
     }
     if remaining > 0 {
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "loop above drains multiples of 64, so remaining is < 64 here; fits u32"
+        )]
         r.read(remaining as u32);
     }
 }
@@ -1713,6 +1787,10 @@ macro_rules! impl_codec {
             }
 
             fn compress_1d(data: &[u8], n: usize, rate: f64) -> Result<Vec<u8>, FormatError> {
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "rate is bits-per-value (format-bounded); rate * 4 (1D block) is a small bit budget that fits usize"
+                )]
                 let maxbits = (rate * 4.0) as usize;
                 let total_bits = n.div_ceil(4) * maxbits;
                 let mut w = BitWriter::with_capacity(total_bits.div_ceil(8) + 8);
@@ -1740,6 +1818,10 @@ macro_rules! impl_codec {
                 n: usize,
                 rate: f64,
             ) -> Result<Vec<u8>, FormatError> {
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "rate is bits-per-value (format-bounded); rate * 4 (1D block) is a small bit budget that fits usize"
+                )]
                 let maxbits = (rate * 4.0) as usize;
                 let mut r = BitReader::new(compressed);
                 let mut output = Vec::with_capacity(n * $esz);
@@ -1761,6 +1843,10 @@ macro_rules! impl_codec {
                 n0: usize,
                 rate: f64,
             ) -> Result<Vec<u8>, FormatError> {
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "rate is bits-per-value (format-bounded); rate * 16 (2D block) is a small bit budget that fits usize"
+                )]
                 let maxbits = (rate * 16.0) as usize;
                 let nb1 = n1.div_ceil(4);
                 let nb0 = n0.div_ceil(4);
@@ -1800,6 +1886,10 @@ macro_rules! impl_codec {
                 n0: usize,
                 rate: f64,
             ) -> Result<Vec<u8>, FormatError> {
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "rate is bits-per-value (format-bounded); rate * 16 (2D block) is a small bit budget that fits usize"
+                )]
                 let maxbits = (rate * 16.0) as usize;
                 let nb1 = n1.div_ceil(4);
                 let nb0 = n0.div_ceil(4);
@@ -1832,6 +1922,10 @@ macro_rules! impl_codec {
                 n0: usize,
                 rate: f64,
             ) -> Result<Vec<u8>, FormatError> {
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "rate is bits-per-value (format-bounded); rate * 64 (3D block) is a small bit budget that fits usize"
+                )]
                 let maxbits = (rate * 64.0) as usize;
                 let nb2 = n2.div_ceil(4);
                 let nb1 = n1.div_ceil(4);
@@ -1904,6 +1998,10 @@ macro_rules! impl_codec {
                 n0: usize,
                 rate: f64,
             ) -> Result<Vec<u8>, FormatError> {
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "rate is bits-per-value (format-bounded); rate * 64 (3D block) is a small bit budget that fits usize"
+                )]
                 let maxbits = (rate * 64.0) as usize;
                 let nb2 = n2.div_ceil(4);
                 let nb1 = n1.div_ceil(4);
@@ -1962,6 +2060,10 @@ macro_rules! impl_codec {
                 n0: usize,
                 rate: f64,
             ) -> Result<Vec<u8>, FormatError> {
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "rate is bits-per-value (format-bounded); rate * 256 (4D block) is a small bit budget that fits usize"
+                )]
                 let maxbits = (rate * 256.0) as usize;
                 let nb3 = n3.div_ceil(4);
                 let nb2 = n2.div_ceil(4);
@@ -2080,6 +2182,10 @@ macro_rules! impl_codec {
                 n0: usize,
                 rate: f64,
             ) -> Result<Vec<u8>, FormatError> {
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "rate is bits-per-value (format-bounded); rate * 256 (4D block) is a small bit budget that fits usize"
+                )]
                 let maxbits = (rate * 256.0) as usize;
                 let nb3 = n3.div_ceil(4);
                 let nb2 = n2.div_ceil(4);
@@ -2356,13 +2462,25 @@ pub fn zfp_cd_values_rate(
         .map(|&d| d.to_usize())
         .collect::<Result<_, _>>()?;
     let rank = dims_usize.len();
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "rank is a validated 1..=4 chunk rank; 4^rank <= 256, fits usize"
+    )]
     let block_values: usize = 4usize.pow(rank as u32);
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "rate (bits-per-value) * block_values (<= 256) is a small bit budget that fits u64"
+    )]
     let maxbits = (rate * block_values as f64) as u64;
     // Encode header bits into a buffer.
     let mut w = BitWriter::new();
     w.write(8, u64::from(b'z'));
     w.write(8, u64::from(b'f'));
     w.write(8, u64::from(b'p'));
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "ZFP_CODEC is the constant 5; the codec id is a single magic byte and fits u8"
+    )]
     w.write(8, u64::from(ZFP_CODEC as u8));
     w.write(52, zfp_meta_for(element_type, &dims_usize));
     // Rate-mode short form: mode = maxbits - 1 for maxbits ≤ 2048.
@@ -2550,6 +2668,10 @@ pub fn zfp_rate_from_cd_values(cd_values: &[u32]) -> Option<f64> {
         let maxbits_enc = (mode >> 27) & 0x7FFF;
         maxbits_enc + 1
     };
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "rank is a validated 1..=4 chunk rank; 4^rank <= 256, fits u64"
+    )]
     let block_values = 4u64.pow(rank as u32);
     Some(maxbits as f64 / block_values as f64)
 }


### PR DESCRIPTION
Closes #72.

## Problem

The `cast-ratchet-32bit` CI job capped the **total count** of i686 narrowing-cast warnings at a baseline of `268`. As @CramBL noted, that has two flaws:

1. The baseline was never ratcheted down, so improvements were never locked in (it had drifted back up to the baseline).
2. A count cap is **fungible** — a genuinely new `u64 as usize`-style cast passes CI as long as an unrelated one is removed in the same PR.

## Change

Replace the count ratchet with `cast-deny-32bit`, which hard-denies `clippy::cast_possible_truncation`, `clippy::cast_possible_wrap`, and `unfulfilled_lint_expectations` on the pinned i686 toolchain. This is the end-state the old job's own comment anticipated.

Every narrowing cast in the library (268 sites across 29 files) was audited and resolved one of three ways:

- **Converted** — the genuine file-derived index/size hazards now go through `crate::convert` (`to_usize`). The chunked-data reader and the MATLAB matrix reader **return an error instead of silently truncating** when a file-derived dimension or element count exceeds the platform's pointer width. These were stragglers; sibling paths already used the checked conversion.
- **Annotated** — bounded casts (writer-chosen on-disk field widths, codec block-local math, serde value conversions, in-memory-image offsets) carry `#[expect(…, reason = "…")]` stating the bound that makes them safe.
- **Eliminated** — a few `assert!` / `debug_assert_eq!` macro-arg casts were rewritten to compare in `u64` (widening), removing the narrowing entirely.

One macro line in `zfp.rs` uses `#[allow]` rather than `#[expect]` (documented inline): the cast is identity in the `u64` monomorphizations and narrowing in the `u32` ones, which `#[expect]` cannot express.

### Why this is better

- **Non-fungible:** a new unannotated narrowing cast fails CI on its own.
- **Self-cleaning:** a stale `#[expect]` left behind after its cast is fixed/removed also fails the gate (`unfulfilled_lint_expectations`), so annotations can't rot.

Also updates the `convert.rs` contributor guidance and adds a `CHANGELOG` entry.

## Verification

- i686 deny gate (the new CI command): **0 cast warnings, 0 unfulfilled expectations**
- `check-32bit` (both feature configs), host `clippy --all-targets -D warnings`, `cargo fmt --check`, no-std, wasm: pass
- Full test suite: **479 lib tests + all integration suites, 0 failures**
- **No public API changes** (the two converted functions are private), so `semver-checks` is unaffected.