### PR TITLE
Support in-place add of chunked/filtered datasets (#76)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- In-place add of chunked, filtered, and extensible datasets: `EditSession::create_dataset` now accepts chunked storage (`with_chunks`), any filter the whole-file writer supports (`with_deflate`, `with_shuffle`, `with_fletcher32`, `with_scale_offset`, `with_zfp`), and extensible (optionally unlimited) dimensions (`with_maxshape`) — previously only contiguous, unfiltered datasets could be added in place. The chunk data, index, and filter pipeline are produced by the same builder the whole-file writer uses and appended at end-of-file, so the added dataset's object header is byte-identical to a freshly written one and is read back faithfully by the reference C library. The filter pipeline is validated before any byte is written, and a chunked dataset's append leaves the prior root intact until the superblock is repointed last, preserving the editor's crash-safety guarantee ([#76](https://github.com/stephenberry/hdf5-pure/issues/76)).
+
+### Fixed
+
+- Malformed chunk geometry is now refused up front by both `FileBuilder` and `EditSession` instead of panicking deep in the chunk splitter (an out-of-bounds index or a divide-by-zero) or producing an unreadable dataset: chunk dimensions whose rank disagrees with the shape, a zero chunk dimension, a maximum shape of the wrong rank or smaller than the current shape, and chunking a scalar dataset all return a descriptive error (`FormatError::InvalidChunkGeometry` from the writer, `Error::EditUnsupported` from the editor). An absurd shape whose element count overflows `u64` is likewise reported rather than panicking a debug build. Zero-element extensible datasets (e.g. shape `[0]` with an unlimited maximum) remain valid ([#76](https://github.com/stephenberry/hdf5-pure/issues/76)).
+
 ## [0.15.0] - 2026-06-16
 
 Adds generic element-typed dataset I/O, file- and dataset-level cache tuning, in-place group attribute editing, OS advisory file locking for the editor, and a gallery of runnable examples; also hardens the 32-bit/WASM readers against silent truncation. Additive minor bump, with two intended behavior changes (editor file locking and the new truncation guards) noted below.

--- a/examples/edit_in_place.rs
+++ b/examples/edit_in_place.rs
@@ -36,6 +36,15 @@ fn main() {
     session
         .create_dataset("run2/signal")
         .with_f64_data(&[1.0, 2.0, 3.0]);
+    // A chunked, shuffled, deflate-compressed dataset can be added in place too;
+    // its chunk data and index are appended just like a contiguous blob.
+    let waveform: Vec<f64> = (0..4096).map(|i| (i as f64 * 0.01).sin()).collect();
+    session
+        .create_dataset("run2/waveform")
+        .with_f64_data(&waveform)
+        .with_chunks(&[512])
+        .with_shuffle()
+        .with_deflate(6);
     session.copy("temperature", "temperature_backup"); // H5Ocopy
     session.delete("sensors/pressure"); // H5Ldelete
     session.commit().expect("commit edits");
@@ -44,6 +53,7 @@ fn main() {
     // ---- Verify ---------------------------------------------------------
     let file = File::open(&path).expect("reopen");
     let signal = file.dataset("run2/signal").unwrap().read_f64().unwrap();
+    let waveform_read = file.dataset("run2/waveform").unwrap().read_f64().unwrap();
     let backup = file
         .dataset("temperature_backup")
         .unwrap()
@@ -51,7 +61,11 @@ fn main() {
         .unwrap();
     let run2_attrs = file.group("run2").unwrap().attrs().unwrap();
 
-    println!("added   run2/signal       = {signal:?}");
+    println!("added   run2/signal        = {signal:?}");
+    println!(
+        "added   run2/waveform      = {} compressed samples",
+        waveform_read.len()
+    );
     println!("copied  temperature_backup = {backup:?}");
     println!("group   run2.kind          = {:?}", run2_attrs.get("kind"));
     println!(
@@ -64,6 +78,7 @@ fn main() {
     );
 
     assert_eq!(signal, vec![1.0, 2.0, 3.0]);
+    assert_eq!(waveform_read, waveform);
     assert_eq!(backup, vec![22.5, 23.1, 21.8]);
     assert!(file.dataset("sensors/pressure").is_err());
     println!("in-place edits verified");

--- a/src/chunked_write.rs
+++ b/src/chunked_write.rs
@@ -196,6 +196,50 @@ impl ChunkOptions {
             shape.to_vec()
         }
     }
+
+    /// Validate the chunk geometry of a dataset that will use chunked storage,
+    /// against its `shape` and optional `maxshape`. Returns a static reason on
+    /// the first problem; callers map it to their own error type. Only
+    /// meaningful when the dataset is actually chunked
+    /// ([`is_chunked`](Self::is_chunked) or a `maxshape` is set).
+    ///
+    /// These checks turn what would otherwise be a panic deep in the chunk
+    /// splitter ([`split_into_chunks`], which indexes `chunk_dims` by the shape's
+    /// rank and divides by each chunk dimension) — or a silently corrupt,
+    /// unreadable dataset — into an up-front, descriptive refusal. A
+    /// zero-element shape (e.g. `[0]` for an empty extensible dataset) is allowed:
+    /// it is not scalar and produces zero chunks, which is well-formed.
+    pub fn validate_geometry(
+        &self,
+        shape: &[u64],
+        maxshape: Option<&[u64]>,
+    ) -> Result<(), &'static str> {
+        if shape.is_empty() {
+            return Err("a scalar dataset cannot be chunked, filtered, or extensible");
+        }
+        // Explicit chunk dimensions must match the shape's rank and be non-zero;
+        // a zero would divide-by-zero when counting chunks per dimension, and a
+        // rank mismatch would index past the end of `chunk_dims`.
+        if let Some(dims) = self.chunk_dims.as_deref() {
+            if dims.len() != shape.len() {
+                return Err("chunk dimensions must have the same rank as the dataset shape");
+            }
+            if dims.contains(&0) {
+                return Err("chunk dimensions must all be non-zero");
+            }
+        }
+        // A maximum shape must match the rank and bound the current shape in
+        // every dimension (an unlimited dimension, `u64::MAX`, bounds anything).
+        if let Some(ms) = maxshape {
+            if ms.len() != shape.len() {
+                return Err("maxshape must have the same rank as the dataset shape");
+            }
+            if ms.iter().zip(shape).any(|(&m, &d)| m != u64::MAX && m < d) {
+                return Err("maxshape must be at least the current shape in every dimension");
+            }
+        }
+        Ok(())
+    }
 }
 
 /// A chunk that has been written to the file buffer.

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -46,11 +46,17 @@
 //!   converted to a compact-link v2 header, carrying its links and attributes
 //!   over (other group messages — symbol table, modification time — are
 //!   dropped); an attribute it cannot reproduce is refused.
-//! - Added datasets are contiguous and unfiltered (no chunking, compression,
-//!   shuffle, scale-offset, or extensible dimensions), have a fixed-size
-//!   datatype with a non-empty shape, and carry only fixed-size (non
-//!   variable-length) attributes, few enough to stay in compact storage. Group
-//!   attribute edits have the same compact, fixed-size attribute restriction.
+//! - Added datasets may be contiguous *or* chunked, with any filter the
+//!   whole-file writer supports (deflate, shuffle, fletcher32, scale-offset,
+//!   ZFP), and may declare extensible (maximum, optionally unlimited)
+//!   dimensions. A chunked dataset's data and index — and any filtered chunks —
+//!   are produced by the same builder the whole-file writer uses and appended at
+//!   end-of-file, so its object header is byte-identical to a freshly written
+//!   one. Every added dataset must have a fixed-size datatype with a non-empty
+//!   shape and carry only fixed-size (non variable-length) attributes, few
+//!   enough to stay in compact storage; object-reference and provenance
+//!   datasets are not added in place. Group attribute edits have the same
+//!   compact, fixed-size attribute restriction.
 //! - A new group's parent must already exist or be created in the same session
 //!   (each level created explicitly); intermediate groups are not auto-created.
 //!
@@ -94,11 +100,15 @@ use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::Path;
 
 use crate::checksum::jenkins_lookup3;
+use crate::chunked_write::{ChunkOptions, build_chunked_data_at_ext};
 use crate::dataspace::{Dataspace, DataspaceType};
 use crate::error::Error;
 use crate::file_lock::{self, FileLocking};
 use crate::file_space_info::{FileSpaceInfo, FileSpaceStrategy};
-use crate::file_writer::{LENGTH_SIZE, OFFSET_SIZE, build_dataset_oh, make_link};
+use crate::file_writer::{
+    LENGTH_SIZE, OFFSET_SIZE, build_chunked_dataset_oh, build_dataset_oh, make_link,
+};
+use crate::filters::ChunkContext;
 use crate::free_space::FreeList;
 use crate::free_space_manager::{self, FreeSection, FsmHeader, fshd_len, serialize_file_fsm};
 use crate::group_v2::resolve_group_entries;
@@ -386,6 +396,12 @@ impl EditSession {
     /// session). Returns the [`DatasetBuilder`] — the same builder used by
     /// [`FileBuilder`](crate::FileBuilder) — to configure data, shape, and
     /// attributes.
+    ///
+    /// The dataset may be contiguous or chunked, and chunked datasets may be
+    /// filtered (`with_deflate`, `with_shuffle`, `with_fletcher32`,
+    /// `with_scale_offset`, `with_zfp`) and/or extensible (`with_maxshape`); see
+    /// the [module docs](self) for what stays unsupported (variable-length or
+    /// dense attributes, object-reference and provenance datasets, empty shapes).
     pub fn create_dataset(&mut self, path: &str) -> &mut DatasetBuilder {
         let mut comps = split_path(path);
         let leaf = comps.pop().unwrap_or_default();
@@ -480,12 +496,18 @@ impl EditSession {
 
     /// Apply all staged additions and deletions to the file in place and flush.
     ///
-    /// Appends each new dataset (data blob + object header) and each new group,
-    /// then appends rewritten object headers for every touched group and its
-    /// ancestors up to the root (omitting any deleted links), then repoints the
-    /// superblock at the new root. On success the staged set is cleared and the
-    /// session can be reused. On any [`Error::EditUnsupported`] the file on disk
-    /// is left untouched: every check runs before the first byte is written.
+    /// Appends each new dataset (its data — a contiguous blob, or the chunk data
+    /// and index for a chunked/filtered dataset — plus its object header) and
+    /// each new group, then appends rewritten object headers for every touched
+    /// group and its ancestors up to the root (omitting any deleted links), then
+    /// repoints the superblock at the new root. On success the staged set is
+    /// cleared and the session can be reused. On any [`Error::EditUnsupported`]
+    /// the file on disk is left untouched: the checks that raise it — including
+    /// each dataset's filter-pipeline and chunk-geometry validation — all run
+    /// before the first byte is written. Should a later step fail mid-apply (an
+    /// I/O error, or a residual build error), the superblock — repointed last —
+    /// still names the prior root, so the file stays valid and the appended bytes
+    /// are unreferenced slack.
     pub fn commit(&mut self) -> Result<(), Error> {
         if self.pending_datasets.is_empty()
             && self.pending_groups.is_empty()
@@ -750,15 +772,19 @@ impl EditSession {
 
             // Datasets directly under this group.
             for fd in flat.remove(key).into_iter().flatten() {
-                let data_addr = self.alloc_or_append(&fd.raw)?;
-                let oh = build_dataset_oh(
-                    &fd.dt,
-                    &fd.ds,
-                    data_addr,
-                    fd.raw.len() as u64,
-                    &fd.attrs,
-                    None,
-                );
+                let oh = if fd.chunk_options.is_chunked() || fd.maxshape.is_some() {
+                    self.build_chunked_dataset(&fd)?
+                } else {
+                    let data_addr = self.alloc_or_append(&fd.raw)?;
+                    build_dataset_oh(
+                        &fd.dt,
+                        &fd.ds,
+                        data_addr,
+                        fd.raw.len() as u64,
+                        &fd.attrs,
+                        None,
+                    )
+                };
                 let oh_addr = self.alloc_or_append(&oh)?;
                 region.extend_from_slice(&encode_link_message(&fd.name, oh_addr));
             }
@@ -1520,6 +1546,55 @@ impl EditSession {
         }
     }
 
+    /// Lay out a chunked / filtered / extensible dataset and return its object
+    /// header bytes (which the caller links into the parent group).
+    ///
+    /// The chunk data and index (B-tree v1 / fixed-array / extensible-array, with
+    /// any filter pipeline applied) are produced as one relocatable blob by
+    /// [`build_chunked_data_at_ext`], whose internal layout — and therefore total
+    /// size — is independent of the base address it is given. The blob is
+    /// appended at end-of-file, so passing the current end-of-file as the base
+    /// makes every absolute address it embeds (chunk addresses, index-structure
+    /// addresses, the addresses in the data-layout message) land exactly where
+    /// the bytes are written. The header is then built with
+    /// [`build_chunked_dataset_oh`] — the same function the whole-file writer
+    /// uses — so the header is byte-identical to one written fresh.
+    ///
+    /// Unlike the contiguous path the blob is always *appended* rather than
+    /// placed via [`alloc_or_append`]: reusing an interior freed region would
+    /// require knowing the blob's size before building it at that region's
+    /// address, and appending keeps the address known up front. Freed space is
+    /// still reused for the object header and for every other object in the
+    /// commit.
+    fn build_chunked_dataset(&mut self, fd: &FlatDataset) -> Result<Vec<u8>, Error> {
+        let base = self.data.len() as u64;
+        let chunk_dims = fd.chunk_options.resolve_chunk_dims(&fd.ds.dimensions);
+        let ctx = ChunkContext::from_datatype(&chunk_dims, &fd.dt);
+        let result = build_chunked_data_at_ext(
+            &fd.raw,
+            &fd.ds.dimensions,
+            ctx,
+            &fd.chunk_options,
+            base,
+            fd.maxshape.as_deref(),
+        )?;
+        // `append` writes at the current end-of-file, which equals `base`: the
+        // blob lands exactly where its embedded addresses expect.
+        let written = self.append(&result.data_bytes)?;
+        debug_assert_eq!(
+            written, base,
+            "chunk blob must land at the base address it was built for",
+        );
+        Ok(build_chunked_dataset_oh(
+            &fd.dt,
+            &fd.ds,
+            &result.layout_message,
+            result.pipeline_message.as_deref(),
+            &fd.attrs,
+            None,
+        ))
+    }
+
     /// On-disk byte spans `(addr, len)` of every chunk of the version 2 object
     /// header at `addr`: chunk 0 (signature, prefix, messages, checksum) plus
     /// each continuation (`OCHK`) block. Used to reclaim a header's storage when
@@ -1691,6 +1766,16 @@ struct FlatDataset {
     ds: Dataspace,
     raw: Vec<u8>,
     attrs: Vec<crate::attribute::AttributeMessage>,
+    /// Chunked/filtered storage options. When [`ChunkOptions::is_chunked`] is
+    /// false and `maxshape` is `None`, the dataset is written as contiguous,
+    /// unfiltered storage; otherwise its chunk data and index are built by
+    /// [`build_chunked_data_at_ext`] and appended at end-of-file.
+    chunk_options: ChunkOptions,
+    /// Maximum dimensions for an extensible dataset (an unlimited dimension is
+    /// `u64::MAX`), mirrored into `ds.max_dimensions`. `None` for a fixed-shape
+    /// dataset. A maxshape with an unlimited dimension selects the
+    /// extensible-array chunk index; a finite maxshape stays fixed-array/single.
+    maxshape: Option<Vec<u64>>,
 }
 
 /// Split a path into non-empty components.
@@ -1709,16 +1794,17 @@ fn ensure_ancestors(nodes: &mut BTreeMap<PathKey, Node>, path: &[String]) {
     }
 }
 
-/// Validate a staged dataset and reduce it to a [`FlatDataset`], rejecting any
-/// feature this engine cannot emit as contiguous, unfiltered storage.
+/// Validate a staged dataset and reduce it to a [`FlatDataset`]. Contiguous,
+/// unfiltered datasets are emitted as such; chunked, filtered, or extensible
+/// datasets carry their [`ChunkOptions`] and maxshape through to the commit,
+/// where [`build_chunked_data_at_ext`] lays out their chunk data and index.
+/// Rejects any remaining feature this engine cannot reproduce faithfully:
+/// object-reference or provenance datasets, variable-length or dense
+/// attributes, an empty (zero-element) shape, or a filter pipeline the build
+/// cannot construct.
 fn flatten_dataset(db: DatasetBuilder) -> Result<FlatDataset, Error> {
     if db.name.is_empty() {
         return Err(Error::EditUnsupported("dataset path has an empty name"));
-    }
-    if db.chunk_options.is_chunked() || db.maxshape.is_some() {
-        return Err(Error::EditUnsupported(
-            "chunked / compressed / extensible datasets cannot be added in place yet",
-        ));
     }
     if db.reference_targets.is_some() {
         return Err(Error::EditUnsupported(
@@ -1749,12 +1835,72 @@ fn flatten_dataset(db: DatasetBuilder) -> Result<FlatDataset, Error> {
 
     let elem = dt.type_size() as u64;
     if elem > 0 {
-        let expected = shape.iter().product::<u64>().saturating_mul(elem);
-        if raw.len() as u64 != expected {
+        // Multiply with checked arithmetic: an absurd shape whose element count
+        // (or byte size) overflows `u64` is refused rather than panicking in a
+        // debug build or silently wrapping in release (which could let a wrapped
+        // product spuriously match `raw.len()`).
+        let expected = shape
+            .iter()
+            .try_fold(1u64, |acc, &d| acc.checked_mul(d))
+            .and_then(|n| n.checked_mul(elem));
+        match expected {
+            Some(expected) if raw.len() as u64 == expected => {}
+            Some(_) => {
+                return Err(Error::EditUnsupported(
+                    "dataset data length does not match its shape",
+                ));
+            }
+            None => {
+                return Err(Error::EditUnsupported(
+                    "dataset shape is too large to address on this platform",
+                ));
+            }
+        }
+    }
+
+    let chunked = db.chunk_options.is_chunked() || db.maxshape.is_some();
+    if chunked {
+        // Refuse malformed chunk geometry up front (the same validation the
+        // whole-file writer applies), so a bad request — chunk dimensions of the
+        // wrong rank, a zero chunk dimension, an inconsistent maximum shape, or
+        // chunking a scalar — never reaches and panics the chunk splitter, nor
+        // yields a dataset the reader cannot decode.
+        db.chunk_options
+            .validate_geometry(&shape, db.maxshape.as_deref())
+            .map_err(Error::EditUnsupported)?;
+        // Deflate is compiled out unless the `deflate` feature is on, but
+        // `build_pipeline` emits its descriptor regardless; catch a
+        // disabled-feature request here so it is refused up front rather than
+        // failing mid-apply when a chunk is compressed.
+        #[cfg(not(feature = "deflate"))]
+        if db.chunk_options.deflate_level.is_some() {
             return Err(Error::EditUnsupported(
-                "dataset data length does not match its shape",
+                "deflate compression requires the `deflate` crate feature",
             ));
         }
+        // Validate the requested filter pipeline now — before any file bytes are
+        // written — so an unsupported filter, an incompatible datatype, or a
+        // disabled compression feature is refused up front; the chunk data
+        // itself is laid out in the commit's apply phase. Chunked/filtered
+        // storage flows through the very builder the normal writer uses
+        // ([`build_chunked_data_at_ext`] + [`build_chunked_dataset_oh`]), so the
+        // resulting object header is byte-identical to a freshly written one.
+        let chunk_dims = db.chunk_options.resolve_chunk_dims(&shape);
+        let ctx = ChunkContext::from_datatype(&chunk_dims, &dt);
+        db.chunk_options
+            .build_pipeline(
+                ctx.element_size,
+                &chunk_dims,
+                ctx.element_type,
+                ctx.scale_offset_type,
+            )
+            .map_err(|_| {
+                Error::EditUnsupported(
+                    "this dataset's filter pipeline cannot be added in place \
+                     (an unsupported filter, an incompatible datatype, or a \
+                     compression feature that is not enabled)",
+                )
+            })?;
     }
 
     if db
@@ -1792,7 +1938,9 @@ fn flatten_dataset(db: DatasetBuilder) -> Result<FlatDataset, Error> {
         )]
         rank: shape.len() as u8,
         dimensions: shape,
-        max_dimensions: None,
+        // A chunked, extensible dataset records its maximum dimensions (an
+        // unlimited dimension is `u64::MAX`); a fixed-shape dataset has none.
+        max_dimensions: db.maxshape.clone(),
     };
     let attrs = db
         .attrs
@@ -1806,6 +1954,8 @@ fn flatten_dataset(db: DatasetBuilder) -> Result<FlatDataset, Error> {
         ds,
         raw,
         attrs,
+        chunk_options: db.chunk_options,
+        maxshape: db.maxshape,
     })
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -198,6 +198,14 @@ pub enum FormatError {
         /// non-zero; used to report the mismatch in elements as well as bytes.
         element_size: usize,
     },
+    /// A chunked/filtered/extensible dataset's chunk geometry is invalid — for
+    /// example chunk dimensions whose rank disagrees with the shape, a zero chunk
+    /// dimension, a maximum shape whose rank disagrees with the shape or that is
+    /// smaller than the current shape, or chunking requested on a scalar dataset.
+    /// Reported up front so a malformed request is refused instead of panicking
+    /// in the chunk splitter or producing an unreadable dataset. The payload is a
+    /// human-readable reason.
+    InvalidChunkGeometry(&'static str),
     /// Invalid filter pipeline version.
     InvalidFilterPipelineVersion(u8),
     /// Unsupported filter ID.
@@ -504,6 +512,9 @@ impl fmt::Display for FormatError {
                     expected / element_size,
                     actual / element_size,
                 )
+            }
+            FormatError::InvalidChunkGeometry(reason) => {
+                write!(f, "invalid chunk geometry: {reason}")
             }
             FormatError::InvalidFilterPipelineVersion(v) => {
                 write!(f, "invalid filter pipeline version: {v}")

--- a/src/file_writer.rs
+++ b/src/file_writer.rs
@@ -627,7 +627,18 @@ impl FileWriter {
             // absurd shape from overflowing into a false match.
             let elem_size = dt.type_size() as u64;
             if !is_empty && elem_size > 0 {
-                let expected = shape.iter().product::<u64>().saturating_mul(elem_size);
+                // Multiply with checked arithmetic, saturating on overflow: an
+                // absurd shape whose element count exceeds `u64` must not panic a
+                // debug build in `Iterator::product` (nor silently wrap a release
+                // build into a false match). A saturated `u64::MAX` can never
+                // equal a real `data.len()`, so it is correctly reported as a
+                // mismatch.
+                let num_elements = shape
+                    .iter()
+                    .copied()
+                    .try_fold(1u64, |acc, d| acc.checked_mul(d))
+                    .unwrap_or(u64::MAX);
+                let expected = num_elements.saturating_mul(elem_size);
                 if raw.len() as u64 != expected {
                     #[expect(
                         clippy::cast_possible_truncation,
@@ -639,6 +650,16 @@ impl FileWriter {
                         element_size: elem_size as usize,
                     });
                 }
+            }
+            // Validate the chunk geometry up front for a chunked / filtered /
+            // extensible dataset, so a malformed request (chunk dimensions of the
+            // wrong rank, a zero chunk dimension, a bad maximum shape, or
+            // chunking a scalar) is refused here instead of panicking in the
+            // chunk splitter or producing an unreadable dataset.
+            if db.chunk_options.is_chunked() || db.maxshape.is_some() {
+                db.chunk_options
+                    .validate_geometry(&shape, db.maxshape.as_deref())
+                    .map_err(FormatError::InvalidChunkGeometry)?;
             }
             let max_dimensions = db.maxshape.clone();
             let dspace = Dataspace {

--- a/tests/edit_crosscheck.rs
+++ b/tests/edit_crosscheck.rs
@@ -16,7 +16,7 @@
 //! repointed, and the result is read back correctly by the C library.
 
 use hdf5::file::LibraryVersion;
-use hdf5_pure::{AttrValue, EditSession, File, FileBuilder};
+use hdf5_pure::{AttrValue, EditSession, File, FileBuilder, ScaleOffset};
 use tempfile::tempdir;
 
 /// Stage an add, an add-into-a-group, a delete, and a copy — the full op set.
@@ -434,5 +434,119 @@ fn free_space_reuse_and_truncation_stay_c_readable() {
     assert_eq!(
         c.dataset("grp/beta").unwrap().read_raw::<i32>().unwrap(),
         vec![10, 20, 30, 40]
+    );
+}
+
+#[test]
+fn chunked_and_filtered_datasets_added_in_place_are_c_readable() {
+    // Issue #76: chunked / filtered / extensible datasets added in place to a
+    // file the editor did not write must be read back faithfully by the
+    // reference C library — the real interop proof that their chunk data, index,
+    // and filter pipeline are emitted correctly.
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("c_chunked_edit.h5");
+    write_c_starter(&path, LibraryVersion::V110, LibraryVersion::latest());
+
+    let f64_data: Vec<f64> = (0..400).map(|i| i as f64 * 0.25).collect();
+    let i32_data: Vec<i32> = (0..256).map(|i| 1000 + (i % 11)).collect();
+    let ext_data: Vec<i32> = (0..128).collect();
+
+    {
+        let mut session = EditSession::open(&path).unwrap();
+        session
+            .create_dataset("deflated")
+            .with_f64_data(&f64_data)
+            .with_chunks(&[100])
+            .with_deflate(6);
+        session
+            .create_dataset("shuffled")
+            .with_f64_data(&f64_data)
+            .with_chunks(&[64])
+            .with_shuffle()
+            .with_deflate(4);
+        session
+            .create_dataset("checked")
+            .with_i32_data(&i32_data)
+            .with_chunks(&[80])
+            .with_fletcher32();
+        session
+            .create_dataset("scaled")
+            .with_i32_data(&i32_data)
+            .with_chunks(&[80])
+            .with_scale_offset(ScaleOffset::Integer(0));
+        // Into a group the C library wrote, exercising header relocation.
+        session
+            .create_dataset("grp/grid")
+            .with_i32_data(&(0..(6 * 4)).collect::<Vec<i32>>())
+            .with_shape(&[6, 4])
+            .with_chunks(&[4, 3]);
+        // Extensible (unlimited) dataset → Extensible-Array chunk index.
+        session
+            .create_dataset("stream")
+            .with_i32_data(&ext_data)
+            .with_shape(&[128])
+            .with_maxshape(&[u64::MAX])
+            .with_chunks(&[32]);
+        session.commit().unwrap();
+    }
+
+    // hdf5-pure reads everything back.
+    {
+        let f = File::open(&path).unwrap();
+        assert_eq!(f.dataset("deflated").unwrap().read_f64().unwrap(), f64_data);
+        assert_eq!(f.dataset("shuffled").unwrap().read_f64().unwrap(), f64_data);
+        assert_eq!(f.dataset("checked").unwrap().read_i32().unwrap(), i32_data);
+        assert_eq!(f.dataset("scaled").unwrap().read_i32().unwrap(), i32_data);
+        assert_eq!(
+            f.dataset("grp/grid").unwrap().read_i32().unwrap(),
+            (0..(6 * 4)).collect::<Vec<i32>>()
+        );
+        assert_eq!(f.dataset("stream").unwrap().read_i32().unwrap(), ext_data);
+        // The C-written survivors are intact.
+        assert_eq!(
+            f.dataset("alpha").unwrap().read_f64().unwrap(),
+            vec![1.0, 2.0, 3.0]
+        );
+    }
+
+    // The reference C library reads the filtered/chunked/extensible additions and
+    // sees them as chunked storage.
+    let c = hdf5::File::open(&path).unwrap();
+    assert_eq!(
+        c.dataset("deflated").unwrap().read_raw::<f64>().unwrap(),
+        f64_data
+    );
+    assert_eq!(
+        c.dataset("shuffled").unwrap().read_raw::<f64>().unwrap(),
+        f64_data
+    );
+    assert_eq!(
+        c.dataset("checked").unwrap().read_raw::<i32>().unwrap(),
+        i32_data
+    );
+    assert_eq!(
+        c.dataset("scaled").unwrap().read_raw::<i32>().unwrap(),
+        i32_data
+    );
+    assert_eq!(
+        c.dataset("grp/grid").unwrap().read_raw::<i32>().unwrap(),
+        (0..(6 * 4)).collect::<Vec<i32>>()
+    );
+    assert_eq!(
+        c.dataset("stream").unwrap().read_raw::<i32>().unwrap(),
+        ext_data
+    );
+    for name in [
+        "deflated", "shuffled", "checked", "scaled", "grp/grid", "stream",
+    ] {
+        assert!(
+            c.dataset(name).unwrap().chunk().is_some(),
+            "C library does not see {name} as chunked"
+        );
+    }
+    // The C-written original is untouched.
+    assert_eq!(
+        c.dataset("alpha").unwrap().read_raw::<f64>().unwrap(),
+        vec![1.0, 2.0, 3.0]
     );
 }

--- a/tests/edit_in_place.rs
+++ b/tests/edit_in_place.rs
@@ -1,7 +1,7 @@
 //! Tests for in-place editing via `EditSession` (issue #32, Group C):
 //! add, delete, and copy datasets and groups at any path.
 
-use hdf5_pure::{AttrValue, DType, EditSession, File, FileBuilder};
+use hdf5_pure::{AttrValue, DType, EditSession, File, FileBuilder, ScaleOffset};
 
 /// Write a starter file with one dataset, returning its path.
 fn write_starter(path: &std::path::Path) {
@@ -844,27 +844,303 @@ fn superblock_eof_matches_file_size_after_edit() {
     std::fs::remove_file(&path).ok();
 }
 
+/// A chunked (but unfiltered) dataset can be added in place and read back, and
+/// the original dataset is left intact.
 #[test]
-fn chunked_dataset_is_rejected_without_writing() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_reject_chunked.h5");
+fn add_chunked_dataset() {
+    let path = std::env::temp_dir().join("hdf5_pure_edit_add_chunked.h5");
     write_starter(&path);
-    let before = std::fs::read(&path).unwrap();
 
+    let data: Vec<f64> = (0..100).map(|i| i as f64 * 0.5).collect();
     {
         let mut session = EditSession::open(&path).unwrap();
         session
             .create_dataset("chunky")
-            .with_f64_data(&[1.0, 2.0, 3.0, 4.0])
-            .with_chunks(&[2]);
-        let err = session.commit().unwrap_err();
-        assert!(
-            err.to_string().contains("in-place edit"),
-            "unexpected error: {err}"
-        );
+            .with_f64_data(&data)
+            .with_chunks(&[25]);
+        session.commit().unwrap();
     }
 
-    // The guard runs before any write, so the file is untouched.
-    let after = std::fs::read(&path).unwrap();
-    assert_eq!(before, after);
+    let file = File::open(&path).unwrap();
+    let chunky = file.dataset("chunky").unwrap();
+    assert_eq!(chunky.shape().unwrap(), vec![100]);
+    assert_eq!(chunky.read_f64().unwrap(), data);
+    // Original dataset untouched.
+    assert_eq!(
+        file.dataset("original").unwrap().read_f64().unwrap(),
+        vec![1.0, 2.0, 3.0, 4.0]
+    );
+    // The superblock's end-of-file matches the physical size after appending the
+    // chunk data, index, and header.
+    assert_eq!(file.file_size(), std::fs::metadata(&path).unwrap().len());
     std::fs::remove_file(&path).ok();
+}
+
+/// Deflate, shuffle+deflate, and fletcher32 filtered datasets each round-trip
+/// through the in-place editor and the reader.
+#[test]
+fn add_filtered_datasets() {
+    let path = std::env::temp_dir().join("hdf5_pure_edit_add_filtered.h5");
+    write_starter(&path);
+
+    let data: Vec<f64> = (0..200).map(|i| i as f64).collect();
+    {
+        let mut session = EditSession::open(&path).unwrap();
+        session
+            .create_dataset("deflated")
+            .with_f64_data(&data)
+            .with_chunks(&[50])
+            .with_deflate(6);
+        session
+            .create_dataset("shuffled")
+            .with_f64_data(&data)
+            .with_chunks(&[50])
+            .with_shuffle()
+            .with_deflate(4);
+        session
+            .create_dataset("checked")
+            .with_f64_data(&data)
+            .with_chunks(&[64])
+            .with_fletcher32();
+        session.commit().unwrap();
+    }
+
+    let file = File::open(&path).unwrap();
+    for name in ["deflated", "shuffled", "checked"] {
+        assert_eq!(
+            file.dataset(name).unwrap().read_f64().unwrap(),
+            data,
+            "dataset {name} did not round-trip"
+        );
+    }
+    assert_eq!(file.file_size(), std::fs::metadata(&path).unwrap().len());
+    std::fs::remove_file(&path).ok();
+}
+
+/// A lossless integer scale-offset dataset round-trips.
+#[test]
+fn add_scale_offset_dataset() {
+    let path = std::env::temp_dir().join("hdf5_pure_edit_add_scaleoffset.h5");
+    write_starter(&path);
+
+    let data: Vec<i32> = (0..120).map(|i| 1000 + (i % 7)).collect();
+    {
+        let mut session = EditSession::open(&path).unwrap();
+        session
+            .create_dataset("counts")
+            .with_i32_data(&data)
+            .with_chunks(&[40])
+            .with_scale_offset(ScaleOffset::Integer(0));
+        session.commit().unwrap();
+    }
+
+    let file = File::open(&path).unwrap();
+    assert_eq!(file.dataset("counts").unwrap().read_i32().unwrap(), data);
+    std::fs::remove_file(&path).ok();
+}
+
+/// A 2-D chunked dataset whose chunks don't evenly divide the shape round-trips
+/// (exercises edge chunks and the fixed-array index used for >1 chunk).
+#[test]
+fn add_2d_chunked_dataset() {
+    let path = std::env::temp_dir().join("hdf5_pure_edit_add_2d_chunked.h5");
+    write_starter(&path);
+
+    let data: Vec<i32> = (0..(7 * 5)).collect();
+    {
+        let mut session = EditSession::open(&path).unwrap();
+        session
+            .create_dataset("grid")
+            .with_i32_data(&data)
+            .with_shape(&[7, 5])
+            .with_chunks(&[3, 2]);
+        session.commit().unwrap();
+    }
+
+    let file = File::open(&path).unwrap();
+    let grid = file.dataset("grid").unwrap();
+    assert_eq!(grid.shape().unwrap(), vec![7, 5]);
+    assert_eq!(grid.read_i32().unwrap(), data);
+    std::fs::remove_file(&path).ok();
+}
+
+/// An extensible (unlimited-dimension) dataset can be added in place; its data
+/// reads back and the file remains valid. The unlimited dimension selects the
+/// Extensible-Array chunk index.
+#[test]
+fn add_extensible_dataset() {
+    let path = std::env::temp_dir().join("hdf5_pure_edit_add_extensible.h5");
+    write_starter(&path);
+
+    let data: Vec<i32> = (0..64).collect();
+    {
+        let mut session = EditSession::open(&path).unwrap();
+        session
+            .create_dataset("stream")
+            .with_i32_data(&data)
+            .with_shape(&[64])
+            .with_maxshape(&[u64::MAX])
+            .with_chunks(&[16]);
+        session.commit().unwrap();
+    }
+
+    let file = File::open(&path).unwrap();
+    let stream = file.dataset("stream").unwrap();
+    assert_eq!(stream.shape().unwrap(), vec![64]);
+    assert_eq!(stream.read_i32().unwrap(), data);
+    assert_eq!(file.file_size(), std::fs::metadata(&path).unwrap().len());
+    std::fs::remove_file(&path).ok();
+}
+
+/// One commit can mix a contiguous dataset and a chunked/compressed dataset
+/// into a nested group, alongside the original.
+#[test]
+fn add_mixed_contiguous_and_chunked_in_group() {
+    let path = std::env::temp_dir().join("hdf5_pure_edit_add_mixed.h5");
+    write_starter(&path);
+
+    let wave: Vec<f64> = (0..512).map(|i| (i as f64 * 0.1).cos()).collect();
+    {
+        let mut session = EditSession::open(&path).unwrap();
+        session.create_group("run");
+        session
+            .create_dataset("run/scalarish")
+            .with_i32_data(&[1, 2, 3]);
+        session
+            .create_dataset("run/wave")
+            .with_f64_data(&wave)
+            .with_chunks(&[128])
+            .with_shuffle()
+            .with_deflate(6);
+        session.commit().unwrap();
+    }
+
+    let file = File::open(&path).unwrap();
+    assert_eq!(
+        file.dataset("run/scalarish").unwrap().read_i32().unwrap(),
+        vec![1, 2, 3]
+    );
+    assert_eq!(file.dataset("run/wave").unwrap().read_f64().unwrap(), wave);
+    assert_eq!(
+        file.dataset("original").unwrap().read_f64().unwrap(),
+        vec![1.0, 2.0, 3.0, 4.0]
+    );
+    assert_eq!(file.file_size(), std::fs::metadata(&path).unwrap().len());
+    std::fs::remove_file(&path).ok();
+}
+
+/// A chunked dataset whose datatype is `f64` still reports the right dtype after
+/// an in-place add, confirming the header is a faithful chunked dataset header.
+#[test]
+fn added_chunked_dataset_reports_dtype() {
+    let path = std::env::temp_dir().join("hdf5_pure_edit_chunked_dtype.h5");
+    write_starter(&path);
+    {
+        let mut session = EditSession::open(&path).unwrap();
+        session
+            .create_dataset("c")
+            .with_f64_data(&(0..50).map(f64::from).collect::<Vec<_>>())
+            .with_chunks(&[10])
+            .with_deflate(3);
+        session.commit().unwrap();
+    }
+    let file = File::open(&path).unwrap();
+    assert_eq!(file.dataset("c").unwrap().dtype().unwrap(), DType::F64);
+    std::fs::remove_file(&path).ok();
+}
+
+/// A ZFP fixed-rate compressed dataset can be added in place and reads back
+/// within ZFP's lossy tolerance (gated on the `zfp` feature).
+#[test]
+#[cfg(feature = "zfp")]
+fn add_zfp_dataset() {
+    let path = std::env::temp_dir().join("hdf5_pure_edit_add_zfp.h5");
+    write_starter(&path);
+
+    let data: Vec<f64> = (0..256).map(|i| (i as f64 * 0.05).sin()).collect();
+    {
+        let mut session = EditSession::open(&path).unwrap();
+        session
+            .create_dataset("zfp")
+            .with_f64_data(&data)
+            .with_chunks(&[64])
+            .with_zfp(32.0);
+        session.commit().unwrap();
+    }
+
+    let file = File::open(&path).unwrap();
+    let back = file.dataset("zfp").unwrap().read_f64().unwrap();
+    assert_eq!(back.len(), data.len());
+    let max_err = data
+        .iter()
+        .zip(back.iter())
+        .map(|(&a, &b)| (a - b).abs())
+        .fold(0f64, f64::max);
+    assert!(max_err < 1e-6, "ZFP max_err {max_err} > 1e-6");
+    std::fs::remove_file(&path).ok();
+}
+
+/// Malformed chunked-dataset requests are refused before any byte is written,
+/// rather than panicking or producing a silently-corrupt dataset: an empty
+/// (zero-element) shape, chunk dims whose rank disagrees with the shape, a zero
+/// chunk dimension, and a maxshape whose rank disagrees with the shape.
+#[test]
+fn malformed_chunked_requests_are_rejected_without_writing() {
+    // A no-capture configurator per malformed case; `fn` pointers keep the case
+    // table a simple type.
+    type Configure = fn(&mut hdf5_pure::DatasetBuilder);
+    let bad: &[(&str, Configure)] = &[
+        ("empty shape", |b| {
+            b.with_f64_data(&[]).with_shape(&[0]).with_chunks(&[4]);
+        }),
+        ("chunk rank mismatch", |b| {
+            b.with_i32_data(&[1, 2, 3, 4, 5, 6])
+                .with_shape(&[2, 3])
+                .with_chunks(&[2]);
+        }),
+        ("zero chunk dim", |b| {
+            b.with_i32_data(&[1, 2, 3, 4])
+                .with_shape(&[4])
+                .with_chunks(&[0]);
+        }),
+        ("maxshape rank mismatch", |b| {
+            b.with_i32_data(&[1, 2, 3, 4])
+                .with_shape(&[4])
+                .with_maxshape(&[u64::MAX, u64::MAX])
+                .with_chunks(&[2]);
+        }),
+        ("scalar with chunks", |b| {
+            b.with_f64_data(&[1.0]).with_shape(&[]).with_chunks(&[1]);
+        }),
+        ("maxshape below shape", |b| {
+            b.with_i32_data(&[1, 2, 3, 4])
+                .with_shape(&[4])
+                .with_maxshape(&[2]);
+        }),
+    ];
+
+    for (label, configure) in bad {
+        let path = std::env::temp_dir().join(format!(
+            "hdf5_pure_edit_reject_{}.h5",
+            label.replace(' ', "_")
+        ));
+        write_starter(&path);
+        let before = std::fs::read(&path).unwrap();
+        {
+            let mut session = EditSession::open(&path).unwrap();
+            configure(session.create_dataset("bad"));
+            let err = session.commit().unwrap_err();
+            assert!(
+                err.to_string().contains("in-place edit"),
+                "[{label}] expected an EditUnsupported refusal, got: {err}"
+            );
+        }
+        // The guard runs before any write, so the file is untouched.
+        assert_eq!(
+            std::fs::read(&path).unwrap(),
+            before,
+            "[{label}] file modified"
+        );
+        std::fs::remove_file(&path).ok();
+    }
 }

--- a/tests/write_read_roundtrip.rs
+++ b/tests/write_read_roundtrip.rs
@@ -1,5 +1,6 @@
 use hdf5_pure::{
-    AttrValue, CompoundTypeBuilder, DType, Datatype, File, FileBuilder, FormatError, make_f64_type,
+    AttrValue, CompoundTypeBuilder, DType, Datatype, Error, File, FileBuilder, FormatError,
+    make_f64_type,
 };
 
 #[test]
@@ -308,6 +309,72 @@ fn nested_compound_tuple_roundtrip() {
     let file = File::from_bytes(bytes).unwrap();
     let ds = file.dataset("nested").unwrap();
     assert_eq!(ds.read_compound::<((i8, u64), f32)>().unwrap(), values);
+}
+
+#[test]
+fn chunked_builder_rejects_invalid_geometry() {
+    // Each malformed chunk-geometry request must be refused with
+    // `InvalidChunkGeometry` rather than panicking in the chunk splitter or
+    // producing an unreadable dataset.
+    type Configure = fn(&mut hdf5_pure::DatasetBuilder);
+    let bad: &[(&str, Configure)] = &[
+        ("chunk rank mismatch", |b| {
+            b.with_i32_data(&[1, 2, 3, 4, 5, 6])
+                .with_shape(&[2, 3])
+                .with_chunks(&[2]);
+        }),
+        ("zero chunk dim", |b| {
+            b.with_i32_data(&[1, 2, 3, 4])
+                .with_shape(&[4])
+                .with_chunks(&[0]);
+        }),
+        ("maxshape rank mismatch", |b| {
+            b.with_i32_data(&[1, 2, 3, 4])
+                .with_shape(&[4])
+                .with_maxshape(&[u64::MAX, u64::MAX])
+                .with_chunks(&[2]);
+        }),
+        ("maxshape below shape", |b| {
+            b.with_i32_data(&[1, 2, 3, 4])
+                .with_shape(&[4])
+                .with_maxshape(&[2]);
+        }),
+        ("scalar with chunks", |b| {
+            b.with_f64_data(&[1.0]).with_shape(&[]).with_chunks(&[1]);
+        }),
+    ];
+
+    for (label, configure) in bad {
+        let mut builder = FileBuilder::new();
+        configure(builder.create_dataset("bad"));
+        let err = builder.finish().unwrap_err();
+        assert!(
+            matches!(err, Error::Format(FormatError::InvalidChunkGeometry(_))),
+            "[{label}] expected InvalidChunkGeometry, got {err:?}"
+        );
+    }
+}
+
+#[test]
+fn chunked_builder_accepts_empty_extensible_dataset() {
+    // A zero-element extensible dataset (shape `[0]`, unlimited max) is a valid,
+    // common pattern (create empty, append later); the geometry guard must not
+    // reject it.
+    let mut builder = FileBuilder::new();
+    builder
+        .create_dataset("stream")
+        .with_i32_data(&[])
+        .with_shape(&[0])
+        .with_maxshape(&[u64::MAX])
+        .with_chunks(&[16]);
+    let bytes = builder
+        .finish()
+        .expect("empty extensible dataset should build");
+
+    let file = File::from_bytes(bytes).unwrap();
+    let ds = file.dataset("stream").unwrap();
+    assert_eq!(ds.shape().unwrap(), vec![0]);
+    assert_eq!(ds.read_i32().unwrap(), Vec::<i32>::new());
 }
 
 #[test]


### PR DESCRIPTION
Closes #76.

## Summary

`EditSession::create_dataset` previously refused any chunked, filtered, or extensible dataset, accepting only contiguous unfiltered ones. This PR lifts that restriction: the in-place editor can now add datasets that are

- **chunked** (`with_chunks`),
- **filtered** with any pipeline the whole-file writer supports (`with_deflate`, `with_shuffle`, `with_fletcher32`, `with_scale_offset`, `with_zfp`), and
- **extensible**, with finite or unlimited (`u64::MAX`) maximum dimensions (`with_maxshape`).

## How it works

The chunk data, index (single-chunk / fixed-array / extensible-array), and filter pipeline are produced by the **same builder the whole-file writer uses** (`build_chunked_data_at_ext` + `build_chunked_dataset_oh`). The blob is relocatable (its embedded addresses are computed from a base address, and its size is independent of that base), so the editor appends it at end-of-file and the object header comes out **byte-identical to a freshly written one** — read back faithfully by the reference HDF5 C library.

Crash-safety is preserved: the filter pipeline is validated before any byte is written, and the chunk blob + header are appended before the superblock is repointed last (the linearization point), so a mid-apply failure leaves the prior root intact.

## Hardening (FileBuilder + EditSession)

While implementing this I found that malformed chunk geometry **panicked** deep in the chunk splitter (out-of-bounds index / divide-by-zero) or produced an unreadable dataset — pre-existing in `FileBuilder` and newly reachable through the editor. Both now refuse such requests up front via a shared `ChunkOptions::validate_geometry`:

- chunk dimensions whose rank disagrees with the shape,
- a zero chunk dimension,
- a maximum shape of the wrong rank or smaller than the current shape,
- chunking a scalar dataset,
- an element count that overflows `u64` (reported instead of panicking a debug build).

Zero-element extensible datasets (e.g. shape `[0]` with an unlimited max) remain valid. Adds `FormatError::InvalidChunkGeometry`.

## Tests

- `tests/edit_in_place.rs`: round-trip coverage for chunked, deflate, shuffle+deflate, fletcher32, scale-offset, 2-D, extensible, mixed contiguous+chunked, ZFP (feature-gated), plus malformed-geometry rejection.
- `tests/edit_crosscheck.rs`: reference HDF5 C library reads back every chunked/filtered/extensible dataset added in place and confirms chunked storage.
- `tests/write_read_roundtrip.rs`: `FileBuilder` geometry-rejection tests + a zero-element extensible acceptance test.
- The `edit_in_place` example now demonstrates adding a compressed dataset.

All tests pass (731 default, 769 with `zfp`); clippy clean on default, `zfp+provenance`, and `no-default-features`.