### PR TITLE
repack: faithful time, non-string-vlen, and object-reference datatypes (#107)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Repack now reproduces three more datatype classes faithfully: non-string variable-length sequences (re-staged through a fresh global heap), object-reference datasets (each address rewritten to its target's new location in the compacted file), and time datatypes (byte order preserved). Chunked/filtered/resizable VL and reference datasets, region or non-8-byte object references, and an object reference to a dropped or out-of-hierarchy target are still refused by name ([#107](https://github.com/stephenberry/hdf5-pure/issues/107)).
+- **Breaking:** `Datatype::Time` gained a `byte_order` field so a time type's byte order survives a read/serialize round-trip (it was previously dropped on read and forced little-endian); code matching the `Time` variant must account for the new field ([#107](https://github.com/stephenberry/hdf5-pure/issues/107)).
+
+### Fixed
+
+- A null or empty variable-length element now writes a zero heap address (HDF5's null-reference convention) instead of an all-ones undefined-address sentinel, which the reference C library rejected as a bad heap index when reading such an element back ([#107](https://github.com/stephenberry/hdf5-pure/issues/107)).
+
 ## [0.16.0] - 2026-06-18
 
 Centers on `repack`: it now copies compressed chunks **verbatim** (so lossy filters survive byte-exact) and runs **fully out-of-core**, and gains variable-length-string support. Also adds in-place dataset-value overwrite, dense-attribute and cross-file object copy, in-place addition of chunked/filtered/extensible datasets, and free-space reclaim for chunked deletes; plus reader hardening (a multi-filter chunk-mask corruption fix, sub-byte integer precision, decompression-bomb bounds, and safer B-tree/heap refusals). Additive minor bump.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "hdf5-pure"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "byteorder",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdf5-pure"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2024"
 # `std::fs::File` advisory locking (used by the write/edit/read open paths for
 # concurrent-writer detection, issue #73) stabilized in Rust 1.89.

--- a/README.md
+++ b/README.md
@@ -573,7 +573,7 @@ For bare-metal `no_std`, disable default features (keep `checksum` for object-he
 
 ```toml
 [dependencies]
-hdf5-pure = { version = "0.16", default-features = false, features = ["checksum"] }
+hdf5-pure = { version = "0.17", default-features = false, features = ["checksum"] }
 ```
 
 The high-level `File` / `FileBuilder` API is `std`-gated, so a `no_std` build exposes only the lower-level primitives. WebAssembly builds keep the default features, since `std` is available on `wasm32-unknown-unknown`.

--- a/docs/reference/limitations.md
+++ b/docs/reference/limitations.md
@@ -60,7 +60,7 @@ Refused today with a `... yet` message, intended to land. Each row links to its 
 
 | Capability | Tracking |
 |---|---|
-| Faithful repack of **time / non-string-vlen / reference** datatypes and unrecognized filters | [#107](https://github.com/stephenberry/hdf5-pure/issues/107) |
+| Repack of **region references**, non-8-byte object references, chunked/filtered/resizable variable-length & reference datasets, and unrecognized filter pipelines (time, contiguous non-string-vlen sequences, and 8-byte object references now repack faithfully) | [#107](https://github.com/stephenberry/hdf5-pure/issues/107) |
 
 ### Reading
 

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -84,10 +84,11 @@ pub enum Datatype {
         exponent_bias: u32,
     },
     /// Class 2: Time type (rarely used).
-    ///
-    /// The byte-order bit is not modelled (this matches the parser, which has
-    /// always ignored it); a serialized time type is emitted little-endian.
-    Time { size: u32, bit_precision: u16 },
+    Time {
+        size: u32,
+        byte_order: DatatypeByteOrder,
+        bit_precision: u16,
+    },
     /// Class 3: Fixed-length string.
     String {
         size: u32,
@@ -290,11 +291,17 @@ impl Datatype {
             2 => {
                 // Time
                 ensure_len(data, pos, 2)?;
+                let byte_order = if bf0 & 0x01 == 0 {
+                    DatatypeByteOrder::LittleEndian
+                } else {
+                    DatatypeByteOrder::BigEndian
+                };
                 let bit_precision = LittleEndian::read_u16(&data[pos..pos + 2]);
                 pos += 2;
                 Ok((
                     Datatype::Time {
                         size,
+                        byte_order,
                         bit_precision,
                     },
                     pos,
@@ -740,11 +747,16 @@ impl Datatype {
             }
             Datatype::Time {
                 size,
+                byte_order,
                 bit_precision,
             } => {
-                // bf0 bit 0 is the byte order; the struct does not model it, so
-                // emit little-endian (matching the parser, which ignores it).
-                let mut buf = Self::build_header(2, 1, [0, 0, 0], *size);
+                // bf0 bit 0 is the byte order (0 = little-endian, 1 = big-endian).
+                let bf0 = if matches!(byte_order, DatatypeByteOrder::BigEndian) {
+                    0x01u8
+                } else {
+                    0
+                };
+                let mut buf = Self::build_header(2, 1, [bf0, 0, 0], *size);
                 buf.extend_from_slice(&bit_precision.to_le_bytes());
                 buf
             }
@@ -1259,9 +1271,35 @@ mod tests {
             dt,
             Datatype::Time {
                 size: 8,
+                byte_order: DatatypeByteOrder::LittleEndian,
                 bit_precision: 64,
             }
         );
+    }
+
+    #[test]
+    fn test_time_byte_order_roundtrips() {
+        // A big-endian time type must serialize and re-parse with its byte order
+        // preserved (bf0 bit 0), so repack can reproduce it faithfully.
+        for (be, order) in [
+            (0u8, DatatypeByteOrder::LittleEndian),
+            (1u8, DatatypeByteOrder::BigEndian),
+        ] {
+            let mut buf = build_dt_header(2, 1, [be, 0, 0], 4);
+            buf.extend_from_slice(&32u16.to_le_bytes());
+            let (dt, _) = Datatype::parse(&buf).unwrap();
+            assert_eq!(
+                dt,
+                Datatype::Time {
+                    size: 4,
+                    byte_order: order.clone(),
+                    bit_precision: 32,
+                }
+            );
+            // serialize -> parse must round-trip the byte order.
+            let (reparsed, _) = Datatype::parse(&dt.serialize()).unwrap();
+            assert_eq!(reparsed, dt);
+        }
     }
 
     #[test]
@@ -1461,6 +1499,7 @@ mod tests {
     fn serialize_parse_time_roundtrip() {
         let dt = Datatype::Time {
             size: 8,
+            byte_order: DatatypeByteOrder::LittleEndian,
             bit_precision: 64,
         };
         let bytes = dt.serialize();

--- a/src/file_writer.rs
+++ b/src/file_writer.rs
@@ -644,7 +644,7 @@ impl FileWriter {
             /// Repack's verbatim chunk payload, when this dataset's chunks are
             /// copied compressed-as-is rather than encoded from `raw`.
             raw_chunks: Option<crate::type_builders::RawChunkPayload>,
-            reference_targets: Option<Vec<String>>,
+            reference_targets: Option<Vec<crate::type_builders::ObjectRefTarget>>,
             /// Staged global heap collection + patch mask for a VL-string
             /// dataset, whose element references in `raw` need their heap
             /// addresses patched once the post-data cursor is known.
@@ -1085,6 +1085,9 @@ impl FileWriter {
             // Group-level datasets: path = group_name/dataset_name (recursive)
             // Groups: path = group_name (recursive)
             let mut path_map = HashMap::<String, u64>::new();
+            // The root group is referenceable under the empty path (repack maps a
+            // reference to the source root group to "").
+            path_map.insert(String::new(), root_group_addr);
             for &i in &root_ds_indices {
                 path_map.insert(all_ds[i].name.clone(), ds_oh_addrs2[i]);
             }
@@ -1125,12 +1128,19 @@ impl FileWriter {
                 );
             }
 
-            // Patch reference datasets
+            // Patch reference datasets: a path target resolves to its object's
+            // destination address (an unknown path falls back to the undefined
+            // address); a raw target is written verbatim (null / undefined).
             for d in all_ds.iter_mut() {
                 if let Some(ref targets) = d.reference_targets {
                     let mut patched = Vec::with_capacity(targets.len() * 8);
-                    for path in targets {
-                        let addr = path_map.get(path).copied().unwrap_or(u64::MAX);
+                    for target in targets {
+                        let addr = match target {
+                            crate::type_builders::ObjectRefTarget::Path(path) => {
+                                path_map.get(path).copied().unwrap_or(u64::MAX)
+                            }
+                            crate::type_builders::ObjectRefTarget::Raw(addr) => *addr,
+                        };
                         patched.extend_from_slice(&addr.to_le_bytes());
                     }
                     d.raw = patched;
@@ -1773,5 +1783,72 @@ mod tests {
             matches!(err, FormatError::ChunkedVlenStringUnsupported),
             "expected ChunkedVlenStringUnsupported, got {err:?}"
         );
+    }
+
+    #[test]
+    fn vlen_sequence_dataset_roundtrips_i32() {
+        // Non-string VL (`H5T_VLEN { i32 }`): the per-element reference stores an
+        // element *count*, while the heap object holds count*4 bytes. The
+        // writer/reader pair must agree on that, including an empty sequence.
+        use crate::type_builders::VlStringElement;
+        use crate::vl_data::{VlByteObject, VlenStringReadOptions};
+
+        let dt = Datatype::VariableLength {
+            is_string: false,
+            padding: None,
+            charset: None,
+            base_type: Box::new(crate::type_builders::make_i32_type()),
+        };
+        let seqs: Vec<Vec<i32>> = vec![vec![1, 2, 3], vec![], vec![-7, 42]];
+        let elements: Vec<VlStringElement> = seqs
+            .iter()
+            .map(|s| VlStringElement::Bytes(s.iter().flat_map(|v| v.to_le_bytes()).collect()))
+            .collect();
+        let mut fw = FileWriter::new();
+        fw.create_dataset("seq")
+            .with_vlen_sequence_elements(dt, &elements)
+            .unwrap();
+        let bytes = fw.finish().unwrap();
+
+        let file = crate::reader::File::from_bytes(bytes).unwrap();
+        let ds = file.dataset("seq").unwrap();
+        assert!(
+            matches!(
+                ds.datatype().unwrap(),
+                Datatype::VariableLength {
+                    is_string: false,
+                    ..
+                }
+            ),
+            "datatype must stay a non-string variable-length sequence"
+        );
+        let (objs, elem_size) = ds
+            .read_vlen_sequence_bytes(VlenStringReadOptions::default())
+            .unwrap();
+        assert_eq!(elem_size, 4);
+        let got: Vec<Vec<i32>> = objs
+            .iter()
+            .map(|o| match o {
+                VlByteObject::Null => Vec::new(),
+                VlByteObject::Bytes(b) => b
+                    .chunks_exact(4)
+                    .map(|c| i32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+                    .collect(),
+            })
+            .collect();
+        assert_eq!(got, seqs);
+    }
+
+    #[test]
+    fn vlen_sequence_rejects_string_datatype() {
+        // The sequence builder must refuse a string-shaped VL datatype, which
+        // belongs to the VL-string path.
+        use crate::type_builders::VlStringElement;
+        let dt = crate::type_builders::make_vlen_string_type(CharacterSet::Utf8);
+        let mut fw = FileWriter::new();
+        let res = fw
+            .create_dataset("x")
+            .with_vlen_sequence_elements(dt, &[VlStringElement::Bytes(b"hi".to_vec())]);
+        assert!(matches!(res, Err(FormatError::TypeMismatch { .. })));
     }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -513,6 +513,7 @@ impl File {
         let chunk_cache = options.resolved_chunk_cache(self.access_options.chunk_cache);
         Ok(Dataset {
             file: self,
+            address: addr,
             header: hdr,
             chunk_cache: ChunkCache::with_config(chunk_cache),
             chunk_cache_config: chunk_cache,
@@ -755,6 +756,12 @@ pub struct Group<'f> {
 }
 
 impl<'f> Group<'f> {
+    /// Address of this group's object header (base-adjusted, file-absolute).
+    /// Used to resolve object references that point at this group.
+    pub(crate) fn header_address(&self) -> u64 {
+        self.address
+    }
+
     /// List the names of datasets in this group.
     pub fn datasets(&self) -> Result<Vec<String>, Error> {
         let entries = self.children()?;
@@ -824,6 +831,7 @@ impl<'f> Group<'f> {
         let chunk_cache = options.resolved_chunk_cache(self.file.access_options.chunk_cache);
         Ok(Dataset {
             file: self.file,
+            address: entry.object_header_address,
             header: hdr,
             chunk_cache: ChunkCache::with_config(chunk_cache),
             chunk_cache_config: chunk_cache,
@@ -856,6 +864,9 @@ impl<'f> Group<'f> {
 /// A lightweight handle to an HDF5 dataset.
 pub struct Dataset<'f> {
     file: &'f File,
+    /// Address of this dataset's object header (base-adjusted, file-absolute).
+    /// Used to resolve object references that point at this dataset.
+    address: u64,
     header: ObjectHeader,
     // Held per-dataset: the chunk index is keyed only by chunk coordinate, so
     // a file-level cache would alias chunk addresses across datasets.
@@ -874,6 +885,12 @@ impl<'f> std::fmt::Debug for Dataset<'f> {
 }
 
 impl<'f> Dataset<'f> {
+    /// Address of this dataset's object header (base-adjusted, file-absolute).
+    /// Used to resolve object references that point at this dataset.
+    pub(crate) fn header_address(&self) -> u64 {
+        self.address
+    }
+
     /// The effective raw chunk-cache configuration for this dataset.
     ///
     /// This reflects the per-dataset [`DatasetAccessOptions`] override when one
@@ -1122,8 +1139,69 @@ impl<'f> Dataset<'f> {
             self.file.offset_size(),
             self.file.length_size(),
             self.file.addr_offset,
+            1, // a VL string's base type is a single byte
             options,
         )?)
+    }
+
+    /// Read every element of a *non-string* variable-length (sequence) dataset as
+    /// its exact heap bytes, alongside the base-type element size in bytes.
+    ///
+    /// Each element's heap object holds `length * element_size` bytes, where
+    /// `length` is the stored element count and `element_size` is the byte width
+    /// of the sequence's base type. Returning the raw bytes (not decoded values)
+    /// keeps a faithful rewrite (repack) byte-exact for any base type whose bytes
+    /// carry no embedded heap or file addresses. Errors with a
+    /// [`TypeMismatch`](crate::FormatError::TypeMismatch) if the datatype is not a
+    /// non-string VL datatype.
+    pub(crate) fn read_vlen_sequence_bytes(
+        &self,
+        options: VlenStringReadOptions,
+    ) -> Result<(Vec<vl_data::VlByteObject>, usize), Error> {
+        let datatype = self.datatype()?;
+        let Datatype::VariableLength { base_type, .. } = &datatype else {
+            return Err(FormatError::TypeMismatch {
+                expected: "non-string VariableLength",
+                actual: "non-VariableLength",
+            }
+            .into());
+        };
+        if vl_data::is_vlen_string_datatype(&datatype) {
+            return Err(FormatError::TypeMismatch {
+                expected: "non-string VariableLength",
+                actual: "VariableLength string",
+            }
+            .into());
+        }
+        let element_size = base_type.type_size() as usize;
+        if element_size == 0 {
+            return Err(
+                FormatError::VlDataError("non-string VL base type has zero size".into()).into(),
+            );
+        }
+        let dataspace = self.dataspace()?;
+        if let Some(limit) = options.max_elements()
+            && dataspace.num_elements() > limit as u64
+        {
+            return Err(FormatError::VariableLengthElementLimitExceeded {
+                limit,
+                actual: dataspace.num_elements(),
+            }
+            .into());
+        }
+        let raw = self.read_raw()?;
+        let source = self.file.source();
+        let objects = vl_data::read_vl_byte_objects_from_source(
+            &source,
+            &raw,
+            dataspace.num_elements(),
+            self.file.offset_size(),
+            self.file.length_size(),
+            self.file.addr_offset,
+            element_size,
+            options,
+        )?;
+        Ok((objects, element_size))
     }
 
     /// Read all attributes of this dataset.

--- a/src/repack.rs
+++ b/src/repack.rs
@@ -16,20 +16,24 @@
 //! naming the object and the reason. It refuses rather than approximate.
 //! Currently reproducible:
 //!
-//! - Datasets with fixed-point, floating-point, fixed-length string, bit-field,
-//!   opaque, compound, enumeration, and array datatypes, contiguous/compact or
-//!   chunked.
+//! - Datasets with fixed-point, floating-point, time, fixed-length string,
+//!   bit-field, opaque, compound, enumeration, and array datatypes,
+//!   contiguous/compact or chunked.
 //! - **Chunked** datasets copy their compressed chunks **verbatim** (chunk by
 //!   chunk, never decoded), so *every* filter is preserved byte-exact: deflate,
 //!   shuffle, fletcher32, integer **and** float scale-offset, ZFP, SZIP, and
 //!   even filters this crate cannot itself apply. The destination always uses a
 //!   v4 chunk index (single-chunk / fixed-array / extensible-array) regardless
 //!   of the source index type.
-//! - Contiguous/compact **variable-length string** datasets (1D and ND), both
-//!   the `is_string: true` shape and the MATLAB VLEN-of-1-byte-ASCII-string
-//!   shape. Each element's exact heap bytes are read and re-staged through a
-//!   fresh global heap, preserving charset, padding, the null-vs-empty
-//!   distinction, embedded NULs, and non-UTF-8 payloads.
+//! - Contiguous/compact **variable-length** datasets (1D and ND): string-shaped
+//!   (`is_string: true` and the MATLAB VLEN-of-1-byte-ASCII-string shape) and
+//!   non-string sequences over any base type that embeds no addresses. Each
+//!   element's exact heap bytes are read and re-staged through a fresh global
+//!   heap, preserving charset, padding, the null-vs-empty distinction, embedded
+//!   NULs, and non-UTF-8 payloads.
+//! - Contiguous/compact **object-reference** datasets: each stored address is
+//!   rewritten to its target object's new location in the compacted file (null
+//!   and undefined references are carried verbatim).
 //! - Group hierarchy of arbitrary depth.
 //! - Attributes representable as [`AttrValue`] (numbers, fixed and
 //!   variable-length strings and their arrays), on datasets, groups, and root.
@@ -45,17 +49,19 @@
 //! dense verbatim path cannot lay out). A lossy pipeline on either of those is
 //! refused.
 //!
-//! Refused (named, never dropped silently): non-string variable-length
-//! (sequences of arbitrary base types); chunked, filtered, or resizable
-//! variable-length string datasets (their element references live inside
-//! compressed chunks written before the global heap addresses are known, so they
-//! cannot be patched in); time (its byte order is not modelled), and reference
-//! datatypes (a reference's stored absolute addresses would go stale on
-//! rewrite); virtual and external data layouts; a lossy filter on the contiguous
-//! re-encode or sparse-chunked fallback path; and any attribute whose datatype
-//! the reader cannot decode into an [`AttrValue`] (e.g. an enumeration, compound,
-//! or boolean attribute). An attribute that cannot be reproduced fails the
-//! repack by name rather than being silently dropped.
+//! Refused (named, never dropped silently): chunked, filtered, or resizable
+//! variable-length (string or sequence) and object-reference datasets (their
+//! element references live inside compressed chunks written before the global
+//! heap addresses are known, so they cannot be patched in); region references and
+//! non-8-byte object references; an object reference to a dropped object or to a
+//! target outside the hard-link hierarchy (a dangling, named-datatype, or region
+//! target), and object references in a userblock file (non-zero base address); a
+//! non-string vlen sequence whose base type embeds an address (nested vlen or
+//! reference); virtual and external data layouts; a lossy filter on the
+//! contiguous re-encode or sparse-chunked fallback path; and any attribute whose
+//! datatype the reader cannot decode into an [`AttrValue`] (e.g. an enumeration,
+//! compound, reference, or boolean attribute). An object that cannot be
+//! reproduced fails the repack by name rather than being silently dropped.
 //!
 //! # Memory
 //!
@@ -69,7 +75,7 @@
 //!
 //! [#82]: https://github.com/stephenberry/hdf5-pure/issues/82
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::Path;
 use std::sync::Arc;
 
@@ -77,7 +83,7 @@ use crate::chunked_read::ChunkInfo;
 use crate::chunked_write::{ChunkMeta, ChunkProvider};
 use crate::convert::TryToUsize;
 use crate::data_layout::DataLayout;
-use crate::datatype::Datatype;
+use crate::datatype::{Datatype, ReferenceType};
 use crate::error::{Error, FormatError};
 use crate::filter_pipeline::{
     FILTER_DEFLATE, FILTER_FLETCHER32, FILTER_SCALEOFFSET, FILTER_SHUFFLE, FilterPipeline,
@@ -86,7 +92,7 @@ use crate::reader::{Dataset, File, Group};
 use crate::scaleoffset::{self, ScaleOffset};
 use crate::source::FileSource;
 use crate::type_builders::{
-    AttrValue, DatasetBuilder, FinishedGroup, GroupBuilder, VlStringElement,
+    AttrValue, DatasetBuilder, FinishedGroup, GroupBuilder, ObjectRefTarget, VlStringElement,
 };
 use crate::vl_data::{VlByteObject, VlenStringReadOptions, is_vlen_string_datatype};
 use crate::writer::FileBuilder;
@@ -156,8 +162,21 @@ pub fn repack<P: AsRef<Path>, Q: AsRef<Path>>(
             .with_file_space_strategy(info.strategy, false, info.threshold)
             .with_file_space_page_size(info.page_size);
     }
+    // Map every source object's (relative) header address to its path, so an
+    // object-reference dataset can be rewritten to point at the same objects in
+    // the compacted output rather than at their stale source addresses.
+    let addr_map = build_object_address_map(&file)?;
+
     let root = file.root();
-    populate(&mut builder, &root, "", &drop, &mut matched, &file)?;
+    populate(
+        &mut builder,
+        &root,
+        "",
+        &drop,
+        &mut matched,
+        &file,
+        &addr_map,
+    )?;
 
     // Every requested drop must have named a real object.
     if let Some(missing) = drop.iter().find(|d| !matched.contains(*d)) {
@@ -213,6 +232,7 @@ fn populate<S: GroupSink>(
     drop: &BTreeSet<String>,
     matched: &mut BTreeSet<String>,
     file: &Arc<File>,
+    addr_map: &HashMap<u64, String>,
 ) -> Result<(), Error> {
     // Attributes, in name order for a deterministic output. Refuse if any
     // attribute on this group cannot be represented (and would be dropped).
@@ -237,7 +257,14 @@ fn populate<S: GroupSink>(
             continue;
         }
         let ds = src.dataset(&name)?;
-        emit_dataset(sink.sink_dataset(&name), &ds, &child_path, file)?;
+        emit_dataset(
+            sink.sink_dataset(&name),
+            &ds,
+            &child_path,
+            file,
+            drop,
+            addr_map,
+        )?;
     }
 
     // Subgroups, sorted by name; built depth-first into a FinishedGroup.
@@ -251,7 +278,7 @@ fn populate<S: GroupSink>(
         }
         let child = src.group(&name)?;
         let mut gb = GroupBuilder::new(&name);
-        populate(&mut gb, &child, &child_path, drop, matched, file)?;
+        populate(&mut gb, &child, &child_path, drop, matched, file, addr_map)?;
         sink.sink_add_group(gb.finish());
     }
     Ok(())
@@ -264,6 +291,8 @@ fn emit_dataset(
     ds: &Dataset,
     path: &str,
     file: &Arc<File>,
+    drop: &BTreeSet<String>,
+    addr_map: &HashMap<u64, String>,
 ) -> Result<(), Error> {
     let datatype = ds.datatype()?;
     let dataspace = ds.dataspace()?;
@@ -283,6 +312,36 @@ fn emit_dataset(
     if is_vlen_string_datatype(&datatype) {
         emit_vlen_string_dataset(db, ds, path, &datatype, &dims, &layout)?;
         // VL-string datasets carry attributes the same way as any other.
+        let attrs = ds.attrs()?;
+        check_attr_completeness(&attrs, &ds.attr_names()?, &format!("dataset {path}"))?;
+        for (name, value) in sorted(attrs) {
+            db.set_attr(&name, value);
+        }
+        return Ok(());
+    }
+
+    // Non-string variable-length (sequence) datasets take the same global-heap
+    // re-staging path as VL strings: each element's exact heap bytes are read and
+    // re-emitted through a fresh global heap, so the stored heap addresses are
+    // rebuilt rather than copied stale. Routed here before the verbatim chunk-copy
+    // path so a chunked one is refused (not copied with stale references).
+    if is_nonstring_vlen(&datatype) {
+        emit_vlen_sequence_dataset(db, ds, path, &datatype, &dims, &layout)?;
+        let attrs = ds.attrs()?;
+        check_attr_completeness(&attrs, &ds.attr_names()?, &format!("dataset {path}"))?;
+        for (name, value) in sorted(attrs) {
+            db.set_attr(&name, value);
+        }
+        return Ok(());
+    }
+
+    // Object-reference datasets store absolute object-header addresses that would
+    // go stale on rewrite, so each reference is resolved to its target's *new*
+    // address (via the source address->path map and the writer's path resolution)
+    // rather than copied. Routed here before the verbatim chunk-copy path so a
+    // chunked one is refused (not copied with stale addresses).
+    if is_object_reference(&datatype) {
+        emit_object_reference_dataset(db, ds, path, &dims, &layout, file, drop, addr_map)?;
         let attrs = ds.attrs()?;
         check_attr_completeness(&attrs, &ds.attr_names()?, &format!("dataset {path}"))?;
         for (name, value) in sorted(attrs) {
@@ -485,6 +544,53 @@ fn emit_vlen_string_dataset(
     Ok(())
 }
 
+/// Re-emit a non-string variable-length (sequence) dataset faithfully: read each
+/// element's exact heap bytes and re-stage them through a fresh global heap, so
+/// the rewritten file's heap addresses are rebuilt rather than copied stale.
+///
+/// Chunked/filtered/resizable layouts are refused by name for the same reason as
+/// VL strings: the element references live inside compressed chunks written
+/// before the global heap addresses are known.
+fn emit_vlen_sequence_dataset(
+    db: &mut DatasetBuilder,
+    ds: &Dataset,
+    path: &str,
+    datatype: &Datatype,
+    dims: &[u64],
+    layout: &DataLayout,
+) -> Result<(), Error> {
+    if matches!(layout, DataLayout::Chunked { .. }) {
+        return Err(Error::RepackUnsupported(format!(
+            "dataset {path}: chunked or filtered non-string variable-length datasets cannot be \
+             repacked (their element references live inside compressed chunks before the global \
+             heap addresses are known)"
+        )));
+    }
+    if let Some(maxshape) = &ds.dataspace()?.max_dimensions
+        && maxshape != dims
+    {
+        return Err(Error::RepackUnsupported(format!(
+            "dataset {path}: resizable non-string variable-length datasets cannot be repacked"
+        )));
+    }
+
+    // Read each element's exact heap bytes (preserving the null-vs-empty
+    // distinction and any embedded NULs), then re-stage with the source datatype.
+    let (objects, _element_size) = ds.read_vlen_sequence_bytes(VlenStringReadOptions::default())?;
+    let elements: Vec<VlStringElement> = objects
+        .into_iter()
+        .map(|o| match o {
+            VlByteObject::Null => VlStringElement::Null,
+            VlByteObject::Bytes(bytes) => VlStringElement::Bytes(bytes),
+        })
+        .collect();
+
+    db.with_vlen_sequence_elements(datatype.clone(), &elements)
+        .map_err(Error::Format)?;
+    db.with_shape(dims);
+    Ok(())
+}
+
 /// A [`ChunkProvider`] that streams a dense chunked dataset's chunks from the
 /// source file one at a time during the write, so repack never holds more than a
 /// single chunk's bytes. Holds an `Arc<File>` (so it owns its source with no
@@ -610,11 +716,11 @@ fn check_attr_completeness(
     Ok(())
 }
 
-/// Reject datatypes whose on-disk form this crate cannot re-emit faithfully
-/// (variable-length; time, whose byte order is not modelled; and reference,
-/// whose stored absolute addresses would go stale on rewrite), recursing into
-/// compound members, enumeration bases, and array element types so a nested
-/// occurrence is caught too.
+/// Reject datatypes whose on-disk form this crate cannot re-emit faithfully,
+/// recursing into compound members, enumeration bases, and array element types so
+/// a nested occurrence is caught too. Region and non-8-byte object references are
+/// the remaining refusals (their stored selections/addresses are not yet
+/// rewritten); 8-byte object references are handled by the reference rewrite path.
 fn check_datatype(dt: &Datatype, path: &str) -> Result<(), Error> {
     let bad = |what: &str| {
         Err(Error::RepackUnsupported(format!(
@@ -623,24 +729,39 @@ fn check_datatype(dt: &Datatype, path: &str) -> Result<(), Error> {
     };
     match dt {
         // Scalar and opaque-bytes datatypes whose on-disk form `Datatype::serialize`
-        // reproduces exactly, so reading the raw element bytes and re-emitting them
-        // is byte-for-byte faithful.
+        // reproduces exactly (including the time type's byte order), so reading the
+        // raw element bytes and re-emitting them is byte-for-byte faithful.
         Datatype::FixedPoint { .. }
         | Datatype::FloatingPoint { .. }
+        | Datatype::Time { .. }
         | Datatype::String { .. }
         | Datatype::BitField { .. }
         | Datatype::Opaque { .. } => Ok(()),
-        // The time type's serialized byte order is not modelled (always emitted
-        // little-endian), so a big-endian source could not be reproduced exactly.
-        Datatype::Time { .. } => bad("time"),
         // String-shaped variable-length datatypes (`is_string: true`, or the
         // MATLAB VLEN-of-1-byte-ASCII-string shape) are reproduced by reading
         // each element's exact heap bytes and re-staging them through the
         // writer's VL-string path; the layout/filter checks gate chunked ones.
-        // Non-string VL (sequences of arbitrary base types) stays refused.
         Datatype::VariableLength { .. } if is_vlen_string_datatype(dt) => Ok(()),
-        Datatype::VariableLength { .. } => bad("non-string variable-length"),
-        Datatype::Reference { .. } => bad("reference"),
+        // Non-string VL (sequences of arbitrary base types) are re-staged the
+        // same way, but only when the base type's bytes carry no embedded heap or
+        // file addresses that a verbatim copy would leave stale.
+        Datatype::VariableLength { base_type, .. } => check_vlen_base_type(base_type, path),
+        // Object references (8-byte object-header addresses) are repacked by
+        // rewriting each address to its target's new location. Region references
+        // (which embed a dataspace selection in the global heap) and non-8-byte
+        // object references are not reproduced yet.
+        Datatype::Reference {
+            ref_type: ReferenceType::Object,
+            size: 8,
+        } => Ok(()),
+        Datatype::Reference {
+            ref_type: ReferenceType::Object,
+            ..
+        } => bad("non-8-byte object reference"),
+        Datatype::Reference {
+            ref_type: ReferenceType::DatasetRegion,
+            ..
+        } => bad("dataset-region reference"),
         Datatype::Compound { members, .. } => {
             for m in members {
                 check_datatype(&m.datatype, path)?;
@@ -650,6 +771,201 @@ fn check_datatype(dt: &Datatype, path: &str) -> Result<(), Error> {
         Datatype::Enumeration { base_type, .. } => check_datatype(base_type, path),
         Datatype::Array { base_type, .. } => check_datatype(base_type, path),
     }
+}
+
+/// Whether `dt` is a non-string variable-length (sequence) datatype — the kind
+/// re-emitted by [`emit_vlen_sequence_dataset`]. Excludes the string-shaped VL
+/// datatypes, which [`emit_vlen_string_dataset`] handles.
+fn is_nonstring_vlen(dt: &Datatype) -> bool {
+    matches!(dt, Datatype::VariableLength { .. }) && !is_vlen_string_datatype(dt)
+}
+
+/// A non-string VL sequence is repacked by re-staging each element's exact heap
+/// bytes verbatim. That is faithful only when the base type's bytes embed no
+/// addresses that would go stale on rewrite: a nested variable-length type (its
+/// elements are themselves global-heap references) and a reference (a stale file
+/// address) are refused, recursing through compound members, array elements, and
+/// enumeration bases so a nested occurrence is caught too.
+fn check_vlen_base_type(dt: &Datatype, path: &str) -> Result<(), Error> {
+    let bad = |what: &str| {
+        Err(Error::RepackUnsupported(format!(
+            "dataset {path}: variable-length sequence of {what} cannot be repacked faithfully yet"
+        )))
+    };
+    match dt {
+        Datatype::FixedPoint { .. }
+        | Datatype::FloatingPoint { .. }
+        | Datatype::Time { .. }
+        | Datatype::String { .. }
+        | Datatype::BitField { .. }
+        | Datatype::Opaque { .. } => Ok(()),
+        Datatype::Reference { .. } => bad("references"),
+        Datatype::VariableLength { .. } => bad("variable-length elements"),
+        Datatype::Compound { members, .. } => {
+            for m in members {
+                check_vlen_base_type(&m.datatype, path)?;
+            }
+            Ok(())
+        }
+        Datatype::Enumeration { base_type, .. } => check_vlen_base_type(base_type, path),
+        Datatype::Array { base_type, .. } => check_vlen_base_type(base_type, path),
+    }
+}
+
+/// Whether `dt` is an object-reference datatype handled by
+/// [`emit_object_reference_dataset`].
+fn is_object_reference(dt: &Datatype) -> bool {
+    matches!(
+        dt,
+        Datatype::Reference {
+            ref_type: ReferenceType::Object,
+            ..
+        }
+    )
+}
+
+/// Whether `path` is dropped from the output: either listed in `drop`, or nested
+/// under a dropped group (so its whole subtree is gone).
+fn is_dropped(path: &str, drop: &BTreeSet<String>) -> bool {
+    if drop.contains(path) {
+        return true;
+    }
+    let mut p = path;
+    while let Some(idx) = p.rfind('/') {
+        p = &p[..idx];
+        if drop.contains(p) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Build a map from each source object's header address to its slash-free path,
+/// for resolving object references. With a zero base address (the case object
+/// references are repacked for) the stored reference value is exactly this
+/// header address, so the lookup is direct.
+fn build_object_address_map(file: &File) -> Result<HashMap<u64, String>, Error> {
+    let mut map = HashMap::new();
+    let root = file.root();
+    // The root group can itself be referenced (the writer registers it under the
+    // empty path).
+    map.insert(root.header_address(), String::new());
+    collect_addresses(&root, "", &mut map)?;
+    Ok(map)
+}
+
+/// Recursively record `(header address -> path)` for every dataset and subgroup.
+fn collect_addresses(
+    group: &Group,
+    prefix: &str,
+    map: &mut HashMap<u64, String>,
+) -> Result<(), Error> {
+    for name in group.datasets()? {
+        let ds = group.dataset(&name)?;
+        map.insert(ds.header_address(), join(prefix, &name));
+    }
+    for name in group.groups()? {
+        let child = group.group(&name)?;
+        let child_path = join(prefix, &name);
+        map.insert(child.header_address(), child_path.clone());
+        collect_addresses(&child, &child_path, map)?;
+    }
+    Ok(())
+}
+
+/// Re-emit an object-reference dataset faithfully: rewrite each stored address to
+/// point at its target's destination location instead of its stale source one.
+///
+/// Each reference is read, resolved through `addr_map` to a source path, and
+/// re-staged as a path target the writer resolves once destination addresses are
+/// known. Null (address 0) and undefined (`HADDR_UNDEF`) references are carried
+/// verbatim. Refused by name: chunked/filtered or resizable layouts, a non-zero
+/// base address, a reference to a dropped object, and a reference whose target is
+/// not a hard-linked group or dataset in the source (dangling, or a named
+/// datatype / region target not modelled yet).
+#[allow(clippy::too_many_arguments)]
+fn emit_object_reference_dataset(
+    db: &mut DatasetBuilder,
+    ds: &Dataset,
+    path: &str,
+    dims: &[u64],
+    layout: &DataLayout,
+    file: &Arc<File>,
+    drop: &BTreeSet<String>,
+    addr_map: &HashMap<u64, String>,
+) -> Result<(), Error> {
+    if matches!(layout, DataLayout::Chunked { .. }) {
+        return Err(Error::RepackUnsupported(format!(
+            "dataset {path}: chunked or filtered object-reference datasets cannot be repacked \
+             (their addresses live inside compressed chunks and would need rewriting in place)"
+        )));
+    }
+    if let Some(maxshape) = &ds.dataspace()?.max_dimensions
+        && maxshape != dims
+    {
+        return Err(Error::RepackUnsupported(format!(
+            "dataset {path}: resizable object-reference datasets cannot be repacked"
+        )));
+    }
+    // Object references store addresses relative to the base address; the rewrite
+    // path assumes a zero base (the universal case), so a userblock file is
+    // refused rather than risk a mis-resolved address.
+    if file.base_address() != 0 {
+        return Err(Error::RepackUnsupported(format!(
+            "dataset {path}: object references in a file with a non-zero base address (userblock) \
+             cannot be repacked yet"
+        )));
+    }
+
+    let n_elements: usize = dims.iter().product::<u64>().to_usize()?;
+    let targets = if n_elements == 0 {
+        Vec::new()
+    } else {
+        let raw = ds.read_raw()?;
+        let needed = n_elements
+            .checked_mul(8)
+            .ok_or(FormatError::OffsetOverflow {
+                offset: n_elements as u64,
+                length: 8,
+            })?;
+        if raw.len() < needed {
+            return Err(FormatError::UnexpectedEof {
+                expected: needed,
+                available: raw.len(),
+            }
+            .into());
+        }
+        let mut targets = Vec::with_capacity(n_elements);
+        for chunk in raw[..needed].chunks_exact(8) {
+            let v = u64::from_le_bytes(chunk.try_into().expect("chunks_exact(8) yields 8 bytes"));
+            // 0 = null, all-ones = HADDR_UNDEF: both point at nothing, carried as-is.
+            if v == 0 || v == u64::MAX {
+                targets.push(ObjectRefTarget::Raw(v));
+                continue;
+            }
+            match addr_map.get(&v) {
+                Some(target_path) if is_dropped(target_path, drop) => {
+                    return Err(Error::RepackUnsupported(format!(
+                        "dataset {path}: object reference to dropped object {target_path:?} \
+                         cannot be repacked"
+                    )));
+                }
+                Some(target_path) => targets.push(ObjectRefTarget::Path(target_path.clone())),
+                None => {
+                    return Err(Error::RepackUnsupported(format!(
+                        "dataset {path}: object reference to address {v:#x} resolves to no \
+                         hard-linked object in the source (dangling, or a named-datatype / \
+                         region target not supported yet)"
+                    )));
+                }
+            }
+        }
+        targets
+    };
+
+    db.with_object_references(targets);
+    db.with_shape(dims);
+    Ok(())
 }
 
 /// Reject data layouts that cannot be read and re-emitted (virtual datasets;
@@ -728,5 +1044,74 @@ fn join(parent: &str, name: &str) -> String {
         name.to_string()
     } else {
         format!("{parent}/{name}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn repack_preserves_big_endian_time_dataset() {
+        // The reference C library cannot create H5T_TIME, so this round-trips a
+        // big-endian time dataset through our own writer and reader: repack must
+        // preserve both the byte order (bf0 bit 0) and the raw element bytes.
+        use crate::datatype::{Datatype, DatatypeByteOrder};
+        use crate::reader::File;
+        use crate::writer::FileBuilder;
+
+        let dir = std::env::temp_dir();
+        let src = dir.join("hdf5_pure_repack_time_src.h5");
+        let dst = dir.join("hdf5_pure_repack_time_dst.h5");
+
+        let dt = Datatype::Time {
+            size: 4,
+            byte_order: DatatypeByteOrder::BigEndian,
+            bit_precision: 32,
+        };
+        let raw: Vec<u8> = vec![
+            0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x03,
+        ];
+        {
+            let mut b = FileBuilder::new();
+            b.create_dataset("t")
+                .with_raw_data(dt.clone(), raw.clone(), 3)
+                .with_shape(&[3]);
+            b.write(&src).unwrap();
+        }
+
+        repack(&src, &dst, &RepackOptions::new()).unwrap();
+
+        let f = File::open(&dst).unwrap();
+        let ds = f.dataset("t").unwrap();
+        assert_eq!(
+            ds.datatype().unwrap(),
+            dt,
+            "time datatype incl. byte order must survive repack"
+        );
+        assert_eq!(
+            ds.read_raw().unwrap(),
+            raw,
+            "time element bytes must be preserved"
+        );
+
+        std::fs::remove_file(&src).ok();
+        std::fs::remove_file(&dst).ok();
+    }
+
+    #[test]
+    fn is_dropped_matches_self_and_ancestors() {
+        let drop: BTreeSet<String> = ["g/old", "lone"].iter().map(|s| s.to_string()).collect();
+        // The dropped path itself.
+        assert!(is_dropped("lone", &drop));
+        assert!(is_dropped("g/old", &drop));
+        // A descendant of a dropped group is dropped (the whole subtree goes).
+        assert!(is_dropped("g/old/child", &drop));
+        assert!(is_dropped("g/old/a/b", &drop));
+        // Unrelated paths and partial-name collisions are not dropped.
+        assert!(!is_dropped("g", &drop));
+        assert!(!is_dropped("g/older", &drop));
+        assert!(!is_dropped("lonely", &drop));
+        assert!(!is_dropped("other/old", &drop));
     }
 }

--- a/src/type_builders.rs
+++ b/src/type_builders.rs
@@ -719,9 +719,19 @@ pub(crate) struct VlStringStaging {
     pub patch_mask: Vec<bool>,
 }
 
-/// Stage the references and global-heap collection for a VL-string
+/// Stage the references and global-heap collection for a variable-length
 /// dataset/attribute from its per-element byte payloads.
-pub(crate) fn stage_vl_string_elements(elements: &[VlStringElement]) -> VlStringStaging {
+///
+/// `element_size` is the byte width of the VL base type. A VL string's base type
+/// is a single byte (`element_size == 1`), so the reference's stored `length`
+/// equals the payload's byte count. A non-string VL sequence stores an element
+/// *count* in that field, so the length written is `bytes.len() / element_size`,
+/// while the heap object still holds the exact bytes.
+pub(crate) fn stage_vl_elements(
+    elements: &[VlStringElement],
+    element_size: usize,
+) -> VlStringStaging {
+    let element_size = element_size.max(1);
     // Collect the non-null payloads in order; their 1-based positions become
     // the heap object indices.
     let mut objects: Vec<&[u8]> = Vec::new();
@@ -730,18 +740,22 @@ pub(crate) fn stage_vl_string_elements(elements: &[VlStringElement]) -> VlString
     for element in elements {
         match element {
             VlStringElement::Null => {
+                // A null VL reference: HDF5 marks "no heap object" with a zero
+                // heap address (`H5T__vlen_disk_isnull` tests addr == 0), not the
+                // all-ones "undefined address" sentinel — the reference C library
+                // rejects the latter as a bad heap index when reading.
                 refs.extend_from_slice(&0u32.to_le_bytes()); // length 0
-                refs.extend_from_slice(&u64::MAX.to_le_bytes()); // undefined address
+                refs.extend_from_slice(&0u64.to_le_bytes()); // null heap address
                 refs.extend_from_slice(&0u32.to_le_bytes()); // object index 0
                 patch_mask.push(false);
             }
             VlStringElement::Bytes(bytes) => {
                 #[expect(
                     clippy::cast_possible_truncation,
-                    reason = "VL element byte length is written into the 4-byte length prefix \
-                              of the variable-length reference"
+                    reason = "VL element length (element count) is written into the 4-byte \
+                              length prefix of the variable-length reference"
                 )]
-                refs.extend_from_slice(&(bytes.len() as u32).to_le_bytes());
+                refs.extend_from_slice(&((bytes.len() / element_size) as u32).to_le_bytes());
                 refs.extend_from_slice(&0u64.to_le_bytes()); // patched later
                 let index = objects.len() + 1; // 1-based heap object index
                 #[expect(
@@ -873,6 +887,21 @@ pub(crate) struct RawChunkPayload {
     pub(crate) provider: core::panic::AssertUnwindSafe<Box<dyn ChunkProvider>>,
 }
 
+/// One element of an object-reference dataset written through the builder.
+///
+/// A reference either names an object by path (resolved to that object's
+/// destination address during serialization) or carries a raw address verbatim.
+/// The raw form preserves a null reference (address 0) or an undefined reference
+/// (`HADDR_UNDEF`, all-ones) exactly, which a faithful rewrite (repack) needs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ObjectRefTarget {
+    /// Resolve to the destination address of the object at this path.
+    Path(String),
+    /// Write this exact 8-byte address (e.g. 0 for null, `u64::MAX` for
+    /// undefined).
+    Raw(u64),
+}
+
 /// Builder for datasets.
 pub struct DatasetBuilder {
     pub(crate) name: String,
@@ -887,9 +916,10 @@ pub struct DatasetBuilder {
     /// filter-pipeline message, and the geometry needed to lay them out. This
     /// takes precedence over `data` / `chunk_options` for chunked storage.
     pub(crate) raw_chunks: Option<RawChunkPayload>,
-    /// When set, this dataset contains object references that should be
-    /// resolved by path during file serialization.
-    pub(crate) reference_targets: Option<Vec<String>>,
+    /// When set, this dataset is an object-reference dataset whose element
+    /// addresses are resolved (per-element by path, or written raw) during file
+    /// serialization once every object's destination address is known.
+    pub(crate) reference_targets: Option<Vec<ObjectRefTarget>>,
     /// When set, this dataset stores variable-length strings: `data` holds the
     /// 16-byte references with placeholder heap addresses, and this staging
     /// carries the global heap collection plus the mask of references to patch
@@ -1062,13 +1092,28 @@ impl DatasetBuilder {
     /// each path is resolved to the absolute address of the named object.
     /// Paths use `/` separators (e.g., `"#refs#/child1"`).
     pub fn with_path_references(&mut self, paths: &[&str]) -> &mut Self {
+        let targets = paths
+            .iter()
+            .map(|s| ObjectRefTarget::Path(s.to_string()))
+            .collect();
+        self.with_object_references(targets)
+    }
+
+    /// Write an object-reference dataset from explicit per-element targets,
+    /// preserving null/undefined references verbatim. The datatype is set to the
+    /// 8-byte object-reference type; each [`ObjectRefTarget::Path`] is resolved to
+    /// its destination address during serialization, while
+    /// [`ObjectRefTarget::Raw`] is written as-is. This is the faithful re-emit
+    /// path used by repack. The shape defaults to `[targets.len()]` unless
+    /// [`with_shape`](Self::with_shape) sets it.
+    pub(crate) fn with_object_references(&mut self, targets: Vec<ObjectRefTarget>) -> &mut Self {
         self.datatype = Some(make_object_reference_type());
-        // Placeholder zeros — will be patched during finish()
-        self.data = Some(vec![0u8; paths.len() * 8]);
-        self.reference_targets = Some(paths.iter().map(|s| s.to_string()).collect());
+        // Placeholder zeros — patched once all destination addresses are known.
+        self.data = Some(vec![0u8; targets.len() * 8]);
         if self.shape.is_none() {
-            self.shape = Some(vec![paths.len() as u64]);
+            self.shape = Some(vec![targets.len() as u64]);
         }
+        self.reference_targets = Some(targets);
         self
     }
 
@@ -1298,8 +1343,60 @@ impl DatasetBuilder {
     /// Shared body of the VL-string write entry points: stage the references
     /// and global heap collection and record them on the builder.
     fn stage_vlen_strings(&mut self, datatype: Datatype, elements: &[VlStringElement]) {
+        // A VL string's base type is one byte, so the reference length is the
+        // byte count (element_size = 1).
+        self.stage_vlen_elements(datatype, elements, 1);
+    }
+
+    /// Write a *non-string* variable-length (sequence) dataset from an explicit
+    /// source datatype and per-element byte payloads.
+    ///
+    /// `datatype` must be a non-string VL datatype (e.g. `H5T_VLEN
+    /// { H5T_NATIVE_DOUBLE }`); its base type is reproduced verbatim. Each
+    /// element's exact heap bytes are re-staged through a fresh global heap, and
+    /// the per-element reference stores the base-type element count. This is the
+    /// faithful re-emit path used by repack. Returns a
+    /// [`TypeMismatch`](crate::FormatError::TypeMismatch) if `datatype` is a
+    /// string-shaped VL datatype or not variable-length at all. The shape
+    /// defaults to `[elements.len()]` unless [`with_shape`](Self::with_shape)
+    /// sets it.
+    pub(crate) fn with_vlen_sequence_elements(
+        &mut self,
+        datatype: Datatype,
+        elements: &[VlStringElement],
+    ) -> Result<&mut Self, crate::error::FormatError> {
+        let Datatype::VariableLength { base_type, .. } = &datatype else {
+            return Err(crate::error::FormatError::TypeMismatch {
+                expected: "non-string VariableLength",
+                actual: "non-VariableLength",
+            });
+        };
+        if crate::vl_data::is_vlen_string_datatype(&datatype) {
+            return Err(crate::error::FormatError::TypeMismatch {
+                expected: "non-string VariableLength",
+                actual: "VariableLength string",
+            });
+        }
+        let element_size = base_type.type_size() as usize;
+        if element_size == 0 {
+            return Err(crate::error::FormatError::VlDataError(
+                "non-string VL base type has zero size".into(),
+            ));
+        }
+        self.stage_vlen_elements(datatype, elements, element_size);
+        Ok(self)
+    }
+
+    /// Shared body of the VL write entry points (string and sequence): stage the
+    /// references and global heap collection and record them on the builder.
+    fn stage_vlen_elements(
+        &mut self,
+        datatype: Datatype,
+        elements: &[VlStringElement],
+        element_size: usize,
+    ) {
         let n = elements.len() as u64;
-        let staging = stage_vl_string_elements(elements);
+        let staging = stage_vl_elements(elements, element_size);
         self.datatype = Some(datatype);
         self.data = Some(staging.refs.clone());
         self.vl_string_staging = Some(staging);

--- a/src/vl_data.rs
+++ b/src/vl_data.rs
@@ -335,12 +335,19 @@ pub(crate) enum VlByteObject {
     Bytes(Vec<u8>),
 }
 
-/// Resolve a VL-string element's exact heap bytes from a random-access source,
+/// Resolve a VL element's exact heap bytes from a random-access source,
 /// preserving the null-vs-empty distinction and never lossily decoding.
 ///
 /// This mirrors [`visit_vl_strings_from_source`] but yields raw bytes (and a
 /// null marker) instead of a `&str`, so a faithful rewrite can reproduce
 /// embedded-NUL and non-UTF-8 payloads exactly.
+///
+/// `element_size` is the byte width of one base-type element of the sequence.
+/// For VL strings the base type is a single byte, so `element_size == 1` and the
+/// reference's stored `length` (an element count) equals the byte count. For a
+/// non-string VL sequence (e.g. `H5T_VLEN { H5T_NATIVE_DOUBLE }`) the stored
+/// `length` counts base-type elements, so the heap object holds
+/// `length * element_size` bytes — exactly what is read here.
 pub(crate) fn read_vl_byte_objects_from_source<S: FileSource + ?Sized>(
     source: &S,
     raw_data: &[u8],
@@ -348,6 +355,7 @@ pub(crate) fn read_vl_byte_objects_from_source<S: FileSource + ?Sized>(
     offset_size: u8,
     length_size: u8,
     base_address: u64,
+    element_size: usize,
     options: VlenStringReadOptions,
 ) -> Result<Vec<VlByteObject>, FormatError> {
     check_element_limit(num_elements, options)?;
@@ -400,14 +408,23 @@ pub(crate) fn read_vl_byte_objects_from_source<S: FileSource + ?Sized>(
                 index,
             },
         )?;
-        if u64::from(element.length) > object.size {
+        // The heap object holds `length` base-type elements of `element_size`
+        // bytes each. Compute the byte count with checked arithmetic so a hostile
+        // `length` cannot overflow, and bound it by the heap object's own size.
+        let byte_len = (element.length as u64)
+            .checked_mul(element_size as u64)
+            .ok_or(FormatError::OffsetOverflow {
+                offset: u64::from(element.length),
+                length: element_size as u64,
+            })?;
+        if byte_len > object.size {
             return Err(FormatError::VlDataError(format!(
-                "VL element length {} exceeds global heap object size {}",
-                element.length, object.size
+                "VL element length {} ({} bytes) exceeds global heap object size {}",
+                element.length, byte_len, object.size
             )));
         }
 
-        let bytes = source.read_exact_at(object.data_address, element.length as usize)?;
+        let bytes = source.read_exact_at(object.data_address, byte_len.to_usize()?)?;
         objects.push(VlByteObject::Bytes(bytes));
     }
 

--- a/tests/repack_crosscheck.rs
+++ b/tests/repack_crosscheck.rs
@@ -205,6 +205,177 @@ fn repack_roundtrips_vlen_string_2d() {
 }
 
 #[test]
+fn repack_roundtrips_c_vlen_sequence_dataset() {
+    use hdf5::types::VarLenArray;
+
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("c_vlen_seq.h5");
+    let dst = dir.path().join("vlen_seq_repacked.h5");
+
+    // The C library writes a non-string VL dataset (`H5T_VLEN { i32 }`),
+    // including an empty sequence.
+    let seqs: Vec<Vec<i32>> = vec![vec![1, 2, 3], vec![], vec![-7, 42, 0, 99], vec![5]];
+    {
+        let file = hdf5::File::create(&src).unwrap();
+        let vals: Vec<VarLenArray<i32>> = seqs
+            .iter()
+            .map(|s| VarLenArray::from_slice(s.as_slice()))
+            .collect();
+        file.new_dataset::<VarLenArray<i32>>()
+            .shape((seqs.len(),))
+            .create("seqs")
+            .unwrap()
+            .write(&vals)
+            .unwrap();
+        file.close().unwrap();
+    }
+
+    repack(&src, &dst, &RepackOptions::new()).unwrap();
+
+    // hdf5-pure must see the repacked datatype as a non-string variable-length
+    // sequence (not silently converted).
+    let f = File::open(&dst).unwrap();
+    let ds = f.dataset("seqs").unwrap();
+    assert!(
+        matches!(
+            ds.datatype().unwrap(),
+            hdf5_pure::Datatype::VariableLength {
+                is_string: false,
+                ..
+            }
+        ),
+        "repacked datatype must stay a non-string variable-length sequence"
+    );
+
+    // The reference C library reads the exact sequences back — the interop proof
+    // that the re-staged global heap and rebuilt references are valid.
+    let c = hdf5::File::open(&dst).unwrap();
+    let cds = c.dataset("seqs").unwrap();
+    let cvals = cds.read_raw::<VarLenArray<i32>>().unwrap();
+    let got: Vec<Vec<i32>> = cvals.iter().map(|v| v.as_slice().to_vec()).collect();
+    assert_eq!(got, seqs);
+}
+
+#[test]
+fn repack_roundtrips_c_object_reference_dataset() {
+    use hdf5::{ObjectReference, ObjectReference1, ReferencedObject};
+
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("c_refs.h5");
+    let dst = dir.path().join("refs_repacked.h5");
+
+    // The C library writes two targets plus a dataset of object references to
+    // them (one in the root, one in a subgroup).
+    {
+        let file = hdf5::File::create(&src).unwrap();
+        file.new_dataset::<f64>()
+            .shape((3,))
+            .create("alpha")
+            .unwrap()
+            .write(&[1.0f64, 2.0, 3.0])
+            .unwrap();
+        let grp = file.create_group("grp").unwrap();
+        grp.new_dataset::<i32>()
+            .shape((4,))
+            .create("beta")
+            .unwrap()
+            .write(&[10i32, 20, 30, 40])
+            .unwrap();
+        let refs = vec![
+            ObjectReference1::create(&file, "alpha").unwrap(),
+            ObjectReference1::create(&file, "grp/beta").unwrap(),
+            // A reference to the root group exercises the empty-path resolution.
+            ObjectReference1::create(&file, "/").unwrap(),
+        ];
+        file.new_dataset::<ObjectReference1>()
+            .shape((3,))
+            .create("refs")
+            .unwrap()
+            .write(&refs)
+            .unwrap();
+        file.close().unwrap();
+    }
+
+    repack(&src, &dst, &RepackOptions::new()).unwrap();
+
+    // hdf5-pure sees the repacked datatype as an object reference (not converted).
+    let f = File::open(&dst).unwrap();
+    assert!(
+        matches!(
+            f.dataset("refs").unwrap().datatype().unwrap(),
+            hdf5_pure::Datatype::Reference {
+                ref_type: hdf5_pure::ReferenceType::Object,
+                ..
+            }
+        ),
+        "repacked datatype must stay an object reference"
+    );
+
+    // The reference C library dereferences each repacked reference to the right
+    // object — the proof that the addresses were rewritten to the new locations
+    // rather than copied stale.
+    let c = hdf5::File::open(&dst).unwrap();
+    let cds = c.dataset("refs").unwrap();
+    let cvals = cds.read_raw::<ObjectReference1>().unwrap();
+    assert_eq!(cvals.len(), 3);
+    match cvals[0].dereference(&c).unwrap() {
+        ReferencedObject::Dataset(d) => {
+            assert_eq!(d.read_raw::<f64>().unwrap(), vec![1.0, 2.0, 3.0]);
+        }
+        other => panic!("ref 0 should resolve to a dataset, got {other:?}"),
+    }
+    match cvals[1].dereference(&c).unwrap() {
+        ReferencedObject::Dataset(d) => {
+            assert_eq!(d.read_raw::<i32>().unwrap(), vec![10, 20, 30, 40]);
+        }
+        other => panic!("ref 1 should resolve to a dataset, got {other:?}"),
+    }
+    match cvals[2].dereference(&c).unwrap() {
+        ReferencedObject::Group(_) => {}
+        other => panic!("ref 2 should resolve to the root group, got {other:?}"),
+    }
+}
+
+#[test]
+fn repack_refuses_reference_to_dropped_object() {
+    use hdf5::{ObjectReference, ObjectReference1};
+
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("c_refs_drop.h5");
+    let dst = dir.path().join("refs_drop_repacked.h5");
+
+    {
+        let file = hdf5::File::create(&src).unwrap();
+        file.new_dataset::<f64>()
+            .shape((2,))
+            .create("target")
+            .unwrap()
+            .write(&[1.0f64, 2.0])
+            .unwrap();
+        let refs = vec![ObjectReference1::create(&file, "target").unwrap()];
+        file.new_dataset::<ObjectReference1>()
+            .shape((1,))
+            .create("refs")
+            .unwrap()
+            .write(&refs)
+            .unwrap();
+        file.close().unwrap();
+    }
+
+    // Dropping the referenced object must fail the repack by name rather than
+    // silently leave a dangling reference.
+    let err = repack(&src, &dst, &RepackOptions::new().drop_path("target")).unwrap_err();
+    match err {
+        hdf5_pure::Error::RepackUnsupported(msg) => assert!(
+            msg.contains("refs") && msg.contains("target") && msg.contains("dropped"),
+            "error should name the reference dataset and the dropped target: {msg}"
+        ),
+        other => panic!("expected RepackUnsupported, got {other:?}"),
+    }
+    assert!(!dst.exists(), "dst must not be created when repack refuses");
+}
+
+#[test]
 fn repack_refuses_chunked_vlen_string_dataset() {
     use hdf5::types::VarLenUnicode;
     use std::str::FromStr;


### PR DESCRIPTION
Extends whole-file `repack` to reproduce three more datatype classes faithfully — the bulk of the deferred-work item #107. Each is read and re-emitted byte-exact, or refused by name; repack never silently degrades data.

## What's now reproducible

- **Non-string variable-length sequences** (`H5T_VLEN { T }`): the vlen byte reader is generalized to read `length × element_size` bytes (the stored `length` is an element *count*, not a byte count), and `DatasetBuilder::with_vlen_sequence_elements` re-stages each element through a fresh global heap — the same mechanism as the VL-string path.
- **Object references**: each stored 8-byte address is read, resolved to a source path via a new address→path map (`Dataset`/`Group` now expose `header_address()`), and re-emitted as a path target the writer resolves to the object's *new* location. Null/undefined references are carried verbatim; references to the root group resolve under the empty path.
- **Time datatypes**: `Datatype::Time` now models the byte-order bit (it was hardcoded little-endian), so a big-endian time type round-trips byte-exact.

## Bonus fix

A null/empty variable-length element previously wrote an all-ones "undefined" heap address, which the reference C library **rejects as a bad heap index** when reading it back. It now uses HDF5's zero-address null convention (`H5T__vlen_disk_isnull`). This was a latent interop bug affecting any vlen dataset with an empty/null element, not just repack.

## Still refused by name (deferred)

Region references, non-8-byte object references, chunked/filtered/resizable VL & reference datasets, an object reference to a dropped or out-of-hierarchy target, object references in a userblock file, and unknown-filter passthrough on the *re-encode* fallback (the common chunked verbatim path already preserves every filter). So #107 is substantially addressed but not fully closed; CHANGELOG and the Limitations page reflect what remains.

## Validation

Cross-checked against the reference HDF5 C library (`hdf5-metno`):
- vlen sequences via `VarLenArray<i32>` (including an empty element),
- object references via `ObjectReference1` — the C library dereferences the rewritten addresses to the correct datasets and the root group,
- a dropped-target reference is refused by name.

Plus in-crate tests for time byte-order round-trip, vlen-sequence writer↔reader symmetry, and the drop-path check. Full suite: 830 tests pass; clippy and `cargo fmt --check` clean.