### PR TITLE
perf: optimize dataset read and write hot paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - A null or empty variable-length element now writes a zero heap address (HDF5's null-reference convention) instead of an all-ones undefined-address sentinel, which the reference C library rejected as a bad heap index when reading such an element back ([#107](https://github.com/stephenberry/hdf5-pure/issues/107)).
 
+### Performance
+
+- Decoding a numeric dataset into a typed `Vec` (`Dataset::read_i32`/`read_u16`/`read_f64` and siblings) now bulk-decodes native-/big-endian standard-layout values instead of going element by element, making integer reads several times faster (≈15× for `read_i32`, ≈9× for `read_u16` on a 1M-element array); sub-byte-precision and unusual layouts keep the exact same results ([#113](https://github.com/stephenberry/hdf5-pure/pull/113)).
+- Reading a chunked dataset now scatters each chunk into the output one contiguous row at a time rather than element by element, ≈3× faster chunk assembly (a 1024×1024 uncompressed read drops from ~7.6 ms to ~2.2 ms) ([#113](https://github.com/stephenberry/hdf5-pure/pull/113)).
+- Writing a chunked, filtered dataset now compresses each chunk once instead of twice (the object-header sizing pass no longer recompresses), ≈2–3× faster compressed writes (a 1024×1024 shuffle+deflate write drops from ~45 ms to ~16 ms) ([#113](https://github.com/stephenberry/hdf5-pure/pull/113)).
+- The byte-shuffle filter is specialized for the common element widths, the chunk cache no longer copies decompressed chunks in and out on the hot path, and the deflate decoder pre-sizes its output buffer ([#113](https://github.com/stephenberry/hdf5-pure/pull/113)).
+
 ## [0.16.0] - 2026-06-18
 
 Centers on `repack`: it now copies compressed chunks **verbatim** (so lossy filters survive byte-exact) and runs **fully out-of-core**, and gains variable-length-string support. Also adds in-place dataset-value overwrite, dense-attribute and cross-file object copy, in-place addition of chunked/filtered/extensible datasets, and free-space reclaim for chunked deletes; plus reader hardening (a multi-filter chunk-mask corruption fix, sub-byte integer precision, decompression-bomb bounds, and safer B-tree/heap refusals). Additive minor bump.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,6 +84,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,6 +104,58 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
@@ -115,6 +185,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,6 +242,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -252,6 +362,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,6 +461,7 @@ name = "hdf5-pure"
 version = "0.17.0"
 dependencies = [
  "byteorder",
+ "criterion",
  "flate2",
  "hdf5-metno",
  "ndarray",
@@ -358,6 +480,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,6 +501,26 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -519,6 +667,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "parking_lot"
@@ -802,6 +956,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -910,6 +1073,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.0.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -985,6 +1158,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1034,6 +1217,15 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,10 @@ serde = { version = "1", features = ["derive"] }
 # Property-based testing for the write/read roundtrip and parser-robustness
 # invariants (issue #26).
 proptest = "1"
+# Benchmark harness for the read/write hot paths (benches/hot_paths.rs). Default
+# features are off to avoid pulling the plotting/HTML-report dependency tree; the
+# benches report to the terminal, which is enough for before/after comparison.
+criterion = { version = "0.5", default-features = false }
 
 # The reference HDF5 C library, used only by the byte-level crosscheck tests.
 # Its `static` feature compiles libhdf5 from source via CMake, which does not
@@ -78,6 +82,10 @@ required-features = ["serde"]
 [[example]]
 name = "ndarray_io"
 required-features = ["ndarray"]
+
+[[bench]]
+name = "hot_paths"
+harness = false
 
 # Style-preference clippy lints muted crate-wide. The remaining clippy
 # surface is still on (`-D warnings` in CI), so genuinely problematic

--- a/benches/hot_paths.rs
+++ b/benches/hot_paths.rs
@@ -1,0 +1,152 @@
+//! Microbenchmarks for the read and write hot paths.
+//!
+//! These exercise the code that dominates a real workload: decoding raw bytes
+//! into typed `Vec`s, assembling chunked datasets into a dense buffer, the
+//! shuffle filter, and building a file. They go through the public API
+//! (`FileBuilder` / `File`) so they stay valid across internal refactors and
+//! measure what a user actually pays for.
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo bench --bench hot_paths
+//! ```
+//!
+//! Each group fixes a representative dataset size; compare the reported times
+//! before and after a change rather than reading absolute numbers.
+
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use hdf5_pure::{File, FileBuilder};
+
+/// Build a file image from a configuring closure.
+fn build(configure: impl FnOnce(&mut FileBuilder)) -> Vec<u8> {
+    let mut b = FileBuilder::new();
+    configure(&mut b);
+    b.finish().expect("serialize file")
+}
+
+// ---------------------------------------------------------------------------
+// Contiguous typed decode (isolates the data_read byte->typed conversion)
+// ---------------------------------------------------------------------------
+
+fn bench_contiguous_decode(c: &mut Criterion) {
+    let n: usize = 1 << 20; // ~1M elements
+
+    let f64_bytes = build(|b| {
+        let data: Vec<f64> = (0..n).map(|i| i as f64 * 0.5).collect();
+        b.create_dataset("d").with_f64_data(&data);
+    });
+    let i32_bytes = build(|b| {
+        let data: Vec<i32> = (0..n)
+            .map(|i| (i as i32).wrapping_mul(2654435761u32 as i32))
+            .collect();
+        b.create_dataset("d").with_i32_data(&data);
+    });
+    let u16_bytes = build(|b| {
+        let data: Vec<u16> = (0..n).map(|i| (i & 0xFFFF) as u16).collect();
+        b.create_dataset("d").with_u16_data(&data);
+    });
+
+    let f64_file = File::from_bytes(f64_bytes).unwrap();
+    let i32_file = File::from_bytes(i32_bytes).unwrap();
+    let u16_file = File::from_bytes(u16_bytes).unwrap();
+
+    let mut g = c.benchmark_group("contiguous_decode_1M");
+    g.bench_function("read_f64", |b| {
+        b.iter(|| black_box(f64_file.dataset("d").unwrap().read_f64().unwrap()))
+    });
+    g.bench_function("read_i32", |b| {
+        b.iter(|| black_box(i32_file.dataset("d").unwrap().read_i32().unwrap()))
+    });
+    g.bench_function("read_u16", |b| {
+        b.iter(|| black_box(u16_file.dataset("d").unwrap().read_u16().unwrap()))
+    });
+    // Cross-type coercion: decode an i32-stored dataset to f64 (FixedPoint path).
+    g.bench_function("read_i32_as_f64", |b| {
+        b.iter(|| black_box(i32_file.dataset("d").unwrap().read_f64().unwrap()))
+    });
+    g.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Chunked assembly (isolates copy_chunk_to_output scatter into the output buf)
+// ---------------------------------------------------------------------------
+
+fn bench_chunked_assembly(c: &mut Criterion) {
+    let rows = 1024u64;
+    let cols = 1024u64;
+    let data: Vec<f64> = (0..(rows * cols)).map(|i| i as f64).collect();
+
+    // Uncompressed chunked: read time is dominated by chunk assembly + decode.
+    let plain = build(|b| {
+        b.create_dataset("d")
+            .with_f64_data(&data)
+            .with_shape(&[rows, cols])
+            .with_chunks(&[128, 128]);
+    });
+    // Shuffle + deflate: adds the shuffle filter and inflate to the assembly.
+    let shuf_def = build(|b| {
+        b.create_dataset("d")
+            .with_f64_data(&data)
+            .with_shape(&[rows, cols])
+            .with_chunks(&[128, 128])
+            .with_shuffle()
+            .with_deflate(6);
+    });
+
+    let plain_file = File::from_bytes(plain).unwrap();
+    let shuf_def_file = File::from_bytes(shuf_def).unwrap();
+
+    let mut g = c.benchmark_group("chunked_read_1024x1024_f64");
+    g.bench_function("uncompressed", |b| {
+        b.iter(|| black_box(plain_file.dataset("d").unwrap().read_f64().unwrap()))
+    });
+    g.bench_function("shuffle_deflate", |b| {
+        b.iter(|| black_box(shuf_def_file.dataset("d").unwrap().read_f64().unwrap()))
+    });
+    g.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Write path
+// ---------------------------------------------------------------------------
+
+fn bench_write(c: &mut Criterion) {
+    let n = 1 << 20;
+    let data: Vec<f64> = (0..n).map(|i| i as f64 * 0.25).collect();
+    let rows = 1024u64;
+    let cols = 1024u64;
+    let data2d: Vec<f64> = (0..(rows * cols)).map(|i| i as f64).collect();
+
+    let mut g = c.benchmark_group("write_1M_f64");
+    g.bench_function("contiguous", |b| {
+        b.iter(|| {
+            black_box(build(|bld| {
+                bld.create_dataset("d").with_f64_data(black_box(&data));
+            }))
+        })
+    });
+    g.bench_function("chunked_shuffle_deflate", |b| {
+        b.iter(|| {
+            black_box(build(|bld| {
+                bld.create_dataset("d")
+                    .with_f64_data(black_box(&data2d))
+                    .with_shape(&[rows, cols])
+                    .with_chunks(&[128, 128])
+                    .with_shuffle()
+                    .with_deflate(6);
+            }))
+        })
+    });
+    g.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_contiguous_decode,
+    bench_chunked_assembly,
+    bench_write
+);
+criterion_main!(benches);

--- a/src/chunk_cache.rs
+++ b/src/chunk_cache.rs
@@ -12,16 +12,9 @@ extern crate alloc;
 use alloc::vec::Vec;
 
 #[cfg(not(feature = "std"))]
-use alloc::alloc::{alloc_zeroed, dealloc, handle_alloc_error};
-#[cfg(feature = "std")]
-use std::alloc::{alloc_zeroed, dealloc, handle_alloc_error};
-
-#[cfg(not(feature = "std"))]
 use crate::nosync::Mutex;
 #[cfg(feature = "std")]
 use std::sync::Mutex;
-
-use core::ops::{Deref, DerefMut};
 
 #[cfg(not(feature = "std"))]
 use alloc::collections::BTreeMap;
@@ -31,13 +24,14 @@ use std::collections::HashMap;
 use crate::chunked_read::ChunkInfo;
 
 // ---------------------------------------------------------------------------
-// Cache-line alignment constants (TVL — Tensor Virtualization Layout)
+// Cache-line alignment
 // ---------------------------------------------------------------------------
 
 /// Cache line size in bytes for the target architecture.
 ///
-/// ARM64 uses 128-byte cache lines; x86_64 uses 64-byte. We align all chunk
-/// buffers to this boundary so SIMD operations can assume aligned input.
+/// ARM64 uses 128-byte cache lines; x86_64 uses 64-byte. The writer aligns
+/// chunk data blocks to this boundary on disk so a chunk read lands on a
+/// cache-line-aligned file offset.
 #[cfg(target_arch = "aarch64")]
 pub const CACHE_LINE_SIZE: usize = 128;
 
@@ -51,148 +45,6 @@ pub const CACHE_LINE_SIZE: usize = 64;
 #[inline]
 pub fn align_to_cache_line(size: usize) -> usize {
     (size + CACHE_LINE_SIZE - 1) & !(CACHE_LINE_SIZE - 1)
-}
-
-// ---------------------------------------------------------------------------
-// CacheAlignedBuffer
-// ---------------------------------------------------------------------------
-
-/// A byte buffer whose data pointer is aligned to [`CACHE_LINE_SIZE`].
-///
-/// This enables SIMD operations to use aligned loads/stores when processing
-/// chunk data, avoiding the penalty of misaligned memory accesses.
-///
-/// The buffer is backed by `std::alloc::Layout`-controlled allocation. It
-/// dereferences to `&[u8]` / `&mut [u8]` for seamless use.
-pub struct CacheAlignedBuffer {
-    ptr: *mut u8,
-    len: usize,
-    capacity: usize,
-}
-
-// SAFETY: The raw pointer is exclusively owned — no aliasing.
-unsafe impl Send for CacheAlignedBuffer {}
-unsafe impl Sync for CacheAlignedBuffer {}
-
-impl CacheAlignedBuffer {
-    /// Allocate a new cache-line-aligned buffer of exactly `len` bytes,
-    /// initialized to zero.
-    pub fn zeroed(len: usize) -> Self {
-        if len == 0 {
-            return Self {
-                ptr: core::ptr::NonNull::dangling().as_ptr(),
-                len: 0,
-                capacity: 0,
-            };
-        }
-        let capacity = align_to_cache_line(len);
-        let layout = core::alloc::Layout::from_size_align(capacity, CACHE_LINE_SIZE)
-            .expect("invalid layout");
-        // SAFETY: layout has non-zero size.
-        let ptr = unsafe { alloc_zeroed(layout) };
-        if ptr.is_null() {
-            handle_alloc_error(layout);
-        }
-        Self { ptr, len, capacity }
-    }
-
-    /// Create a cache-line-aligned copy of an existing byte slice.
-    pub fn from_slice(data: &[u8]) -> Self {
-        let mut buf = Self::zeroed(data.len());
-        buf.as_mut_slice()[..data.len()].copy_from_slice(data);
-        buf
-    }
-
-    /// Create from an existing `Vec<u8>`, copying into an aligned allocation.
-    pub fn from_vec(v: Vec<u8>) -> Self {
-        Self::from_slice(&v)
-    }
-
-    /// The length of the valid data (may be less than capacity).
-    #[inline]
-    pub fn len(&self) -> usize {
-        self.len
-    }
-
-    /// Whether the buffer is empty.
-    #[inline]
-    #[allow(dead_code)] // exercised by unit tests; companion to `len`
-    pub fn is_empty(&self) -> bool {
-        self.len == 0
-    }
-
-    /// Borrow as a byte slice.
-    #[inline]
-    pub fn as_slice(&self) -> &[u8] {
-        if self.len == 0 {
-            return &[];
-        }
-        // SAFETY: ptr is valid for `len` bytes and properly aligned.
-        unsafe { core::slice::from_raw_parts(self.ptr, self.len) }
-    }
-
-    /// Borrow as a mutable byte slice.
-    #[inline]
-    pub fn as_mut_slice(&mut self) -> &mut [u8] {
-        if self.len == 0 {
-            return &mut [];
-        }
-        // SAFETY: ptr is valid for `len` bytes and properly aligned.
-        unsafe { core::slice::from_raw_parts_mut(self.ptr, self.len) }
-    }
-
-    /// Convert to a `Vec<u8>` (copies data into a standard allocation).
-    pub fn to_vec(&self) -> Vec<u8> {
-        self.as_slice().to_vec()
-    }
-
-    /// Returns `true` if the data pointer is aligned to `CACHE_LINE_SIZE`.
-    #[inline]
-    pub fn is_aligned(&self) -> bool {
-        self.len == 0 || (self.ptr as usize).is_multiple_of(CACHE_LINE_SIZE)
-    }
-}
-
-impl Drop for CacheAlignedBuffer {
-    fn drop(&mut self) {
-        if self.capacity > 0 {
-            let layout = core::alloc::Layout::from_size_align(self.capacity, CACHE_LINE_SIZE)
-                .expect("invalid layout");
-            // SAFETY: ptr was allocated with this layout.
-            unsafe { dealloc(self.ptr, layout) };
-        }
-    }
-}
-
-impl Clone for CacheAlignedBuffer {
-    fn clone(&self) -> Self {
-        Self::from_slice(self.as_slice())
-    }
-}
-
-impl Deref for CacheAlignedBuffer {
-    type Target = [u8];
-    #[inline]
-    fn deref(&self) -> &[u8] {
-        self.as_slice()
-    }
-}
-
-impl DerefMut for CacheAlignedBuffer {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut [u8] {
-        self.as_mut_slice()
-    }
-}
-
-impl core::fmt::Debug for CacheAlignedBuffer {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CacheAlignedBuffer")
-            .field("len", &self.len)
-            .field("capacity", &self.capacity)
-            .field("aligned", &self.is_aligned())
-            .finish()
-    }
 }
 
 /// Coordinate key for a chunk — the N-dimensional offset vector.
@@ -333,7 +185,7 @@ impl ChunkCacheStats {
 
 struct CachedChunk {
     coord: ChunkCoord,
-    data: CacheAlignedBuffer,
+    data: Vec<u8>,
     /// Monotonically increasing access counter for LRU ordering.
     last_access: u64,
 }
@@ -463,60 +315,38 @@ impl ChunkCache {
 
     // ----- Decompressed data cache (LRU) -----
 
-    /// Try to get cached decompressed data for a chunk coordinate.
+    /// Run `f` over a borrowed view of a cached chunk's decompressed bytes, if
+    /// present, returning its result.
     ///
-    /// Returns a clone of the cache-line-aligned buffer.
-    pub fn get_decompressed(&self, coord: &[u64]) -> Option<Vec<u8>> {
-        let mut inner = self.inner.lock().unwrap();
-        inner.tick += 1;
-        let tick = inner.tick;
-
-        for slot in inner.slots.iter_mut() {
-            if slot.coord.as_slice() == coord {
-                slot.last_access = tick;
-                return Some(slot.data.to_vec());
-            }
-        }
-        None
-    }
-
-    /// Try to get a reference-counted clone of the aligned buffer for a chunk.
-    ///
-    /// Currently only exercised by unit tests; gated so it is not shipped as
-    /// dead code.
-    #[cfg(test)]
-    pub fn get_decompressed_aligned(&self, coord: &[u64]) -> Option<CacheAlignedBuffer> {
+    /// The closure runs while the cache lock is held, which lets the caller copy
+    /// the chunk straight into its output buffer with no intermediate `Vec`
+    /// allocation or clone. The closure must not touch this cache (it would
+    /// deadlock); the chunk-assembly scatter it is used for does not.
+    pub fn with_decompressed<R>(&self, coord: &[u64], f: impl FnOnce(&[u8]) -> R) -> Option<R> {
         let mut inner = self.inner.lock().unwrap();
         inner.tick += 1;
         let tick = inner.tick;
         for slot in inner.slots.iter_mut() {
             if slot.coord.as_slice() == coord {
                 slot.last_access = tick;
-                return Some(slot.data.clone());
+                return Some(f(&slot.data));
             }
         }
         None
     }
 
-    /// Insert decompressed chunk data into the LRU cache.
-    ///
-    /// The data is stored in a [`CacheAlignedBuffer`] so subsequent reads
-    /// return cache-line-aligned memory.
-    pub fn put_decompressed(&self, coord: ChunkCoord, data: Vec<u8>) {
-        if !self.accepts_decompressed_len(data.len()) {
-            return;
-        }
-        let aligned = CacheAlignedBuffer::from_slice(&data);
-        self.put_decompressed_aligned(coord, aligned);
-    }
-
+    /// Whether a decompressed chunk of `data_len` bytes would be admitted to the
+    /// cache (cache enabled and the chunk within the per-chunk byte budget). Used
+    /// to skip copying a chunk into an owned buffer when it would be rejected.
     fn accepts_decompressed_len(&self, data_len: usize) -> bool {
         let inner = self.inner.lock().unwrap();
         inner.max_bytes != 0 && inner.max_slots != 0 && data_len <= inner.max_bytes
     }
 
-    /// Insert an already-aligned buffer into the LRU cache.
-    pub fn put_decompressed_aligned(&self, coord: ChunkCoord, data: CacheAlignedBuffer) {
+    /// Insert decompressed chunk data into the LRU cache, taking ownership of the
+    /// buffer (no copy). A chunk too large for the budget, or a disabled cache,
+    /// drops the buffer instead of storing it.
+    pub fn put_decompressed(&self, coord: ChunkCoord, data: Vec<u8>) {
         let mut inner = self.inner.lock().unwrap();
         let data_len = data.len();
 
@@ -557,6 +387,17 @@ impl ChunkCache {
             data,
             last_access: tick,
         });
+    }
+
+    /// Insert a copy of `data` into the LRU cache, but only if it would actually
+    /// be admitted. This lets the unfiltered read path scatter directly from the
+    /// file buffer and copy into the cache only when caching is enabled and the
+    /// chunk fits the budget (avoiding a throwaway copy otherwise).
+    pub fn put_decompressed_slice(&self, coord: ChunkCoord, data: &[u8]) {
+        if !self.accepts_decompressed_len(data.len()) {
+            return;
+        }
+        self.put_decompressed(coord, data.to_vec());
     }
 
     /// Clear the entire cache (index + decompressed data).
@@ -616,11 +457,17 @@ mod tests {
         assert_eq!(addrs, vec![0x1000, 0x2000]);
     }
 
+    /// Test helper: clone a cached chunk's bytes if present (the production
+    /// path uses `with_decompressed` to avoid this copy).
+    fn get_decompressed(cache: &ChunkCache, coord: &[u64]) -> Option<Vec<u8>> {
+        cache.with_decompressed(coord, <[u8]>::to_vec)
+    }
+
     #[test]
     fn decompressed_cache_hit() {
         let cache = ChunkCache::new();
         cache.put_decompressed(vec![0, 0], vec![1, 2, 3, 4]);
-        let got = cache.get_decompressed(&[0, 0]).unwrap();
+        let got = get_decompressed(&cache, &[0, 0]).unwrap();
         assert_eq!(got, vec![1, 2, 3, 4]);
     }
 
@@ -633,15 +480,15 @@ mod tests {
         assert_eq!(cache.stats().cached_chunks(), 2);
 
         // Access slot 0 to make it more recent
-        cache.get_decompressed(&[0]);
+        get_decompressed(&cache, &[0]);
 
         // Insert slot 2 — should evict slot 1 (LRU)
         cache.put_decompressed(vec![2], vec![3; 10]);
         assert_eq!(cache.stats().cached_chunks(), 2);
 
-        assert!(cache.get_decompressed(&[0]).is_some());
-        assert!(cache.get_decompressed(&[1]).is_none()); // evicted
-        assert!(cache.get_decompressed(&[2]).is_some());
+        assert!(get_decompressed(&cache, &[0]).is_some());
+        assert!(get_decompressed(&cache, &[1]).is_none()); // evicted
+        assert!(get_decompressed(&cache, &[2]).is_some());
     }
 
     #[test]
@@ -655,7 +502,25 @@ mod tests {
         // This needs 20 bytes but only 10 free — evict LRU
         cache.put_decompressed(vec![2], vec![0; 20]);
         assert!(cache.stats().cached_bytes() <= 50);
-        assert!(cache.get_decompressed(&[0]).is_none()); // evicted (LRU)
+        assert!(get_decompressed(&cache, &[0]).is_none()); // evicted (LRU)
+    }
+
+    #[test]
+    fn put_decompressed_slice_only_copies_when_admitted() {
+        // Disabled cache: the slice is not copied or stored.
+        let cache = ChunkCache::with_config(ChunkCacheConfig::disabled());
+        cache.put_decompressed_slice(vec![0], &[1, 2, 3]);
+        assert_eq!(cache.stats().cached_chunks(), 0);
+
+        // Enabled cache within budget: stored.
+        let cache = ChunkCache::with_capacity(1024, 16);
+        cache.put_decompressed_slice(vec![0], &[1, 2, 3, 4]);
+        assert_eq!(get_decompressed(&cache, &[0]).unwrap(), vec![1, 2, 3, 4]);
+
+        // Over the per-chunk budget: not stored.
+        let cache = ChunkCache::with_capacity(2, 16);
+        cache.put_decompressed_slice(vec![0], &[1, 2, 3, 4]);
+        assert_eq!(cache.stats().cached_chunks(), 0);
     }
 
     #[test]
@@ -705,76 +570,6 @@ mod tests {
         cache.put_decompressed(vec![0], vec![1, 2, 3]); // duplicate
         assert_eq!(cache.stats().cached_chunks(), 1);
         assert_eq!(cache.stats().cached_bytes(), 3);
-    }
-
-    // --- CacheAlignedBuffer tests ---
-
-    #[test]
-    fn aligned_buffer_basic() {
-        let buf = CacheAlignedBuffer::zeroed(256);
-        assert_eq!(buf.len(), 256);
-        assert!(buf.is_aligned());
-        assert_eq!(&buf[..4], &[0, 0, 0, 0]);
-    }
-
-    #[test]
-    fn aligned_buffer_from_slice() {
-        let data = vec![1u8, 2, 3, 4, 5];
-        let buf = CacheAlignedBuffer::from_slice(&data);
-        assert_eq!(buf.len(), 5);
-        assert!(buf.is_aligned());
-        assert_eq!(buf.to_vec(), data);
-    }
-
-    #[test]
-    fn aligned_buffer_from_vec() {
-        let data = vec![42u8; 1024];
-        let buf = CacheAlignedBuffer::from_vec(data.clone());
-        assert!(buf.is_aligned());
-        assert_eq!(buf.to_vec(), data);
-    }
-
-    #[test]
-    fn aligned_buffer_empty() {
-        let buf = CacheAlignedBuffer::zeroed(0);
-        assert!(buf.is_empty());
-        assert!(buf.is_aligned());
-        assert_eq!(buf.to_vec(), Vec::<u8>::new());
-    }
-
-    #[test]
-    fn aligned_buffer_clone_is_aligned() {
-        let buf = CacheAlignedBuffer::from_slice(&[1, 2, 3, 4]);
-        let cloned = buf.clone();
-        assert!(cloned.is_aligned());
-        assert_eq!(buf.to_vec(), cloned.to_vec());
-    }
-
-    #[test]
-    fn aligned_buffer_deref_works() {
-        let buf = CacheAlignedBuffer::from_slice(&[10, 20, 30]);
-        assert_eq!(buf[0], 10);
-        assert_eq!(buf[1], 20);
-        assert_eq!(buf[2], 30);
-    }
-
-    #[test]
-    fn aligned_buffer_various_sizes() {
-        // Test alignment for various sizes including non-power-of-two
-        for size in [1, 7, 63, 64, 65, 127, 128, 129, 255, 256, 1000, 4096] {
-            let buf = CacheAlignedBuffer::zeroed(size);
-            assert!(buf.is_aligned(), "not aligned for size {size}");
-            assert_eq!(buf.len(), size);
-        }
-    }
-
-    #[test]
-    fn cached_data_is_aligned() {
-        let cache = ChunkCache::new();
-        cache.put_decompressed(vec![0, 0], vec![1, 2, 3, 4, 5, 6, 7, 8]);
-        let aligned = cache.get_decompressed_aligned(&[0, 0]).unwrap();
-        assert!(aligned.is_aligned());
-        assert_eq!(aligned.to_vec(), vec![1, 2, 3, 4, 5, 6, 7, 8]);
     }
 
     #[test]

--- a/src/chunked_read.rs
+++ b/src/chunked_read.rs
@@ -7,7 +7,7 @@ extern crate alloc;
 use alloc::{format, vec, vec::Vec};
 
 use crate::btree_v1::btree_v1_node_header_size;
-use crate::chunk_cache::{CacheAlignedBuffer, ChunkCache};
+use crate::chunk_cache::ChunkCache;
 use crate::convert::{TryToUsize, slice_range, u32_from};
 use crate::data_layout::DataLayout;
 use crate::dataspace::Dataspace;
@@ -26,15 +26,14 @@ use crate::source::FileSource;
 #[cfg(feature = "parallel")]
 use crate::parallel_read;
 
-/// Decompress all chunks into cache-line-aligned buffers, using lane-partitioned
-/// parallel decompression when the `parallel` feature is enabled and the chunk
-/// count exceeds the threshold.
+/// Decompress all chunks, using lane-partitioned parallel decompression when the
+/// `parallel` feature is enabled and the chunk count exceeds the threshold.
 fn decompress_all_chunks(
     file_data: &[u8],
     chunks: &[ChunkInfo],
     pipeline: Option<&FilterPipeline>,
     ctx: ChunkContext<'_>,
-) -> Result<Vec<CacheAlignedBuffer>, FormatError> {
+) -> Result<Vec<Vec<u8>>, FormatError> {
     #[cfg(feature = "parallel")]
     {
         if let Some(pl) = pipeline {
@@ -44,12 +43,11 @@ fn decompress_all_chunks(
                 let (data, _stats) = parallel_read::decompress_chunks_lane_partitioned(
                     file_data, chunks, pl, ctx, seed, None, // auto-detect lane count
                 )?;
-                return Ok(data.into_iter().map(CacheAlignedBuffer::from_vec).collect());
+                return Ok(data);
             }
         }
     }
 
-    // Sequential fallback — allocate into aligned buffers
     let mut result = Vec::with_capacity(chunks.len());
     for chunk_info in chunks {
         let r = slice_range(chunk_info.address, u64::from(chunk_info.chunk_size))?;
@@ -66,7 +64,7 @@ fn decompress_all_chunks(
         } else {
             raw_chunk.to_vec()
         };
-        result.push(CacheAlignedBuffer::from_vec(decompressed));
+        result.push(decompressed);
     }
     Ok(result)
 }
@@ -82,7 +80,7 @@ fn decompress_all_chunks_from_source<S: FileSource + ?Sized>(
     chunks: &[ChunkInfo],
     pipeline: Option<&FilterPipeline>,
     ctx: ChunkContext<'_>,
-) -> Result<Vec<CacheAlignedBuffer>, FormatError> {
+) -> Result<Vec<Vec<u8>>, FormatError> {
     let mut result = Vec::with_capacity(chunks.len());
     for chunk_info in chunks {
         let raw_chunk =
@@ -92,7 +90,7 @@ fn decompress_all_chunks_from_source<S: FileSource + ?Sized>(
         } else {
             raw_chunk
         };
-        result.push(CacheAlignedBuffer::from_vec(decompressed));
+        result.push(decompressed);
     }
     Ok(result)
 }
@@ -924,20 +922,6 @@ pub fn read_chunked_data_cached_from_source<S: FileSource + ?Sized>(
 
     for chunk_info in &chunks {
         let coord: Vec<u64> = chunk_info.offsets.iter().take(rank).copied().collect();
-        let decompressed = if let Some(cached) = cache.get_decompressed(&coord) {
-            cached
-        } else {
-            let raw_chunk =
-                source.read_exact_at(chunk_info.address, chunk_info.chunk_size.to_usize()?)?;
-            let dec = if let Some(pl) = pipeline {
-                decompress_chunk(&raw_chunk, pl, ctx, chunk_info.filter_mask)?
-            } else {
-                raw_chunk
-            };
-            cache.put_decompressed(coord.clone(), dec.clone());
-            dec
-        };
-
         let chunk_offsets: Vec<usize> = chunk_info
             .offsets
             .iter()
@@ -945,12 +929,10 @@ pub fn read_chunked_data_cached_from_source<S: FileSource + ?Sized>(
             .map(|&o| o.to_usize())
             .collect::<Result<_, _>>()?;
 
-        if rank == 0 {
-            let copy_len = decompressed.len().min(output.len());
-            output[..copy_len].copy_from_slice(&decompressed[..copy_len]);
-        } else {
-            copy_chunk_to_output(
-                &decompressed,
+        // Scatter straight from the cached chunk under the lock (no copy out).
+        let hit = cache.with_decompressed(&coord, |bytes| {
+            place_chunk(
+                bytes,
                 &mut output,
                 &chunk_offsets,
                 &chunk_dims,
@@ -960,7 +942,31 @@ pub fn read_chunked_data_cached_from_source<S: FileSource + ?Sized>(
                 elem_size,
                 rank,
             );
+        });
+        if hit.is_some() {
+            continue;
         }
+
+        // Cache miss: fetch the chunk's bytes from the source (already owned).
+        let raw_chunk =
+            source.read_exact_at(chunk_info.address, chunk_info.chunk_size.to_usize()?)?;
+        let dec = if let Some(pl) = pipeline {
+            decompress_chunk(&raw_chunk, pl, ctx, chunk_info.filter_mask)?
+        } else {
+            raw_chunk
+        };
+        place_chunk(
+            &dec,
+            &mut output,
+            &chunk_offsets,
+            &chunk_dims,
+            &ds_dims,
+            &ds_strides,
+            &chunk_strides,
+            elem_size,
+            rank,
+        );
+        cache.put_decompressed(coord, dec); // move; dropped if not admitted
     }
 
     Ok(output)
@@ -1183,7 +1189,7 @@ fn collect_chunk_index_spans(
 /// access): shared by the buffered and streaming chunked readers.
 fn assemble_chunks(
     chunks: &[ChunkInfo],
-    decompressed: &[CacheAlignedBuffer],
+    decompressed: &[Vec<u8>],
     rank: usize,
     chunk_dims: &[usize],
     ds_dims: &[usize],
@@ -1214,22 +1220,17 @@ fn assemble_chunks(
             .map(|&o| o as usize)
             .collect();
 
-        if rank == 0 {
-            let copy_len = decompressed.len().min(output.len());
-            output[..copy_len].copy_from_slice(&decompressed[..copy_len]);
-        } else {
-            copy_chunk_to_output(
-                decompressed,
-                &mut output,
-                &chunk_offsets,
-                chunk_dims,
-                ds_dims,
-                &ds_strides,
-                &chunk_strides,
-                elem_size,
-                rank,
-            );
-        }
+        place_chunk(
+            decompressed,
+            &mut output,
+            &chunk_offsets,
+            chunk_dims,
+            ds_dims,
+            &ds_strides,
+            &chunk_strides,
+            elem_size,
+            rank,
+        );
     }
 
     output
@@ -1401,28 +1402,6 @@ pub fn read_chunked_data_cached(
     for chunk_info in &chunks {
         let coord: Vec<u64> = chunk_info.offsets.iter().take(rank).copied().collect();
 
-        // Try decompressed cache first
-        let decompressed = if let Some(cached) = cache.get_decompressed(&coord) {
-            cached
-        } else {
-            // Decompress from file
-            let r = slice_range(chunk_info.address, u64::from(chunk_info.chunk_size))?;
-            if r.end > file_data.len() {
-                return Err(FormatError::UnexpectedEof {
-                    expected: r.end,
-                    available: file_data.len(),
-                });
-            }
-            let raw_chunk = &file_data[r];
-            let dec = if let Some(pl) = pipeline {
-                decompress_chunk(raw_chunk, pl, ctx, chunk_info.filter_mask)?
-            } else {
-                raw_chunk.to_vec()
-            };
-            cache.put_decompressed(coord, dec.clone());
-            dec
-        };
-
         #[expect(
             clippy::cast_possible_truncation,
             reason = "chunk coordinate offsets are bounded by ds_dims, which already fit usize"
@@ -1434,12 +1413,10 @@ pub fn read_chunked_data_cached(
             .map(|&o| o as usize)
             .collect();
 
-        if rank == 0 {
-            let copy_len = decompressed.len().min(output.len());
-            output[..copy_len].copy_from_slice(&decompressed[..copy_len]);
-        } else {
-            copy_chunk_to_output(
-                &decompressed,
+        // Scatter straight from the cached chunk under the lock (no copy out).
+        let hit = cache.with_decompressed(&coord, |bytes| {
+            place_chunk(
+                bytes,
                 &mut output,
                 &chunk_offsets,
                 &chunk_dims,
@@ -1449,13 +1426,103 @@ pub fn read_chunked_data_cached(
                 elem_size,
                 rank,
             );
+        });
+        if hit.is_some() {
+            continue;
+        }
+
+        // Cache miss: read the chunk's bytes from the file.
+        let r = slice_range(chunk_info.address, u64::from(chunk_info.chunk_size))?;
+        if r.end > file_data.len() {
+            return Err(FormatError::UnexpectedEof {
+                expected: r.end,
+                available: file_data.len(),
+            });
+        }
+        let raw_chunk = &file_data[r];
+        if let Some(pl) = pipeline {
+            let dec = decompress_chunk(raw_chunk, pl, ctx, chunk_info.filter_mask)?;
+            place_chunk(
+                &dec,
+                &mut output,
+                &chunk_offsets,
+                &chunk_dims,
+                &ds_dims,
+                &ds_strides,
+                &chunk_strides,
+                elem_size,
+                rank,
+            );
+            cache.put_decompressed(coord, dec); // move; dropped if not admitted
+        } else {
+            // No pipeline: scatter directly from the file buffer, and copy into
+            // the cache only if it would actually be retained.
+            place_chunk(
+                raw_chunk,
+                &mut output,
+                &chunk_offsets,
+                &chunk_dims,
+                &ds_dims,
+                &ds_strides,
+                &chunk_strides,
+                elem_size,
+                rank,
+            );
+            cache.put_decompressed_slice(coord, raw_chunk);
         }
     }
 
     Ok(output)
 }
 
+/// Place one decompressed chunk into the dense output buffer, handling the
+/// scalar (`rank == 0`) case and delegating the N-D case to the row-copy kernel.
+/// Shared by the buffered, cached, and streaming chunked readers so they all use
+/// the same scatter logic.
+#[allow(clippy::too_many_arguments)]
+fn place_chunk(
+    chunk_data: &[u8],
+    output: &mut [u8],
+    chunk_offsets: &[usize],
+    chunk_dims: &[usize],
+    ds_dims: &[usize],
+    ds_strides: &[usize],
+    chunk_strides: &[usize],
+    elem_size: usize,
+    rank: usize,
+) {
+    if rank == 0 {
+        let copy_len = chunk_data.len().min(output.len());
+        output[..copy_len].copy_from_slice(&chunk_data[..copy_len]);
+    } else {
+        copy_chunk_to_output(
+            chunk_data,
+            output,
+            chunk_offsets,
+            chunk_dims,
+            ds_dims,
+            ds_strides,
+            chunk_strides,
+            elem_size,
+            rank,
+        );
+    }
+}
+
 /// Copy chunk data into the output buffer at the correct N-D position.
+///
+/// The innermost dimension is contiguous in both the chunk and the dataset (both
+/// have stride 1 there in a row-major layout), so each in-bounds row of the
+/// chunk is moved with a single `copy_from_slice` instead of one tiny copy per
+/// element. Only the outer `rank - 1` dimensions are walked (with an odometer),
+/// which removes the per-element flat→N-D coordinate division/modulo that
+/// dominated the old kernel. Edge chunks that overhang the dataset are clamped in
+/// the innermost dimension (a shortened row) and skipped per-row in the outer
+/// dimensions (a row whose outer global coordinate is past the dataset bound),
+/// reproducing the old per-element out-of-bounds skip exactly. The per-row length
+/// is also clamped to the bytes actually available on both sides, so a malformed
+/// (short) chunk copies only its valid prefix and is never an out-of-bounds
+/// access — matching the old per-element guard's silent-skip behavior.
 #[allow(clippy::too_many_arguments)]
 fn copy_chunk_to_output(
     chunk_data: &[u8],
@@ -1468,36 +1535,63 @@ fn copy_chunk_to_output(
     elem_size: usize,
     rank: usize,
 ) {
-    // Iterate over all elements in the chunk using a flat index
-    let chunk_total: usize = chunk_dims.iter().product();
-    for flat_idx in 0..chunk_total {
-        // Convert flat index to N-D chunk-local coordinates
-        let mut remaining = flat_idx;
-        let mut ds_flat = 0usize;
-        let mut out_of_bounds = false;
+    debug_assert!(rank >= 1, "rank == 0 is handled by the callers");
+    // Row contiguity (the whole optimization) relies on a unit innermost stride
+    // in both layouts, which the row-major stride construction guarantees.
+    debug_assert_eq!(chunk_strides[rank - 1], 1);
+    debug_assert_eq!(ds_strides[rank - 1], 1);
 
-        for d in 0..rank {
-            let coord_in_chunk = remaining / chunk_strides[d];
-            remaining %= chunk_strides[d];
+    let inner = rank - 1;
 
-            let global_coord = chunk_offsets[d] + coord_in_chunk;
-            if global_coord >= ds_dims[d] {
-                out_of_bounds = true;
+    // In-bounds run length along the contiguous innermost dimension: the chunk
+    // is stored at full size but may hang over the dataset's edge.
+    let inner_row_len = chunk_dims[inner].min(ds_dims[inner].saturating_sub(chunk_offsets[inner]));
+    if inner_row_len == 0 {
+        return; // the chunk lies entirely past the inner edge
+    }
+    let row_bytes = inner_row_len * elem_size;
+    // Destination offset contributed by the innermost dimension (stride 1).
+    let inner_dst = chunk_offsets[inner] * ds_strides[inner];
+
+    // Walk the outer dimensions with an odometer (`coord` is the chunk-local
+    // coordinate of each outer dim), copying one contiguous row per step.
+    let outer_total: usize = chunk_dims[..inner].iter().product();
+    let mut coord = vec![0usize; inner];
+
+    for _ in 0..outer_total {
+        let mut chunk_base = 0usize;
+        let mut ds_base = inner_dst;
+        let mut in_bounds = true;
+        for d in 0..inner {
+            chunk_base += coord[d] * chunk_strides[d];
+            let global = chunk_offsets[d] + coord[d];
+            if global >= ds_dims[d] {
+                in_bounds = false;
                 break;
             }
-            ds_flat += global_coord * ds_strides[d];
+            ds_base += global * ds_strides[d];
         }
 
-        if out_of_bounds {
-            continue;
+        if in_bounds {
+            let src = chunk_base * elem_size;
+            let dst = ds_base * elem_size;
+            // Clamp to the bytes available on each side, on an element boundary.
+            let mut avail = row_bytes
+                .min(chunk_data.len().saturating_sub(src))
+                .min(output.len().saturating_sub(dst));
+            avail -= avail % elem_size;
+            if avail > 0 {
+                output[dst..dst + avail].copy_from_slice(&chunk_data[src..src + avail]);
+            }
         }
 
-        let src_start = flat_idx * elem_size;
-        let dst_start = ds_flat * elem_size;
-
-        if src_start + elem_size <= chunk_data.len() && dst_start + elem_size <= output.len() {
-            output[dst_start..dst_start + elem_size]
-                .copy_from_slice(&chunk_data[src_start..src_start + elem_size]);
+        // Advance the odometer over the outer dims (last outer dim varies fastest).
+        for d in (0..inner).rev() {
+            coord[d] += 1;
+            if coord[d] < chunk_dims[d] {
+                break;
+            }
+            coord[d] = 0;
         }
     }
 }

--- a/src/chunked_write.rs
+++ b/src/chunked_write.rs
@@ -7,7 +7,7 @@ extern crate alloc;
 use alloc::{vec, vec::Vec};
 
 use crate::checksum::jenkins_lookup3;
-use crate::chunk_cache::align_to_cache_line;
+use crate::chunk_cache::{CACHE_LINE_SIZE, align_to_cache_line};
 use crate::convert::TryToUsize;
 use crate::error::FormatError;
 use crate::extensible_array::{EaGeometry, ExtensibleArrayHeader};
@@ -309,9 +309,13 @@ pub fn split_into_chunks(
 
     #[expect(
         clippy::cast_possible_truncation,
-        reason = "chunk dimensions derived from the in-memory write request; bounded by addressable memory"
+        reason = "chunk/dataset dimensions derived from the in-memory write request; bounded by addressable memory"
     )]
-    let chunk_total_elements: usize = chunk_dims.iter().map(|&d| d as usize).product();
+    let (chunk_dims_us, shape_us): (Vec<usize>, Vec<usize>) = (
+        chunk_dims.iter().map(|&d| d as usize).collect(),
+        shape.iter().map(|&d| d as usize).collect(),
+    );
+    let chunk_total_elements: usize = chunk_dims_us.iter().product();
 
     #[expect(
         clippy::cast_possible_truncation,
@@ -319,60 +323,74 @@ pub fn split_into_chunks(
     )]
     let mut result = Vec::with_capacity(total_chunks as usize);
 
+    // Innermost dimension is contiguous in both the dataset (`raw_data`) and the
+    // chunk buffer, so each in-bounds row is gathered with a single
+    // `copy_from_slice`. Only the outer `rank - 1` dims are walked (odometer),
+    // matching the read-side `copy_chunk_to_output` kernel.
+    let inner = rank - 1;
+    let mut coord = vec![0usize; inner];
+
     for linear_idx in 0..total_chunks {
-        // Convert linear index to chunk grid coordinates
+        // Convert linear index to chunk grid coordinates and the chunk's
+        // dataset-space offset.
         let mut chunk_grid_coords = vec![0u64; rank];
         let mut remaining = linear_idx;
         for d in (0..rank).rev() {
             chunk_grid_coords[d] = remaining % num_chunks_per_dim[d];
             remaining /= num_chunks_per_dim[d];
         }
-
-        // Chunk offset in dataset space
         let offsets: Vec<u64> = (0..rank)
             .map(|d| chunk_grid_coords[d] * chunk_dims[d])
             .collect();
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "chunk offset derived from the in-memory write request; bounded by addressable memory"
+        )]
+        let offsets_us: Vec<usize> = offsets.iter().map(|&o| o as usize).collect();
 
-        // Extract chunk data
         let mut chunk_bytes = vec![0u8; chunk_total_elements * element_size];
 
-        for flat_idx in 0..chunk_total_elements {
-            let mut remaining_idx = flat_idx;
-            let mut ds_flat = 0usize;
-            let mut out_of_bounds = false;
-
-            for d in 0..rank {
-                let coord_in_chunk = remaining_idx / chunk_strides[d];
-                remaining_idx %= chunk_strides[d];
-
-                #[expect(
-                    clippy::cast_possible_truncation,
-                    reason = "chunk offset derived from the in-memory write request; bounded by addressable memory"
-                )]
-                let global_coord = offsets[d] as usize + coord_in_chunk;
-                #[expect(
-                    clippy::cast_possible_truncation,
-                    reason = "dataset dimension derived from the in-memory write request; bounded by addressable memory"
-                )]
-                let dim_extent = shape[d] as usize;
-                if global_coord >= dim_extent {
-                    out_of_bounds = true;
-                    break;
+        // In-bounds run length along the contiguous innermost dimension.
+        let inner_row_len =
+            chunk_dims_us[inner].min(shape_us[inner].saturating_sub(offsets_us[inner]));
+        if inner_row_len > 0 {
+            let row_bytes = inner_row_len * element_size;
+            let inner_src = offsets_us[inner] * ds_strides[inner];
+            let outer_total: usize = chunk_dims_us[..inner].iter().product();
+            for c in coord.iter_mut() {
+                *c = 0;
+            }
+            for _ in 0..outer_total {
+                let mut dst_base = 0usize;
+                let mut src_base = inner_src;
+                let mut in_bounds = true;
+                for d in 0..inner {
+                    dst_base += coord[d] * chunk_strides[d];
+                    let global = offsets_us[d] + coord[d];
+                    if global >= shape_us[d] {
+                        in_bounds = false;
+                        break;
+                    }
+                    src_base += global * ds_strides[d];
                 }
-                ds_flat += global_coord * ds_strides[d];
-            }
 
-            if out_of_bounds {
-                // Zero-filled (already initialized)
-                continue;
-            }
+                if in_bounds {
+                    let src = src_base * element_size;
+                    let dst = dst_base * element_size;
+                    let mut avail = row_bytes.min(raw_data.len().saturating_sub(src));
+                    avail -= avail % element_size;
+                    if avail > 0 {
+                        chunk_bytes[dst..dst + avail].copy_from_slice(&raw_data[src..src + avail]);
+                    }
+                }
 
-            let src_start = ds_flat * element_size;
-            let dst_start = flat_idx * element_size;
-
-            if src_start + element_size <= raw_data.len() {
-                chunk_bytes[dst_start..dst_start + element_size]
-                    .copy_from_slice(&raw_data[src_start..src_start + element_size]);
+                for d in (0..inner).rev() {
+                    coord[d] += 1;
+                    if coord[d] < chunk_dims_us[d] {
+                        break;
+                    }
+                    coord[d] = 0;
+                }
             }
         }
 
@@ -1404,19 +1422,39 @@ fn write_undefined_element(
     }
 }
 
-/// Build chunked data with absolute addresses and optional maxshape.
-///
-/// `ctx` carries chunk_dims, element_size, and (for type-aware filters like
-/// ZFP) the scalar element type. Build it via [`ChunkContext::from_datatype`]
-/// when a `Datatype` is in scope.
-pub fn build_chunked_data_at_ext(
+/// A chunked dataset's chunks already split and compressed — the expensive,
+/// **address-independent** half of building a chunked layout. The compressed
+/// bytes, the chunk-index choice, and the pipeline message do not depend on
+/// where the data lands in the file; only the absolute addresses embedded in the
+/// chunk index do. The writer sizes a dataset's object header in one pass and
+/// emits its data in a later pass (it needs every prior object's size to know
+/// this object's address), so it computes this set once and feeds it to
+/// [`assemble_chunked_at`] twice — sizing at a dummy address, then emitting at
+/// the real one — instead of recompressing the whole dataset each pass.
+pub(crate) struct CompressedChunkSet {
+    /// Per-chunk compressed bytes, in dense row-major grid order.
+    compressed: Vec<Vec<u8>>,
+    /// Per-chunk uncompressed size (a full chunk is stored at full size, edge
+    /// overhang zero-filled, so these are all equal in practice).
+    raw_sizes: Vec<u64>,
+    chunk_dims_u32: Vec<u32>,
+    element_size: usize,
+    has_filters: bool,
+    use_extensible: bool,
+    pipeline_message: Option<Vec<u8>>,
+}
+
+/// Split `raw_data` into chunks and compress each one, producing the
+/// address-independent [`CompressedChunkSet`]. This performs the dataset's only
+/// pass of the filter pipeline (shuffle/deflate/ZFP/…); [`assemble_chunked_at`]
+/// then lays the result out at a concrete address without recompressing.
+pub(crate) fn compress_chunks(
     raw_data: &[u8],
     shape: &[u64],
     ctx: ChunkContext<'_>,
     options: &ChunkOptions,
-    base_address: u64,
     maxshape: Option<&[u64]>,
-) -> Result<ChunkedDataResult, FormatError> {
+) -> Result<CompressedChunkSet, FormatError> {
     let chunk_dims = ctx.chunk_dims;
     let element_size = ctx.element_size as usize;
     let pipeline = options.build_pipeline(
@@ -1430,35 +1468,18 @@ pub fn build_chunked_data_at_ext(
     let num_chunks = chunks.len();
     let has_filters = pipeline.is_some();
 
-    // Compress each chunk, padding to cache-line boundaries for aligned access
-    let mut data_buf = Vec::new();
-    let mut written_chunks = Vec::with_capacity(num_chunks);
-
-    for (_offsets, chunk_bytes) in &chunks {
-        let compressed = if let Some(ref pl) = pipeline {
-            compress_chunk(chunk_bytes, pl, ctx)?
+    let mut compressed = Vec::with_capacity(num_chunks);
+    let mut raw_sizes = Vec::with_capacity(num_chunks);
+    for (_offsets, chunk_bytes) in chunks {
+        raw_sizes.push(chunk_bytes.len() as u64);
+        let c = if let Some(ref pl) = pipeline {
+            compress_chunk(&chunk_bytes, pl, ctx)?
         } else {
-            chunk_bytes.clone()
+            // No pipeline: the split already produced an owned chunk buffer;
+            // move it into the set instead of cloning.
+            chunk_bytes
         };
-
-        // Pad current position to cache-line boundary
-        let aligned_offset = align_to_cache_line(data_buf.len());
-        if aligned_offset > data_buf.len() {
-            data_buf.resize(aligned_offset, 0u8);
-        }
-
-        let address = base_address + data_buf.len() as u64;
-        let compressed_size = compressed.len() as u64;
-        let raw_size = chunk_bytes.len() as u64;
-
-        data_buf.extend_from_slice(&compressed);
-
-        written_chunks.push(WrittenChunk {
-            address,
-            compressed_size,
-            raw_size,
-            filter_mask: 0,
-        });
+        compressed.push(c);
     }
 
     #[expect(
@@ -1466,13 +1487,67 @@ pub fn build_chunked_data_at_ext(
         reason = "chunk dimensions written into the on-disk u32 dimension fields selected for this file"
     )]
     let chunk_dims_u32: Vec<u32> = chunk_dims.iter().map(|&d| d as u32).collect();
+
+    Ok(CompressedChunkSet {
+        compressed,
+        raw_sizes,
+        chunk_dims_u32,
+        element_size,
+        has_filters,
+        use_extensible: maxshape.is_some_and(|ms| ms.contains(&u64::MAX)),
+        pipeline_message: pipeline.as_ref().map(|pl| pl.serialize()),
+    })
+}
+
+/// Lay an already-[`compress`ed](compress_chunks) chunk set out at `base_address`,
+/// producing the on-disk data region (chunk bytes + cache-line padding + chunk
+/// index) and the v4 data-layout message. Cheap: this only concatenates and
+/// builds the index, so it can be run more than once (different addresses)
+/// without repeating the dataset's compression.
+pub(crate) fn assemble_chunked_at(
+    set: &CompressedChunkSet,
+    base_address: u64,
+) -> Result<ChunkedDataResult, FormatError> {
+    let CompressedChunkSet {
+        compressed,
+        raw_sizes,
+        chunk_dims_u32,
+        element_size,
+        has_filters,
+        use_extensible,
+        pipeline_message,
+    } = set;
+    let element_size = *element_size;
+    let has_filters = *has_filters;
+    let num_chunks = compressed.len();
+
+    // Pre-size the data buffer: chunk bytes plus a cache-line slack per chunk.
+    let chunk_bytes_total: usize = compressed.iter().map(Vec::len).sum();
+    let mut data_buf = Vec::with_capacity(chunk_bytes_total + (num_chunks + 1) * CACHE_LINE_SIZE);
+    let mut written_chunks = Vec::with_capacity(num_chunks);
+
+    for (chunk, &raw_size) in compressed.iter().zip(raw_sizes.iter()) {
+        // Pad current position to cache-line boundary.
+        let aligned_offset = align_to_cache_line(data_buf.len());
+        if aligned_offset > data_buf.len() {
+            data_buf.resize(aligned_offset, 0u8);
+        }
+
+        let address = base_address + data_buf.len() as u64;
+        data_buf.extend_from_slice(chunk);
+
+        written_chunks.push(WrittenChunk {
+            address,
+            compressed_size: chunk.len() as u64,
+            raw_size,
+            filter_mask: 0,
+        });
+    }
+
     let offset_size: u8 = 8;
     let length_size: u8 = 8;
 
-    // Determine if we should use Extensible Array (resizable datasets)
-    let use_extensible = maxshape.is_some_and(|ms| ms.contains(&u64::MAX));
-
-    // Pad before index structures so they are also cache-line aligned
+    // Pad before index structures so they are also cache-line aligned.
     let aligned_idx = align_to_cache_line(data_buf.len());
     if aligned_idx > data_buf.len() {
         data_buf.resize(aligned_idx, 0u8);
@@ -1482,7 +1557,7 @@ pub fn build_chunked_data_at_ext(
         clippy::cast_possible_truncation,
         reason = "element size written into the on-disk u32 dimension field selected for this file"
     )]
-    let layout_message = if use_extensible {
+    let layout_message = if *use_extensible {
         let ea_address = base_address + data_buf.len() as u64;
 
         let ea_bytes = build_extensible_array_at(
@@ -1494,12 +1569,7 @@ pub fn build_chunked_data_at_ext(
         )?;
         data_buf.extend_from_slice(&ea_bytes);
 
-        serialize_v4_extensible_array(
-            &chunk_dims_u32,
-            ea_address,
-            offset_size,
-            element_size as u32,
-        )
+        serialize_v4_extensible_array(chunk_dims_u32, ea_address, offset_size, element_size as u32)
     } else if num_chunks == 1 {
         let chunk_addr = written_chunks[0].address;
         let filtered_size = if has_filters {
@@ -1509,7 +1579,7 @@ pub fn build_chunked_data_at_ext(
         };
         let filter_mask = if has_filters { Some(0u32) } else { None };
         serialize_v4_single_chunk(
-            &chunk_dims_u32,
+            chunk_dims_u32,
             chunk_addr,
             filtered_size,
             filter_mask,
@@ -1529,7 +1599,7 @@ pub fn build_chunked_data_at_ext(
         data_buf.extend_from_slice(&fa_bytes);
 
         serialize_v4_fixed_array(
-            &chunk_dims_u32,
+            chunk_dims_u32,
             fa_address,
             offset_size,
             element_size as u32,
@@ -1537,13 +1607,34 @@ pub fn build_chunked_data_at_ext(
         )
     };
 
-    let pipeline_message = pipeline.as_ref().map(|pl| pl.serialize());
-
     Ok(ChunkedDataResult {
         data_bytes: data_buf,
         layout_message,
-        pipeline_message,
+        pipeline_message: pipeline_message.clone(),
     })
+}
+
+/// Build chunked data with absolute addresses and optional maxshape.
+///
+/// Convenience composition of [`compress_chunks`] + [`assemble_chunked_at`] for
+/// callers (the in-place editor, tests) that build a single chunked dataset at a
+/// known address in one shot. The file writer instead keeps the
+/// [`CompressedChunkSet`] between its sizing and emit passes so it compresses
+/// each dataset only once.
+///
+/// `ctx` carries chunk_dims, element_size, and (for type-aware filters like
+/// ZFP) the scalar element type. Build it via [`ChunkContext::from_datatype`]
+/// when a `Datatype` is in scope.
+pub fn build_chunked_data_at_ext(
+    raw_data: &[u8],
+    shape: &[u64],
+    ctx: ChunkContext<'_>,
+    options: &ChunkOptions,
+    base_address: u64,
+    maxshape: Option<&[u64]>,
+) -> Result<ChunkedDataResult, FormatError> {
+    let set = compress_chunks(raw_data, shape, ctx, options, maxshape)?;
+    assemble_chunked_at(&set, base_address)
 }
 
 /// Per-chunk metadata in dense row-major grid order — enough to compute the

--- a/src/data_read.rs
+++ b/src/data_read.rs
@@ -1,7 +1,7 @@
 //! Raw data reading and typed conversion for HDF5 datasets.
 
 #[cfg(not(feature = "std"))]
-use alloc::{string::String, vec, vec::Vec};
+use alloc::{string::String, vec::Vec};
 
 use crate::chunk_cache::ChunkCache;
 use crate::chunked_read::{
@@ -279,6 +279,71 @@ fn get_size(dt: &Datatype) -> usize {
     dt.type_size() as usize
 }
 
+/// True when a numeric element is stored in the "standard" full-width layout —
+/// no sub-byte bit offset, a precision equal to the full byte width, and a plain
+/// little- or big-endian order at a power-of-two width up to 8 bytes. Such
+/// elements decode with a single `from_le_bytes`/`from_be_bytes` per element
+/// (a `chunks_exact` bulk loop the compiler can vectorize and bounds-check once)
+/// instead of the general per-element [`reorder_bytes`]/[`read_raw_word`]
+/// bit-extraction path. Sub-byte-precision integers, Vax order, and non-standard
+/// widths fall through to that slow path, so their decoding is unchanged.
+fn is_standard_layout(
+    elem_size: usize,
+    order: &DatatypeByteOrder,
+    bit_offset: u16,
+    bit_precision: u16,
+) -> bool {
+    matches!(
+        order,
+        DatatypeByteOrder::LittleEndian | DatatypeByteOrder::BigEndian
+    ) && bit_offset == 0
+        && bit_precision as usize == elem_size * 8
+        && matches!(elem_size, 1 | 2 | 4 | 8)
+}
+
+/// Bulk-decode `$raw` — already validated as a whole multiple of the storage
+/// width — into a `Vec<$out>` for a standard-layout numeric type. `$store` is the
+/// width-matched storage scalar (e.g. `i32` for a 4-byte signed integer, `f64`
+/// for an 8-byte float). Each element is decoded with the correct endianness via
+/// `from_le_bytes`/`from_be_bytes` and converted to the requested `$out` element
+/// type with `as`, which reproduces the per-element slow path exactly for the
+/// full-width case: integer storage is bit-reinterpreted then sign/zero-extended
+/// or narrowed; float storage is value-converted. `chunks_exact` yields
+/// guaranteed `$store`-sized slices, so `try_into` never fails and the bounds
+/// check is hoisted out of the loop.
+macro_rules! bulk_decode {
+    ($raw:expr, $count:expr, $order:expr, $store:ty, $out:ty) => {{
+        const W: usize = core::mem::size_of::<$store>();
+        let mut result: Vec<$out> = Vec::with_capacity($count);
+        match $order {
+            DatatypeByteOrder::BigEndian => {
+                for c in $raw.chunks_exact(W) {
+                    let a: [u8; W] = c.try_into().unwrap();
+                    #[allow(
+                        clippy::cast_possible_truncation,
+                        clippy::cast_possible_wrap,
+                        clippy::unnecessary_cast
+                    )]
+                    result.push(<$store>::from_be_bytes(a) as $out);
+                }
+            }
+            // LittleEndian here (Vax is excluded by `is_standard_layout`).
+            _ => {
+                for c in $raw.chunks_exact(W) {
+                    let a: [u8; W] = c.try_into().unwrap();
+                    #[allow(
+                        clippy::cast_possible_truncation,
+                        clippy::cast_possible_wrap,
+                        clippy::unnecessary_cast
+                    )]
+                    result.push(<$store>::from_le_bytes(a) as $out);
+                }
+            }
+        }
+        result
+    }};
+}
+
 /// Convert raw bytes to `f64` values.
 pub fn read_as_f64(raw: &[u8], datatype: &Datatype) -> Result<Vec<f64>, FormatError> {
     ensure_numeric(datatype, "FloatingPoint or FixedPoint")?;
@@ -290,38 +355,43 @@ pub fn read_as_f64(raw: &[u8], datatype: &Datatype) -> Result<Vec<f64>, FormatEr
         });
     }
     let count = raw.len() / elem_size;
+    let order = get_byte_order(datatype);
+    let (bit_offset, bit_precision) = int_bits(datatype);
 
-    // Fast path: native-endian f64 can use bulk copy (zero conversion overhead)
-    #[cfg(target_endian = "little")]
-    if matches!(
-        datatype,
-        Datatype::FloatingPoint {
-            size: 8,
-            byte_order: DatatypeByteOrder::LittleEndian,
-            ..
+    // Fast path: standard full-width layout, bulk-decoded with `from_*_bytes`.
+    if is_standard_layout(elem_size, &order, bit_offset, bit_precision) {
+        match datatype {
+            Datatype::FloatingPoint { size: 4, .. } => {
+                return Ok(bulk_decode!(raw, count, order, f32, f64));
+            }
+            Datatype::FloatingPoint { size: 8, .. } => {
+                return Ok(bulk_decode!(raw, count, order, f64, f64));
+            }
+            Datatype::FixedPoint { signed: true, .. } => {
+                return Ok(match elem_size {
+                    1 => bulk_decode!(raw, count, order, i8, f64),
+                    2 => bulk_decode!(raw, count, order, i16, f64),
+                    4 => bulk_decode!(raw, count, order, i32, f64),
+                    8 => bulk_decode!(raw, count, order, i64, f64),
+                    _ => unreachable!(),
+                });
+            }
+            Datatype::FixedPoint { signed: false, .. } => {
+                return Ok(match elem_size {
+                    1 => bulk_decode!(raw, count, order, u8, f64),
+                    2 => bulk_decode!(raw, count, order, u16, f64),
+                    4 => bulk_decode!(raw, count, order, u32, f64),
+                    8 => bulk_decode!(raw, count, order, u64, f64),
+                    _ => unreachable!(),
+                });
+            }
+            // Other classes (e.g. a 2-byte float, with no `f16`) fall through to
+            // the slow path, which errors exactly as before.
+            _ => {}
         }
-    ) {
-        let mut result = vec![0.0f64; count];
-        // Safety equivalent via from_le_bytes — but we use safe transmute-free copy
-        for (i, val) in result.iter_mut().enumerate() {
-            let off = i * 8;
-            *val = f64::from_le_bytes([
-                raw[off],
-                raw[off + 1],
-                raw[off + 2],
-                raw[off + 3],
-                raw[off + 4],
-                raw[off + 5],
-                raw[off + 6],
-                raw[off + 7],
-            ]);
-        }
-        return Ok(result);
     }
 
-    let order = get_byte_order(datatype);
     let mut result = Vec::with_capacity(count);
-
     for i in 0..count {
         let chunk = &raw[i * elem_size..(i + 1) * elem_size];
         let val = convert_to_f64(chunk, datatype, &order)?;
@@ -383,6 +453,20 @@ pub fn read_as_i64(raw: &[u8], datatype: &Datatype) -> Result<Vec<i64>, FormatEr
     let count = raw.len() / elem_size;
     let order = get_byte_order(datatype);
     let (bit_offset, bit_precision) = int_bits(datatype);
+
+    // Fast path: standard full-width layout, bulk-decoded then sign-extended.
+    // Signed storage types reproduce `read_signed_int`'s sign-extension for the
+    // full-width case (and a float read as i64 bit-reinterprets identically).
+    if is_standard_layout(elem_size, &order, bit_offset, bit_precision) {
+        return Ok(match elem_size {
+            1 => bulk_decode!(raw, count, order, i8, i64),
+            2 => bulk_decode!(raw, count, order, i16, i64),
+            4 => bulk_decode!(raw, count, order, i32, i64),
+            8 => bulk_decode!(raw, count, order, i64, i64),
+            _ => unreachable!(),
+        });
+    }
+
     let mut result = Vec::with_capacity(count);
     for i in 0..count {
         let chunk = &raw[i * elem_size..(i + 1) * elem_size];
@@ -405,6 +489,19 @@ pub fn read_as_u64(raw: &[u8], datatype: &Datatype) -> Result<Vec<u64>, FormatEr
     let count = raw.len() / elem_size;
     let order = get_byte_order(datatype);
     let (bit_offset, bit_precision) = int_bits(datatype);
+
+    // Fast path: standard full-width layout, bulk-decoded with zero-extension
+    // (unsigned storage types reproduce `read_unsigned_int`'s magnitude).
+    if is_standard_layout(elem_size, &order, bit_offset, bit_precision) {
+        return Ok(match elem_size {
+            1 => bulk_decode!(raw, count, order, u8, u64),
+            2 => bulk_decode!(raw, count, order, u16, u64),
+            4 => bulk_decode!(raw, count, order, u32, u64),
+            8 => bulk_decode!(raw, count, order, u64, u64),
+            _ => unreachable!(),
+        });
+    }
+
     let mut result = Vec::with_capacity(count);
     for i in 0..count {
         let chunk = &raw[i * elem_size..(i + 1) * elem_size];
@@ -426,6 +523,39 @@ pub fn read_as_f32(raw: &[u8], datatype: &Datatype) -> Result<Vec<f32>, FormatEr
     }
     let count = raw.len() / elem_size;
     let order = get_byte_order(datatype);
+    let (bit_offset, bit_precision) = int_bits(datatype);
+
+    // Fast path: standard full-width layout, bulk-decoded with `from_*_bytes`.
+    if is_standard_layout(elem_size, &order, bit_offset, bit_precision) {
+        match datatype {
+            Datatype::FloatingPoint { size: 4, .. } => {
+                return Ok(bulk_decode!(raw, count, order, f32, f32));
+            }
+            Datatype::FloatingPoint { size: 8, .. } => {
+                return Ok(bulk_decode!(raw, count, order, f64, f32));
+            }
+            Datatype::FixedPoint { signed: true, .. } => {
+                return Ok(match elem_size {
+                    1 => bulk_decode!(raw, count, order, i8, f32),
+                    2 => bulk_decode!(raw, count, order, i16, f32),
+                    4 => bulk_decode!(raw, count, order, i32, f32),
+                    8 => bulk_decode!(raw, count, order, i64, f32),
+                    _ => unreachable!(),
+                });
+            }
+            Datatype::FixedPoint { signed: false, .. } => {
+                return Ok(match elem_size {
+                    1 => bulk_decode!(raw, count, order, u8, f32),
+                    2 => bulk_decode!(raw, count, order, u16, f32),
+                    4 => bulk_decode!(raw, count, order, u32, f32),
+                    8 => bulk_decode!(raw, count, order, u64, f32),
+                    _ => unreachable!(),
+                });
+            }
+            _ => {}
+        }
+    }
+
     let mut result = Vec::with_capacity(count);
     for i in 0..count {
         let chunk = &raw[i * elem_size..(i + 1) * elem_size];
@@ -494,6 +624,19 @@ pub fn read_as_i32(raw: &[u8], datatype: &Datatype) -> Result<Vec<i32>, FormatEr
     let count = raw.len() / elem_size;
     let order = get_byte_order(datatype);
     let (bit_offset, bit_precision) = int_bits(datatype);
+
+    // Fast path: standard full-width layout, bulk-decoded then narrowed to i32
+    // (matches `read_signed_int(..) as i32` for the full-width case).
+    if is_standard_layout(elem_size, &order, bit_offset, bit_precision) {
+        return Ok(match elem_size {
+            1 => bulk_decode!(raw, count, order, i8, i32),
+            2 => bulk_decode!(raw, count, order, i16, i32),
+            4 => bulk_decode!(raw, count, order, i32, i32),
+            8 => bulk_decode!(raw, count, order, i64, i32),
+            _ => unreachable!(),
+        });
+    }
+
     let mut result = Vec::with_capacity(count);
     for i in 0..count {
         let chunk = &raw[i * elem_size..(i + 1) * elem_size];
@@ -505,6 +648,113 @@ pub fn read_as_i32(raw: &[u8], datatype: &Datatype) -> Result<Vec<i32>, FormatEr
         result.push(v as i32);
     }
     Ok(result)
+}
+
+/// Convert raw bytes to `i16` values (counterpart of [`read_as_i32`] for the
+/// narrower element type, used by [`crate::Dataset::read_i16`]).
+pub fn read_as_i16(raw: &[u8], datatype: &Datatype) -> Result<Vec<i16>, FormatError> {
+    ensure_numeric(datatype, "FixedPoint")?;
+    let elem_size = get_size(datatype);
+    if elem_size == 0 || !raw.len().is_multiple_of(elem_size) {
+        return Err(FormatError::DataSizeMismatch {
+            expected: 0,
+            actual: raw.len(),
+        });
+    }
+    let count = raw.len() / elem_size;
+    let order = get_byte_order(datatype);
+    let (bit_offset, bit_precision) = int_bits(datatype);
+
+    if is_standard_layout(elem_size, &order, bit_offset, bit_precision) {
+        return Ok(match elem_size {
+            1 => bulk_decode!(raw, count, order, i8, i16),
+            2 => bulk_decode!(raw, count, order, i16, i16),
+            4 => bulk_decode!(raw, count, order, i32, i16),
+            8 => bulk_decode!(raw, count, order, i64, i16),
+            _ => unreachable!(),
+        });
+    }
+
+    // Slow path: decode wide, then narrow (matches the prior `read_i16` route
+    // through `read_as_i32`).
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "read_as_i16 narrows each stored value to the requested i16"
+    )]
+    Ok(read_as_i32(raw, datatype)?
+        .into_iter()
+        .map(|v| v as i16)
+        .collect())
+}
+
+/// Convert raw bytes to `u32` values (counterpart of [`read_as_u64`] for the
+/// narrower element type, used by [`crate::Dataset::read_u32`]).
+pub fn read_as_u32(raw: &[u8], datatype: &Datatype) -> Result<Vec<u32>, FormatError> {
+    ensure_numeric(datatype, "FixedPoint (unsigned)")?;
+    let elem_size = get_size(datatype);
+    if elem_size == 0 || !raw.len().is_multiple_of(elem_size) {
+        return Err(FormatError::DataSizeMismatch {
+            expected: 0,
+            actual: raw.len(),
+        });
+    }
+    let count = raw.len() / elem_size;
+    let order = get_byte_order(datatype);
+    let (bit_offset, bit_precision) = int_bits(datatype);
+
+    if is_standard_layout(elem_size, &order, bit_offset, bit_precision) {
+        return Ok(match elem_size {
+            1 => bulk_decode!(raw, count, order, u8, u32),
+            2 => bulk_decode!(raw, count, order, u16, u32),
+            4 => bulk_decode!(raw, count, order, u32, u32),
+            8 => bulk_decode!(raw, count, order, u64, u32),
+            _ => unreachable!(),
+        });
+    }
+
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "read_as_u32 narrows each stored value to the requested u32"
+    )]
+    Ok(read_as_u64(raw, datatype)?
+        .into_iter()
+        .map(|v| v as u32)
+        .collect())
+}
+
+/// Convert raw bytes to `u16` values (counterpart of [`read_as_u64`] for the
+/// narrower element type, used by [`crate::Dataset::read_u16`]).
+pub fn read_as_u16(raw: &[u8], datatype: &Datatype) -> Result<Vec<u16>, FormatError> {
+    ensure_numeric(datatype, "FixedPoint (unsigned)")?;
+    let elem_size = get_size(datatype);
+    if elem_size == 0 || !raw.len().is_multiple_of(elem_size) {
+        return Err(FormatError::DataSizeMismatch {
+            expected: 0,
+            actual: raw.len(),
+        });
+    }
+    let count = raw.len() / elem_size;
+    let order = get_byte_order(datatype);
+    let (bit_offset, bit_precision) = int_bits(datatype);
+
+    if is_standard_layout(elem_size, &order, bit_offset, bit_precision) {
+        return Ok(match elem_size {
+            1 => bulk_decode!(raw, count, order, u8, u16),
+            2 => bulk_decode!(raw, count, order, u16, u16),
+            4 => bulk_decode!(raw, count, order, u32, u16),
+            8 => bulk_decode!(raw, count, order, u64, u16),
+            _ => unreachable!(),
+        });
+    }
+
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "read_as_u16 narrows each stored value to the requested u16"
+    )]
+    Ok(read_as_u64(raw, datatype)?
+        .into_iter()
+        .map(|v| v as u16)
+        .collect())
 }
 
 /// Read fixed-length strings from raw bytes.
@@ -678,6 +928,8 @@ mod tests {
     use super::*;
     use crate::dataspace::{Dataspace, DataspaceType};
     use crate::datatype::{CharacterSet, StringPadding};
+    #[cfg(not(feature = "std"))]
+    use alloc::vec;
 
     fn make_f64_le_type() -> Datatype {
         Datatype::FloatingPoint {
@@ -1071,5 +1323,129 @@ mod tests {
         );
         let u8t = make_u8_type();
         assert_eq!(read_as_u64(&[200u8], &u8t).unwrap(), vec![200]);
+    }
+
+    // --- Bulk fast-path equivalence guards ---
+    //
+    // The native-endian fast paths must produce byte-identical results to the
+    // general per-element path for every width, endianness, and cross-type
+    // coercion the readers accept.
+
+    fn make_int(size: u32, signed: bool, be: bool) -> Datatype {
+        Datatype::FixedPoint {
+            size,
+            byte_order: if be {
+                DatatypeByteOrder::BigEndian
+            } else {
+                DatatypeByteOrder::LittleEndian
+            },
+            signed,
+            bit_offset: 0,
+            bit_precision: (size * 8) as u16,
+        }
+    }
+
+    #[test]
+    fn fast_path_big_endian_signed_matches_values() {
+        // i32 big-endian: fast path uses from_be_bytes; verify against known vals.
+        let dt = make_int(4, true, true);
+        let vals = [1i32, -1, 2_000_000_000, -2_000_000_000, 0];
+        let mut raw = Vec::new();
+        for v in vals {
+            raw.extend_from_slice(&v.to_be_bytes());
+        }
+        assert_eq!(
+            read_as_i64(&raw, &dt).unwrap(),
+            vals.iter().map(|&v| v as i64).collect::<Vec<_>>()
+        );
+        assert_eq!(read_as_i32(&raw, &dt).unwrap(), vals.to_vec());
+        // Read big-endian i32 as f64 (FixedPoint -> f64 coercion).
+        assert_eq!(
+            read_as_f64(&raw, &dt).unwrap(),
+            vals.iter().map(|&v| v as f64).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn fast_path_unsigned_read_as_signed_reinterprets() {
+        // An unsigned u32 read via read_as_i64 must sign-reinterpret the full
+        // width, exactly as the per-element read_signed_int did.
+        let dt = make_int(4, false, false);
+        let raw = 0xFFFF_FFFFu32.to_le_bytes();
+        assert_eq!(read_as_i64(&raw, &dt).unwrap(), vec![-1]);
+        // And read as u64 zero-extends.
+        assert_eq!(read_as_u64(&raw, &dt).unwrap(), vec![0xFFFF_FFFF]);
+    }
+
+    #[test]
+    fn fast_path_narrowing_readers_match_wide_then_narrow() {
+        // read_as_i16/u16/u32 must equal the old "decode wide, then `as`" route
+        // for both LE and BE and for narrowing from a wider stored width.
+        for be in [false, true] {
+            let i64t = make_int(8, true, be);
+            let vals = [1i64, -1, 70_000, -70_000, i64::from(i32::MAX)];
+            let mut raw = Vec::new();
+            for v in vals {
+                if be {
+                    raw.extend_from_slice(&v.to_be_bytes());
+                } else {
+                    raw.extend_from_slice(&v.to_le_bytes());
+                }
+            }
+            let wide = read_as_i64(&raw, &i64t).unwrap();
+            let i16s = read_as_i16(&raw, &i64t).unwrap();
+            assert_eq!(
+                i16s,
+                wide.iter().map(|&v| v as i16).collect::<Vec<_>>(),
+                "i16 narrow be={be}"
+            );
+
+            let u64t = make_int(8, false, be);
+            let uwide = read_as_u64(&raw, &u64t).unwrap();
+            assert_eq!(
+                read_as_u16(&raw, &u64t).unwrap(),
+                uwide.iter().map(|&v| v as u16).collect::<Vec<_>>(),
+                "u16 narrow be={be}"
+            );
+            assert_eq!(
+                read_as_u32(&raw, &u64t).unwrap(),
+                uwide.iter().map(|&v| v as u32).collect::<Vec<_>>(),
+                "u32 narrow be={be}"
+            );
+        }
+    }
+
+    #[test]
+    fn fast_path_all_widths_roundtrip_f32() {
+        // f32/f64 and every integer width, LE and BE, decode to f32 correctly.
+        let f4 = read_as_f32(&1.5f32.to_be_bytes(), &make_f32_be_type()).unwrap();
+        assert_eq!(f4, vec![1.5]);
+        let f8le = Datatype::FloatingPoint {
+            size: 8,
+            byte_order: DatatypeByteOrder::LittleEndian,
+            bit_offset: 0,
+            bit_precision: 64,
+            exponent_location: 52,
+            exponent_size: 11,
+            mantissa_location: 0,
+            mantissa_size: 52,
+            exponent_bias: 1023,
+        };
+        assert_eq!(
+            read_as_f32(&2.25f64.to_le_bytes(), &f8le).unwrap(),
+            vec![2.25f32]
+        );
+        // Signed/unsigned 1/2/4/8-byte ints decode to f32.
+        for (size, be) in [(1u32, false), (2, true), (4, false), (8, true)] {
+            let dt = make_int(size, true, be);
+            let v: i64 = -3;
+            let bytes = if be { v.to_be_bytes() } else { v.to_le_bytes() };
+            let raw = if be {
+                &bytes[8 - size as usize..]
+            } else {
+                &bytes[..size as usize]
+            };
+            assert_eq!(read_as_f32(raw, &dt).unwrap(), vec![-3.0f32]);
+        }
     }
 }

--- a/src/file_writer.rs
+++ b/src/file_writer.rs
@@ -16,8 +16,8 @@ use std::collections::HashMap;
 
 use crate::attribute::AttributeMessage;
 use crate::chunked_write::{
-    ByteSink, ChunkOptions, VerbatimLayout, VerbatimPlan, build_chunked_data_at_ext,
-    emit_chunked_data_verbatim, plan_chunked_data_verbatim,
+    ByteSink, ChunkOptions, CompressedChunkSet, VerbatimLayout, VerbatimPlan, assemble_chunked_at,
+    compress_chunks, emit_chunked_data_verbatim, plan_chunked_data_verbatim,
 };
 use crate::convert::TryToUsize;
 use crate::dataspace::{Dataspace, DataspaceType};
@@ -683,7 +683,11 @@ impl FileWriter {
         /// single dispatch point keeps the dummy-sizing and real-address passes
         /// from diverging. The layout is computed from chunk *sizes* alone, so
         /// it is identical whether the chunks are in memory or streamed.
-        fn build_chunked(d: &DsFlat, base_address: u64) -> Result<ChunkedBuilt, FormatError> {
+        fn build_chunked(
+            d: &DsFlat,
+            base_address: u64,
+            chunk_set: Option<&CompressedChunkSet>,
+        ) -> Result<ChunkedBuilt, FormatError> {
             if let Some(rc) = &d.raw_chunks {
                 // Verbatim chunks are always streamed: the layout is planned from
                 // chunk sizes alone, and the bytes are pulled from the provider in
@@ -708,16 +712,11 @@ impl FileWriter {
                     data: DsData::Streamed(plan),
                 })
             } else {
-                let chunk_dims = d.chunk_options.resolve_chunk_dims(&d.ds.dimensions);
-                let ctx = crate::filters::ChunkContext::from_datatype(&chunk_dims, &d.dt);
-                let result = build_chunked_data_at_ext(
-                    &d.raw,
-                    &d.ds.dimensions,
-                    ctx,
-                    &d.chunk_options,
-                    base_address,
-                    d.maxshape.as_deref(),
-                )?;
+                // Encode path: the chunks were compressed once up front; just lay
+                // the cached set out at this address (no recompression).
+                let set = chunk_set
+                    .expect("an encode-path chunked dataset must have a precomputed chunk set");
+                let result = assemble_chunked_at(set, base_address)?;
                 Ok(ChunkedBuilt {
                     layout_message: result.layout_message,
                     pipeline_message: result.pipeline_message,
@@ -935,6 +934,35 @@ impl FileWriter {
             .iter()
             .map(|d| d.chunk_options.is_chunked() || d.maxshape.is_some() || d.raw_chunks.is_some())
             .collect();
+
+        // Compress each encode-path chunked dataset exactly once, up front. The
+        // object-header sizing pass and the data-emit pass both need the chunk
+        // layout, but only the embedded addresses differ between them — the
+        // (expensive) compression does not. Caching the `CompressedChunkSet` here
+        // lets both passes call the cheap `assemble_chunked_at` instead of
+        // recompressing the whole dataset twice. Verbatim datasets carry their
+        // bytes pre-compressed and are planned (not recompressed), so they get no
+        // entry.
+        let chunk_sets: Vec<Option<CompressedChunkSet>> = all_ds
+            .iter()
+            .enumerate()
+            .map(|(i, d)| {
+                if is_chunked[i] && d.raw_chunks.is_none() {
+                    let chunk_dims = d.chunk_options.resolve_chunk_dims(&d.ds.dimensions);
+                    let ctx = crate::filters::ChunkContext::from_datatype(&chunk_dims, &d.dt);
+                    Ok(Some(compress_chunks(
+                        &d.raw,
+                        &d.ds.dimensions,
+                        ctx,
+                        &d.chunk_options,
+                        d.maxshape.as_deref(),
+                    )?))
+                } else {
+                    Ok(None)
+                }
+            })
+            .collect::<Result<_, FormatError>>()?;
+
         let root_dense = root_attrs.len() > DENSE_ATTR_THRESHOLD;
         let group_dense: Vec<bool> = groups
             .iter()
@@ -998,7 +1026,7 @@ impl FileWriter {
                 None
             };
             let oh = if is_chunked[i] {
-                let built = build_chunked(d, dummy_cursor)?;
+                let built = build_chunked(d, dummy_cursor, chunk_sets[i].as_ref())?;
                 dummy_cursor += built.data.len();
                 build_chunked_dataset_oh(
                     &d.dt,
@@ -1156,10 +1184,10 @@ impl FileWriter {
             chunked_msgs: Option<(Vec<u8>, Option<Vec<u8>>)>,
         }
         let mut ds_layouts: Vec<DsLayout> = Vec::new();
-        for (i, d) in all_ds.iter().enumerate() {
+        for (i, d) in all_ds.iter_mut().enumerate() {
             if is_chunked[i] {
                 let base_address = cursor2 as u64;
-                let built = build_chunked(d, base_address)?;
+                let built = build_chunked(d, base_address, chunk_sets[i].as_ref())?;
                 cursor2 += built.data.len().to_usize()?;
                 ds_layouts.push(DsLayout {
                     data: built.data,
@@ -1167,7 +1195,9 @@ impl FileWriter {
                     chunked_msgs: Some((built.layout_message, built.pipeline_message)),
                 });
             } else {
-                let data = d.raw.clone();
+                // `d.raw` is not read again for a contiguous/compact dataset, so
+                // move its element buffer into the layout rather than cloning it.
+                let data = core::mem::take(&mut d.raw);
                 let addr = if data.is_empty() {
                     u64::MAX
                 } else {

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -320,9 +320,12 @@ fn zfp_decompress(
 fn deflate_decompress(data: &[u8], max_output: Option<usize>) -> Result<Vec<u8>, FormatError> {
     use std::io::Read;
     let decoder = flate2::read::ZlibDecoder::new(data);
-    let mut result = Vec::new();
     match max_output {
         Some(limit) => {
+            // The decoded size is known a priori (the chunk's expected byte
+            // size), so reserve it up front instead of letting `read_to_end`
+            // reallocate through ~log2(N) doublings.
+            let mut result = Vec::with_capacity(limit);
             // Read at most `limit + 1` bytes: anything beyond `limit` proves the
             // stream exceeds the expected chunk size, so reject rather than OOM.
             let cap = (limit as u64).saturating_add(1);
@@ -336,15 +339,17 @@ fn deflate_decompress(data: &[u8], max_output: Option<usize>) -> Result<Vec<u8>,
                      (possible decompression bomb)"
                 )));
             }
+            Ok(result)
         }
         None => {
             let mut decoder = decoder;
+            let mut result = Vec::new();
             decoder
                 .read_to_end(&mut result)
                 .map_err(|e| FormatError::DecompressionError(e.to_string()))?;
+            Ok(result)
         }
     }
-    Ok(result)
 }
 
 #[cfg(not(feature = "deflate"))]
@@ -370,6 +375,29 @@ fn deflate_compress(_data: &[u8], _level: u32) -> Result<Vec<u8>, FormatError> {
     Err(FormatError::UnsupportedFilter(FILTER_DEFLATE))
 }
 
+/// Unshuffle one element width `N` (const-generic, so the inner byte loop is
+/// unrolled): gather byte `j` of element `i` from plane `j` and write the `N`
+/// reconstructed bytes of the element as one contiguous store.
+fn unshuffle_n<const N: usize>(data: &[u8], result: &mut [u8], num_elements: usize) {
+    for (i, out) in result.chunks_exact_mut(N).enumerate() {
+        let mut elem = [0u8; N];
+        for (j, b) in elem.iter_mut().enumerate() {
+            *b = data[j * num_elements + i];
+        }
+        out.copy_from_slice(&elem);
+    }
+}
+
+/// Shuffle one element width `N` (const-generic): read the `N` contiguous bytes
+/// of element `i` and scatter byte `j` into plane `j`.
+fn shuffle_n<const N: usize>(data: &[u8], result: &mut [u8], num_elements: usize) {
+    for (i, elem) in data.chunks_exact(N).enumerate() {
+        for (j, &b) in elem.iter().enumerate() {
+            result[j * num_elements + i] = b;
+        }
+    }
+}
+
 /// Unshuffle (decompress direction): reconstruct interleaved element bytes.
 /// On disk: all byte-0s of each element together, then all byte-1s, etc.
 /// Output: elements in natural order.
@@ -385,9 +413,20 @@ fn shuffle_decompress(data: &[u8], element_size: usize) -> Result<Vec<u8>, Forma
     let num_elements = data.len() / element_size;
     let mut result = vec![0u8; data.len()];
 
-    for i in 0..num_elements {
-        for j in 0..element_size {
-            result[i * element_size + j] = data[j * num_elements + i];
+    // Specialize the common scalar widths so the inner loop unrolls and each
+    // element is written as one contiguous store; fall back to the generic loop
+    // for unusual widths (compound members, wide types).
+    match element_size {
+        2 => unshuffle_n::<2>(data, &mut result, num_elements),
+        4 => unshuffle_n::<4>(data, &mut result, num_elements),
+        8 => unshuffle_n::<8>(data, &mut result, num_elements),
+        16 => unshuffle_n::<16>(data, &mut result, num_elements),
+        _ => {
+            for i in 0..num_elements {
+                for j in 0..element_size {
+                    result[i * element_size + j] = data[j * num_elements + i];
+                }
+            }
         }
     }
 
@@ -407,9 +446,17 @@ fn shuffle_compress(data: &[u8], element_size: usize) -> Result<Vec<u8>, FormatE
     let num_elements = data.len() / element_size;
     let mut result = vec![0u8; data.len()];
 
-    for i in 0..num_elements {
-        for j in 0..element_size {
-            result[j * num_elements + i] = data[i * element_size + j];
+    match element_size {
+        2 => shuffle_n::<2>(data, &mut result, num_elements),
+        4 => shuffle_n::<4>(data, &mut result, num_elements),
+        8 => shuffle_n::<8>(data, &mut result, num_elements),
+        16 => shuffle_n::<16>(data, &mut result, num_elements),
+        _ => {
+            for i in 0..num_elements {
+                for j in 0..element_size {
+                    result[j * num_elements + i] = data[i * element_size + j];
+                }
+            }
         }
     }
 
@@ -557,6 +604,41 @@ mod tests {
         let shuffled = shuffle_compress(&data, 4).unwrap();
         let unshuffled = shuffle_decompress(&shuffled, 4).unwrap();
         assert_eq!(unshuffled, data);
+    }
+
+    #[test]
+    fn shuffle_roundtrip_all_widths() {
+        // Every specialized width (2/4/8/16) plus generic fallbacks (3, 6, 7).
+        for &es in &[2usize, 3, 4, 6, 7, 8, 16] {
+            let data: Vec<u8> = (0..(es * 50)).map(|i| (i * 31 % 256) as u8).collect();
+            let shuffled = shuffle_compress(&data, es).unwrap();
+            assert_eq!(shuffled.len(), data.len(), "es={es}");
+            let back = shuffle_decompress(&shuffled, es).unwrap();
+            assert_eq!(back, data, "shuffle roundtrip failed for element_size {es}");
+        }
+    }
+
+    #[test]
+    fn shuffle_specialized_matches_generic() {
+        // The const-generic specialization must produce byte-identical output to
+        // the plain transpose for the same width.
+        fn generic_shuffle(data: &[u8], es: usize) -> Vec<u8> {
+            let ne = data.len() / es;
+            let mut out = vec![0u8; data.len()];
+            for i in 0..ne {
+                for j in 0..es {
+                    out[j * ne + i] = data[i * es + j];
+                }
+            }
+            out
+        }
+        for &es in &[2usize, 4, 8, 16] {
+            let data: Vec<u8> = (0..(es * 37)).map(|i| (i * 17 + 3) as u8).collect();
+            assert_eq!(
+                shuffle_compress(&data, es).unwrap(),
+                generic_shuffle(&data, es)
+            );
+        }
     }
 
     #[test]

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -976,39 +976,24 @@ impl<'f> Dataset<'f> {
     }
 
     /// Read all data as `i16` values.
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "read_i16 narrows each stored value to the i16 element type the caller requested"
-    )]
     pub fn read_i16(&self) -> Result<Vec<i16>, Error> {
         let raw = self.read_raw()?;
         let dt = self.datatype()?;
-        let vals = data_read::read_as_i32(&raw, &dt)?;
-        Ok(vals.into_iter().map(|v| v as i16).collect())
+        Ok(data_read::read_as_i16(&raw, &dt)?)
     }
 
     /// Read all data as `u16` values.
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "read_u16 narrows each stored value to the u16 element type the caller requested"
-    )]
     pub fn read_u16(&self) -> Result<Vec<u16>, Error> {
         let raw = self.read_raw()?;
         let dt = self.datatype()?;
-        let vals = data_read::read_as_u64(&raw, &dt)?;
-        Ok(vals.into_iter().map(|v| v as u16).collect())
+        Ok(data_read::read_as_u16(&raw, &dt)?)
     }
 
     /// Read all data as `u32` values.
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "read_u32 narrows each stored value to the u32 element type the caller requested"
-    )]
     pub fn read_u32(&self) -> Result<Vec<u32>, Error> {
         let raw = self.read_raw()?;
         let dt = self.datatype()?;
-        let vals = data_read::read_as_u64(&raw, &dt)?;
-        Ok(vals.into_iter().map(|v| v as u32).collect())
+        Ok(data_read::read_as_u32(&raw, &dt)?)
     }
 
     /// Read all data as `String` values.

--- a/tests/chunked_edge_roundtrip.rs
+++ b/tests/chunked_edge_roundtrip.rs
@@ -1,0 +1,98 @@
+//! Roundtrip tests for chunked datasets whose chunk dimensions do *not* evenly
+//! divide the dataset dimensions, so chunks overhang the dataset edge in both
+//! the innermost (contiguous) and outer dimensions. This is the case the bulk
+//! row-copy assembly kernel (`copy_chunk_to_output`) must get exactly right: it
+//! clamps the inner row and skips out-of-bounds outer rows. Even/odd ranks,
+//! several element types, and an uncompressed vs shuffle+deflate path are all
+//! covered, comparing the read-back against the known row-major input.
+
+use hdf5_pure::{File, FileBuilder};
+
+/// Write a flat row-major `f64` dataset with the given shape and chunk shape,
+/// read it back, and assert it equals the input.
+fn roundtrip_f64(shape: &[u64], chunks: &[u64], shuffle_deflate: bool) {
+    let total: u64 = shape.iter().product();
+    let data: Vec<f64> = (0..total).map(|i| i as f64 * 1.5 - 7.0).collect();
+
+    let mut b = FileBuilder::new();
+    {
+        let ds = b
+            .create_dataset("d")
+            .with_f64_data(&data)
+            .with_shape(shape)
+            .with_chunks(chunks);
+        if shuffle_deflate {
+            ds.with_shuffle().with_deflate(6);
+        }
+    }
+    let bytes = b.finish().unwrap();
+
+    let file = File::from_bytes(bytes).unwrap();
+    let ds = file.dataset("d").unwrap();
+    assert_eq!(
+        ds.shape().unwrap(),
+        shape,
+        "shape {shape:?} chunks {chunks:?}"
+    );
+    assert_eq!(
+        ds.read_f64().unwrap(),
+        data,
+        "f64 roundtrip mismatch for shape {shape:?} chunks {chunks:?} sd={shuffle_deflate}"
+    );
+}
+
+#[test]
+fn edge_chunks_1d() {
+    // 25 elements, chunk 10 => last chunk overhangs (inner-dim overhang).
+    roundtrip_f64(&[25], &[10], false);
+    roundtrip_f64(&[25], &[10], true);
+    // Chunk larger than the dataset (single overhanging chunk).
+    roundtrip_f64(&[7], &[16], false);
+}
+
+#[test]
+fn edge_chunks_2d() {
+    // 5x7 with 2x3 chunks: rows {0,2,4} (row-4 chunk overhangs row 5 -> outer
+    // overhang) and cols {0,3,6} (col-6 chunk overhangs cols 7,8 -> inner
+    // overhang). Both edge cases in one fixture.
+    roundtrip_f64(&[5, 7], &[2, 3], false);
+    roundtrip_f64(&[5, 7], &[2, 3], true);
+    // Tall-and-thin and wide-and-short variants.
+    roundtrip_f64(&[13, 4], &[4, 4], false);
+    roundtrip_f64(&[4, 13], &[4, 4], false);
+}
+
+#[test]
+fn edge_chunks_3d() {
+    // 3x3x5 with 2x2x2 chunks: overhang in all three dimensions.
+    roundtrip_f64(&[3, 3, 5], &[2, 2, 2], false);
+    roundtrip_f64(&[3, 3, 5], &[2, 2, 2], true);
+}
+
+#[test]
+fn edge_chunks_integer_types() {
+    // Exercise the assembly kernel together with the integer decode fast paths
+    // for both a narrowing read (i32 stored, read as i32) and a wide read.
+    let shape = [5u64, 7];
+    let total: u64 = shape.iter().product();
+
+    let i32_data: Vec<i32> = (0..total as i32).map(|i| i.wrapping_mul(99) - 5).collect();
+    let mut b = FileBuilder::new();
+    b.create_dataset("d")
+        .with_i32_data(&i32_data)
+        .with_shape(&shape)
+        .with_chunks(&[2, 3])
+        .with_shuffle()
+        .with_deflate(6);
+    let file = File::from_bytes(b.finish().unwrap()).unwrap();
+    assert_eq!(file.dataset("d").unwrap().read_i32().unwrap(), i32_data);
+
+    let u16_data: Vec<u16> = (0..total).map(|i| ((i * 137) & 0xFFFF) as u16).collect();
+    let mut b = FileBuilder::new();
+    b.create_dataset("d")
+        .with_u16_data(&u16_data)
+        .with_shape(&shape)
+        .with_chunks(&[3, 2]);
+    let file = File::from_bytes(b.finish().unwrap()).unwrap();
+    assert_eq!(file.dataset("d").unwrap().read_u16().unwrap(), u16_data);
+}


### PR DESCRIPTION
## Summary

An optimization and benchmarking pass over the read and write hot paths. All changes preserve byte-exact behavior (verified against the reference HDF5 C library), and there is no public API change. A new Criterion benchmark harness (`benches/hot_paths.rs`, default features off) measures everything below through the public API.

## Results (`cargo bench --bench hot_paths`, this machine)

| Benchmark | Before | After | Speedup |
|---|---:|---:|---:|
| `contiguous_decode_1M/read_f64` | 2.41 ms | 1.84 ms | 1.3× |
| `contiguous_decode_1M/read_i32` | 7.82 ms | 0.53 ms | **14.7×** |
| `contiguous_decode_1M/read_u16` | 4.39 ms | 0.48 ms | **9.1×** |
| `contiguous_decode_1M/read_i32_as_f64` | 7.82 ms | 1.18 ms | 6.6× |
| `chunked_read_1024x1024_f64/uncompressed` | 7.65 ms | 2.21 ms | 3.5× |
| `chunked_read_1024x1024_f64/shuffle_deflate` | 16.93 ms | 8.01 ms | 2.1× |
| `write_1M_f64/contiguous` | 1.81 ms | 1.74 ms | ~1.0× |
| `write_1M_f64/chunked_shuffle_deflate` | 44.74 ms | 15.55 ms | **2.9×** |

## What changed

**Typed decode (`data_read.rs`, `reader.rs`).** The integer readers had no native-endian fast path: every element ran through `reorder_bytes` (a per-element `[u8; 8]` copy), `read_raw_word`, bit masking, and sign extension. They now bulk-decode standard full-width little-/big-endian values with `chunks_exact` + `from_le_bytes`/`from_be_bytes` (a loop the compiler vectorizes), falling back to the exact-same slow path for sub-byte precision, Vax order, and unusual widths. `read_i16`/`read_u16`/`read_u32` now decode straight to the target width instead of decoding into a wide `Vec` and re-collecting.

**Chunk assembly (`chunked_read.rs`, `chunk_cache.rs`).** `copy_chunk_to_output` copied one element at a time with a flat→N-D coordinate decomposition (a divide+modulo per dimension per element). It now copies each contiguous inner row with a single `copy_from_slice`, walking only the outer dimensions, with edge-chunk clamping that reproduces the old out-of-bounds skip exactly. The chunk cache now stores plain `Vec<u8>` and exposes a `with_decompressed` accessor, so the assembly scatters directly from the cached/decompressed bytes — removing the per-chunk clone, the cache-aligned-buffer copy, and the get-time `to_vec`. The unused `CacheAlignedBuffer` (whose alignment was never actually exploited) is removed. New edge-chunk roundtrip tests cover non-dividing chunk dims across ranks 1–3.

**Filters (`filters.rs`).** The byte-shuffle filter is specialized for the common element widths (2/4/8/16) with const-generic unrolled gather/scatter; the deflate decoder reserves its known decoded size up front instead of growing through ~log₂(N) reallocations.

**Write path (`chunked_write.rs`, `file_writer.rs`).** The writer sized a dataset's object header in one pass and emitted its data in a later pass, calling `build_chunked` (split + compress every chunk) in **both** — so the entire filter pipeline ran twice per chunked+filtered dataset. The work is now split into an address-independent `compress_chunks` (the single expensive pass, cached between the two passes) and a cheap `assemble_chunked_at` run per pass. `split_into_chunks` also gathers contiguous inner rows, the unfiltered chunk buffer is moved instead of cloned, and a contiguous dataset's element buffer is moved into the layout instead of cloned.

## Correctness

- Full test suite green (490 lib tests + the integration suites), including the byte-level crosschecks against the reference HDF5 C library (`c_write_compat`, `hdf5_crosscheck`, `repack_crosscheck`, `edit_crosscheck`, the extensible/fixed-array crosschecks) — the write changes produce byte-identical files.
- New regression tests pin the decode fast-path/slow-path equivalence (big-endian, unsigned-as-signed reinterpretation, narrowing, all widths→f32) and the chunk-assembly edge cases.
- `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, the `no_std` check, and the 32-bit (`i686`) narrowing-cast gate all pass.
