### PR TITLE
mat: read cell arrays and the modern `string` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- MATLAB **cell arrays** now deserialize: `mat::from_bytes` / `mat::from_file` resolve each element's `#refs#` object reference and rebuild the sequence, so `Vec<Struct>`, ragged `Vec<Vec<T>>`, `Vec<Option<T>>` (with `None` slots restored), and nested cells round-trip — previously refused with `UnsupportedType("cell array")`. New public `Dataset::dereference` and `Object` resolve an HDF5 object reference (`H5R_OBJECT`) to the group or dataset it names, and MATLAB's reserved `#refs#` / `#subsystem#` groups are skipped on read ([#114](https://github.com/stephenberry/hdf5-pure/issues/114)).
+- The modern MATLAB **`string`** class now deserializes: an opaque (`MATLAB_object_decode=3`) `string` dataset's object id is resolved against the `#subsystem#/MCOS` store and its UTF-16 saveobj payload decoded, so values written with `Options::with_modern_strings()` round-trip and a scalar `string` reads back as a Rust `String`. The remaining MCOS opaque classes (`datetime`, `categorical`, `table`, `containers.Map`, `dictionary`, …) are refused with the typed `MatError::UnsupportedMatlabClass` rather than misread ([#114](https://github.com/stephenberry/hdf5-pure/issues/114)).
+
 ## [0.17.0] - 2026-06-18
 
 Repack now reproduces three more datatype classes faithfully — non-string variable-length sequences, object-reference datasets, and time datatypes — and the dataset read and write hot paths are several times faster (bulk numeric decode, contiguous-row chunk scatter, compress-once filtered writes). **Breaking:** `Datatype::Time` gained a `byte_order` field, so code matching that variant must account for it; minor bump.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,7 +458,7 @@ dependencies = [
 
 [[package]]
 name = "hdf5-pure"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "byteorder",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdf5-pure"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2024"
 # `std::fs::File` advisory locking (used by the write/edit/read open paths for
 # concurrent-writer detection, issue #73) stabilized in Rust 1.89.

--- a/src/error.rs
+++ b/src/error.rs
@@ -293,6 +293,11 @@ pub enum FormatError {
         /// The requested upper bound.
         requested_high: &'static str,
     },
+    /// An HDF5 object reference (`H5R_OBJECT`) could not be resolved to an
+    /// object: the stored address is null or undefined (`HADDR_UNDEF`), or it
+    /// does not point at a group or dataset object header. The payload is the
+    /// stored (base-relative) address, preserved for diagnostics.
+    InvalidObjectReference(u64),
 }
 
 impl fmt::Display for FormatError {
@@ -603,6 +608,13 @@ impl fmt::Display for FormatError {
                     f,
                     "requested library-version bounds [{requested_low}, {requested_high}] \
                      cannot be satisfied: this crate writes the {writes} format"
+                )
+            }
+            FormatError::InvalidObjectReference(addr) => {
+                write!(
+                    f,
+                    "invalid HDF5 object reference: address {addr:#x} is null/undefined \
+                     or does not point at a group or dataset"
                 )
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,7 +225,7 @@ pub use error::FormatError;
 
 #[cfg(feature = "std")]
 pub use reader::{
-    Dataset, DatasetAccessOptions, File, FileAccessOptions, Group, is_hdf5, is_hdf5_bytes,
+    Dataset, DatasetAccessOptions, File, FileAccessOptions, Group, Object, is_hdf5, is_hdf5_bytes,
 };
 
 #[cfg(feature = "std")]

--- a/src/mat/de/mcos_reader.rs
+++ b/src/mat/de/mcos_reader.rs
@@ -1,0 +1,327 @@
+//! Reader for MATLAB's MCOS opaque-object subsystem (`#subsystem#`).
+//!
+//! MATLAB stores its non-builtin classes — the modern `string`, plus
+//! `datetime`, `categorical`, `table`, `containers.Map`, … — as
+//! `mxOPAQUE_CLASS` objects (`MATLAB_object_decode = 3`). The object's data does
+//! not live on its own dataset; instead the dataset carries a small `uint32`
+//! metadata array that names an *object id*, and the actual property data is
+//! interned in the hidden `#subsystem#/MCOS` store.
+//!
+//! On-disk shape (reverse-engineered against this crate's own writer, which
+//! mirrors MATLAB byte-for-byte for `string`):
+//!
+//! - The opaque **parent dataset** holds `uint32`
+//!   `[0xDD000000, ndims, dim0, …, object_id0, …, class_id]`. The reserved
+//!   header is `2 + ndims` words; then one *object id* per element
+//!   (`prod(dims)` of them); then a trailing *class id*.
+//! - `/#subsystem#/MCOS` is a `FileWrapper__` object-reference dataset whose
+//!   cell array is `[metadata blob, canonical empty, saveobj_0, saveobj_1, …,
+//!   <trailing default/alias cells>]`. The saveobj payload for object id `k`
+//!   (1-based) is therefore cell `k + 1` ([`MCOS_RESERVED_CELL_PREFIX`] leading
+//!   cells before the first payload).
+//!
+//! This module currently decodes the `string` class; other opaque classes are
+//! refused with a typed [`MatError::UnsupportedMatlabClass`] rather than
+//! misread. The subsystem parse is the foundation the remaining classes build
+//! on.
+
+use std::collections::HashMap;
+
+use crate::convert::TryToUsize;
+use crate::file_writer::AttrValue;
+use crate::mat::error::MatError;
+use crate::mat::string_object::{
+    MATLAB_CLASS_STRING, MATLAB_OBJECT_DECODE_OPAQUE, MATLAB_STRING_SAVEOBJ_VERSION,
+    MCOS_MAGIC_NUMBER,
+};
+use crate::mat::value::MatValue;
+use crate::reader::{Dataset, File, Object};
+use crate::types::DType;
+
+/// Number of reserved cells at the front of the `#subsystem#/MCOS` cell array
+/// before the first object's saveobj payload: the `FileWrapper__` metadata blob
+/// and the canonical-empty placeholder. The saveobj for 1-based object id `k`
+/// lives at cell `MCOS_RESERVED_CELL_PREFIX + (k - 1)`.
+const MCOS_RESERVED_CELL_PREFIX: usize = 2;
+
+/// The parsed `#subsystem#/MCOS` opaque-object store for one file.
+///
+/// Holds the dereferenced MCOS cell array; opaque parent datasets index into it
+/// by object id. Parsed once per file and shared across every opaque dataset
+/// read (top-level variables and struct fields alike reference the same store).
+pub(crate) struct Mcos<'f> {
+    cells: Vec<Object<'f>>,
+}
+
+impl<'f> Mcos<'f> {
+    /// Parse the `#subsystem#/MCOS` store, or `Ok(None)` if the file has no
+    /// `#subsystem#` group (a file with no opaque objects).
+    pub(crate) fn parse(file: &'f File) -> Result<Option<Self>, MatError> {
+        let subsystem = match file.group("#subsystem#") {
+            Ok(g) => g,
+            // No subsystem group: the file holds no opaque objects.
+            Err(_) => return Ok(None),
+        };
+        let mcos = subsystem.dataset("MCOS").map_err(MatError::Hdf5)?;
+        let cells = mcos.dereference().map_err(MatError::Hdf5)?;
+        Ok(Some(Self { cells }))
+    }
+
+    /// Read the saveobj `uint64` payload for a 1-based object id.
+    fn saveobj_payload(&self, object_id: u32) -> Result<Vec<u64>, MatError> {
+        if object_id == 0 {
+            return Err(MatError::Custom(
+                "opaque object id 0 is invalid (ids are 1-based)".into(),
+            ));
+        }
+        let idx = MCOS_RESERVED_CELL_PREFIX + (object_id as usize - 1);
+        let cell = self.cells.get(idx).ok_or_else(|| {
+            MatError::Custom(format!(
+                "opaque object id {object_id} maps to MCOS cell {idx}, but the store has {} cells",
+                self.cells.len()
+            ))
+        })?;
+        match cell {
+            Object::Dataset(d) => {
+                // The saveobj payload is always a `uint64` array. Refuse any
+                // other datatype rather than letting `read_u64` widen a
+                // narrower or floating-point cell into `u64` — the packing
+                // (4 UTF-16 units per 64-bit word) is only valid for `uint64`,
+                // so a divergent layout must error, not be reinterpreted.
+                let dtype = d.dtype().map_err(MatError::Hdf5)?;
+                if dtype != DType::U64 {
+                    return Err(MatError::Custom(format!(
+                        "MCOS saveobj cell {idx} has datatype {dtype:?}; expected uint64"
+                    )));
+                }
+                d.read_u64().map_err(MatError::Hdf5)
+            }
+            Object::Group(_) => Err(MatError::Custom(format!(
+                "MCOS cell {idx} is a group; expected a saveobj dataset"
+            ))),
+        }
+    }
+}
+
+/// Decode an opaque (`mxOPAQUE_CLASS`) dataset into a [`MatValue`].
+///
+/// `decode` is the `MATLAB_object_decode` value; `attrs` are the parent
+/// dataset's attributes (carrying `MATLAB_class`). Only `string`
+/// (`decode == 3`) is decoded so far; any other opaque class is refused by name.
+pub(crate) fn decode_opaque(
+    ds: &Dataset<'_>,
+    attrs: &HashMap<String, AttrValue>,
+    decode: i64,
+    mcos: Option<&Mcos<'_>>,
+) -> Result<MatValue, MatError> {
+    let class = raw_matlab_class(attrs).ok_or_else(|| {
+        MatError::Custom("opaque object (MATLAB_object_decode set) has no MATLAB_class".into())
+    })?;
+
+    if decode == i64::from(MATLAB_OBJECT_DECODE_OPAQUE) && class == MATLAB_CLASS_STRING {
+        let mcos = mcos.ok_or_else(|| {
+            MatError::Custom(
+                "file references an MCOS opaque object but has no #subsystem# store".into(),
+            )
+        })?;
+        return decode_string_object(ds, mcos);
+    }
+
+    // Every other modern MATLAB type (datetime, categorical, table,
+    // containers.Map, dictionary, enum, user classdefs, …) is also an MCOS
+    // opaque object; decoding them is tracked follow-up work. Refuse by name
+    // rather than misread.
+    Err(MatError::UnsupportedMatlabClass(class))
+}
+
+/// Decode a `MATLAB_class = "string"` opaque dataset.
+fn decode_string_object(ds: &Dataset<'_>, mcos: &Mcos<'_>) -> Result<MatValue, MatError> {
+    let metadata = ds.read_u32().map_err(MatError::Hdf5)?;
+    let object_ids = parse_opaque_object_ids(&metadata)?;
+
+    // The serde writer emits one scalar `string` object, but a single object can
+    // encode a string array and a dataset can name several objects; collect
+    // every decoded value and represent the result accordingly.
+    let mut values: Vec<String> = Vec::new();
+    for object_id in object_ids {
+        let payload = mcos.saveobj_payload(object_id)?;
+        values.extend(decode_string_saveobj(&payload)?);
+    }
+
+    // Intentional lowering (not a shape-losing bug): a single value becomes a
+    // scalar `String`; zero values (an empty `0×0 string`) or a genuine string
+    // array become a cell of strings, which deserializes to `Vec<String>`. The
+    // serde writer only ever emits scalar `string` objects, so the `1` arm is
+    // the path these tests exercise; the cell arm is the forward-compatible
+    // representation for real-MATLAB string arrays.
+    Ok(match values.len() {
+        1 => MatValue::String(values.pop().expect("len checked")),
+        _ => MatValue::Cell(values.into_iter().map(MatValue::String).collect()),
+    })
+}
+
+/// Extract the 1-based object ids from an opaque parent dataset's `uint32`
+/// metadata: `[MAGIC, ndims, dims…, object_ids…, class_id]`.
+fn parse_opaque_object_ids(data: &[u32]) -> Result<Vec<u32>, MatError> {
+    // Minimum: MAGIC, ndims, (≥0 dims), (≥0 ids), class_id.
+    if data.len() < 3 {
+        return Err(MatError::Custom(format!(
+            "opaque metadata too short: {} words",
+            data.len()
+        )));
+    }
+    if data[0] != MCOS_MAGIC_NUMBER {
+        return Err(MatError::Custom(format!(
+            "opaque metadata magic mismatch: {:#x}",
+            data[0]
+        )));
+    }
+    let ndims = (data[1] as u64).to_usize()?;
+    let dims_end = 2usize
+        .checked_add(ndims)
+        .ok_or_else(|| MatError::Custom("opaque metadata ndims overflow".into()))?;
+    // Need the dims block plus at least the trailing class id.
+    if data.len() < dims_end + 1 {
+        return Err(MatError::Custom(
+            "opaque metadata truncated before object ids".into(),
+        ));
+    }
+    let num_objects = checked_product(&data[2..dims_end])?;
+    let ids_end = dims_end
+        .checked_add(num_objects)
+        .ok_or_else(|| MatError::Custom("opaque metadata object count overflow".into()))?;
+    // Exactly one trailing class id must follow the object ids.
+    if data.len() != ids_end + 1 {
+        return Err(MatError::Custom(format!(
+            "opaque metadata length {} does not match header (expected {})",
+            data.len(),
+            ids_end + 1
+        )));
+    }
+    Ok(data[dims_end..ids_end].to_vec())
+}
+
+/// Decode a `string` saveobj payload into its string values.
+///
+/// Layout: `[VERSION, ndims, dims…, lens…, UTF-16 packed 4 units per u64]`.
+/// A length of `u64::MAX` is MATLAB's `<missing>` sentinel (no code units),
+/// decoded here as an empty string.
+fn decode_string_saveobj(payload: &[u64]) -> Result<Vec<String>, MatError> {
+    if payload.len() < 2 {
+        return Err(MatError::Custom("string saveobj payload too short".into()));
+    }
+    if payload[0] != MATLAB_STRING_SAVEOBJ_VERSION {
+        return Err(MatError::Custom(format!(
+            "unsupported string saveobj version: {}",
+            payload[0]
+        )));
+    }
+    let ndims = payload[1].to_usize()?;
+    let dims_end = 2usize
+        .checked_add(ndims)
+        .ok_or_else(|| MatError::Custom("string saveobj ndims overflow".into()))?;
+    if payload.len() < dims_end {
+        return Err(MatError::Custom(
+            "string saveobj truncated before lengths".into(),
+        ));
+    }
+    let count = checked_product_u64(&payload[2..dims_end])?;
+    let lens_end = dims_end
+        .checked_add(count)
+        .ok_or_else(|| MatError::Custom("string saveobj count overflow".into()))?;
+    if payload.len() < lens_end {
+        return Err(MatError::Custom(
+            "string saveobj truncated before code units".into(),
+        ));
+    }
+    let lens = &payload[dims_end..lens_end];
+
+    // Total UTF-16 code units across all (non-missing) strings.
+    let mut total_units: usize = 0;
+    for &len in lens {
+        if len != u64::MAX {
+            total_units = total_units
+                .checked_add(len.to_usize()?)
+                .ok_or_else(|| MatError::Custom("string saveobj unit count overflow".into()))?;
+        }
+    }
+
+    // Unpack `total_units` code units from the packed u64 words (4 per word).
+    let mut units: Vec<u16> = Vec::with_capacity(total_units);
+    'words: for &word in &payload[lens_end..] {
+        for shift in [0u32, 16, 32, 48] {
+            if units.len() == total_units {
+                break 'words;
+            }
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "extracting one packed 16-bit UTF-16 code unit from a 64-bit word"
+            )]
+            units.push((word >> shift) as u16);
+        }
+    }
+    if units.len() < total_units {
+        return Err(MatError::Custom(
+            "string saveobj code-unit data is shorter than the declared lengths".into(),
+        ));
+    }
+
+    let mut strings = Vec::with_capacity(lens.len());
+    let mut pos = 0usize;
+    for &len in lens {
+        if len == u64::MAX {
+            strings.push(String::new());
+            continue;
+        }
+        let len = len.to_usize()?;
+        let slice = &units[pos..pos + len];
+        pos += len;
+        let s = String::from_utf16(slice).map_err(|e| MatError::Utf16Decode(e.to_string()))?;
+        strings.push(s);
+    }
+    Ok(strings)
+}
+
+/// Read the raw `MATLAB_class` attribute string without parsing it into a
+/// builtin [`MatClass`](crate::mat::class::MatClass) (opaque class names such as
+/// `string` are not builtin variants).
+fn raw_matlab_class(attrs: &HashMap<String, AttrValue>) -> Option<String> {
+    match attrs.get("MATLAB_class") {
+        Some(AttrValue::AsciiString(s)) | Some(AttrValue::String(s)) => Some(s.clone()),
+        Some(AttrValue::StringArray(v)) if v.len() == 1 => Some(v[0].clone()),
+        _ => None,
+    }
+}
+
+/// `MATLAB_object_decode` value for a dataset, if present, normalized to `i64`.
+/// A non-zero value marks an opaque object; `None`/`0` is an ordinary dataset.
+pub(crate) fn matlab_object_decode(attrs: &HashMap<String, AttrValue>) -> Option<i64> {
+    let v = match attrs.get("MATLAB_object_decode")? {
+        AttrValue::I64(v) => *v,
+        AttrValue::I32(v) => i64::from(*v),
+        AttrValue::U32(v) => i64::from(*v),
+        AttrValue::U64(v) => i64::try_from(*v).ok()?,
+        _ => return None,
+    };
+    (v != 0).then_some(v)
+}
+
+fn checked_product(values: &[u32]) -> Result<usize, MatError> {
+    let mut acc = 1usize;
+    for &v in values {
+        acc = acc
+            .checked_mul((v as u64).to_usize()?)
+            .ok_or_else(|| MatError::Custom("opaque dimension product overflow".into()))?;
+    }
+    Ok(acc)
+}
+
+fn checked_product_u64(values: &[u64]) -> Result<usize, MatError> {
+    let mut acc = 1usize;
+    for &v in values {
+        acc = acc
+            .checked_mul(v.to_usize()?)
+            .ok_or_else(|| MatError::Custom("string saveobj dimension product overflow".into()))?;
+    }
+    Ok(acc)
+}

--- a/src/mat/de/mod.rs
+++ b/src/mat/de/mod.rs
@@ -1,5 +1,6 @@
 //! Deserializer for MATLAB v7.3 `.mat` files.
 
+mod mcos_reader;
 mod reader;
 mod value_de;
 

--- a/src/mat/de/reader.rs
+++ b/src/mat/de/reader.rs
@@ -3,13 +3,22 @@
 use std::collections::HashMap;
 
 use crate::convert::TryToUsize;
+use crate::error::FormatError;
 use crate::file_writer::AttrValue;
 use crate::mat::class::MatClass;
+use crate::mat::de::mcos_reader::{self, Mcos};
 use crate::mat::error::MatError;
 use crate::mat::utf16;
 use crate::mat::value::{MatValue, NumVec, ScalarNum};
-use crate::reader::{Dataset, File, Group};
+use crate::reader::{Dataset, File, Group, Object};
 use crate::types::DType;
+
+/// Maximum struct/cell nesting depth followed when reading. Real MATLAB data
+/// nests a handful of levels deep; this bound is generous headroom that still
+/// turns a malformed file — e.g. a cell whose object reference points back at
+/// itself, or a cyclic group link — into a typed error instead of unbounded
+/// recursion and a stack overflow.
+const MAX_NESTING_DEPTH: usize = 256;
 
 /// Parse a MAT v7.3 file into an ordered list of `(name, value)` fields
 /// rooted at the file's top level.
@@ -17,35 +26,76 @@ pub(crate) fn read_file(bytes: &[u8]) -> Result<Vec<(String, MatValue)>, MatErro
     // Accept raw HDF5 too — we don't require the MATLAB signature to be
     // present to deserialize successfully.
     let file = File::from_bytes(bytes.to_vec()).map_err(MatError::Hdf5)?;
+    // Parse the MCOS opaque-object store once; opaque datasets (modern `string`,
+    // …) anywhere in the file resolve their payloads against it. `None` when the
+    // file has no `#subsystem#` group.
+    let mcos = Mcos::parse(&file)?;
     let root = file.root();
-    read_group(&root)
+    read_group(&root, mcos.as_ref(), 0)
 }
 
-fn read_group(group: &Group<'_>) -> Result<Vec<(String, MatValue)>, MatError> {
+fn read_group(
+    group: &Group<'_>,
+    mcos: Option<&Mcos<'_>>,
+    depth: usize,
+) -> Result<Vec<(String, MatValue)>, MatError> {
+    if depth > MAX_NESTING_DEPTH {
+        return Err(MatError::Format(FormatError::NestingDepthExceeded));
+    }
     let mut out = Vec::new();
 
     // Collect datasets first, then subgroups. Preserve iteration order from
-    // the HDF5 link table.
+    // the HDF5 link table. Skip MATLAB's reserved internal entries — `#refs#`
+    // (cell/object-reference payloads) and `#subsystem#` (the MCOS opaque-class
+    // store): MATLAB hides them, no variable name can begin with `#`, and their
+    // contents are reached by reference from the variables that use them, not
+    // by walking the top level.
     for name in group.datasets().map_err(MatError::Hdf5)? {
+        if name.starts_with('#') {
+            continue;
+        }
         let ds = group.dataset(&name).map_err(MatError::Hdf5)?;
-        out.push((name, read_dataset(&ds)?));
+        out.push((name, read_dataset(&ds, mcos, depth)?));
     }
     for name in group.groups().map_err(MatError::Hdf5)? {
+        if name.starts_with('#') {
+            continue;
+        }
         let sub = group.group(&name).map_err(MatError::Hdf5)?;
-        out.push((name, read_group_as_value(&sub)?));
+        out.push((name, read_group_as_value(&sub, mcos, depth + 1)?));
     }
     Ok(out)
 }
 
-fn read_group_as_value(group: &Group<'_>) -> Result<MatValue, MatError> {
-    let fields = read_group(group)?;
+fn read_group_as_value(
+    group: &Group<'_>,
+    mcos: Option<&Mcos<'_>>,
+    depth: usize,
+) -> Result<MatValue, MatError> {
+    let fields = read_group(group, mcos, depth)?;
     Ok(MatValue::Struct(fields))
 }
 
 /// Read a single dataset into a `MatValue` using its MATLAB_class attribute
-/// (if present) and its HDF5 shape.
-fn read_dataset(ds: &Dataset<'_>) -> Result<MatValue, MatError> {
+/// (if present) and its HDF5 shape. `depth` bounds struct/cell nesting.
+fn read_dataset(
+    ds: &Dataset<'_>,
+    mcos: Option<&Mcos<'_>>,
+    depth: usize,
+) -> Result<MatValue, MatError> {
+    if depth > MAX_NESTING_DEPTH {
+        return Err(MatError::Format(FormatError::NestingDepthExceeded));
+    }
     let attrs = ds.attrs().map_err(MatError::Hdf5)?;
+
+    // An `mxOPAQUE_CLASS` object (`MATLAB_object_decode` set) stores its data in
+    // the `#subsystem#` MCOS store, not on this dataset. Decode it there before
+    // the builtin-class path — its `MATLAB_class` (e.g. `string`) is not a
+    // `MatClass` variant.
+    if let Some(decode) = mcos_reader::matlab_object_decode(&attrs) {
+        return mcos_reader::decode_opaque(ds, &attrs, decode, mcos);
+    }
+
     let class = matlab_class_from_attrs(&attrs)?;
     let shape = ds.shape().map_err(MatError::Hdf5)?;
     let dtype = ds.dtype().map_err(MatError::Hdf5)?;
@@ -59,6 +109,14 @@ fn read_dataset(ds: &Dataset<'_>) -> Result<MatValue, MatError> {
         // rather than collapsing to a numeric empty vec.
         if matches!(class, MatClass::Double | MatClass::Single) && is_complex_dtype(&dtype) {
             return empty_complex_value(class, &shape);
+        }
+        // An empty struct-classed *dataset* (`MATLAB_empty=1`) is `struct([])`,
+        // the marker the serializer writes for `Option::None` inside a
+        // sequence. Surface it as `EmptyStructArray` so an `Option` field
+        // round-trips to `None` (an empty struct *group*, by contrast, reads as
+        // an empty struct via `read_group_as_value`).
+        if class == MatClass::Struct {
+            return Ok(MatValue::EmptyStructArray);
         }
         // Empty numeric/char: produce an empty 1-D vec of the correct tag.
         return Ok(empty_value_for_class(class));
@@ -90,8 +148,30 @@ fn read_dataset(ds: &Dataset<'_>) -> Result<MatValue, MatError> {
         MatClass::Struct => Err(MatError::Custom(
             "dataset has MATLAB_class='struct'; expected a group".into(),
         )),
-        MatClass::Cell => Err(MatError::UnsupportedType("cell array")),
+        MatClass::Cell => read_cell(ds, mcos, depth),
     }
+}
+
+/// Read a cell-array dataset: a vector of HDF5 object references, each pointing
+/// at a member object (struct group, numeric/char dataset, nested cell, …)
+/// interned under `#refs#`. Members are decoded in storage order and collected
+/// into a flat [`MatValue::Cell`], matching the column-vector layout the
+/// serializer writes (the deserializer flattens a cell to a sequence).
+fn read_cell(
+    ds: &Dataset<'_>,
+    mcos: Option<&Mcos<'_>>,
+    depth: usize,
+) -> Result<MatValue, MatError> {
+    let members = ds.dereference().map_err(MatError::Hdf5)?;
+    let mut elems = Vec::with_capacity(members.len());
+    for member in members {
+        let value = match member {
+            Object::Dataset(d) => read_dataset(&d, mcos, depth + 1)?,
+            Object::Group(g) => read_group_as_value(&g, mcos, depth + 1)?,
+        };
+        elems.push(value);
+    }
+    Ok(MatValue::Cell(elems))
 }
 
 /// Extract and parse the `MATLAB_class` attribute value, if present.
@@ -160,7 +240,7 @@ fn empty_value_for_class(class: MatClass) -> MatValue {
         MatClass::UInt32 => MatValue::Vec1D(NumVec::empty_with_tag(ScalarTag::U32)),
         MatClass::UInt64 => MatValue::Vec1D(NumVec::empty_with_tag(ScalarTag::U64)),
         MatClass::Struct => MatValue::Struct(Vec::new()),
-        MatClass::Cell => MatValue::Struct(Vec::new()),
+        MatClass::Cell => MatValue::Cell(Vec::new()),
     }
 }
 

--- a/src/mat/error.rs
+++ b/src/mat/error.rs
@@ -37,6 +37,12 @@ pub enum MatError {
     MissingField(String),
     /// A `MATLAB_class` attribute value wasn't recognized.
     UnknownClass(String),
+    /// A recognized but not-yet-supported MATLAB class was encountered on read
+    /// — an MCOS opaque class (`datetime`, `categorical`, `table`,
+    /// `containers.Map`, `dictionary`, an enumeration, a user `classdef`, …)
+    /// whose decoder is not yet implemented. Refused by name rather than
+    /// misread; the modern `string` class is supported.
+    UnsupportedMatlabClass(String),
     /// UTF-16 decoding of a `char` dataset failed.
     Utf16Decode(String),
     /// A generic serde-originated error (from `Error::custom`).
@@ -67,6 +73,11 @@ impl fmt::Display for MatError {
             }
             MatError::MissingField(name) => write!(f, "missing required field: {name}"),
             MatError::UnknownClass(c) => write!(f, "unknown MATLAB_class: {c:?}"),
+            MatError::UnsupportedMatlabClass(c) => write!(
+                f,
+                "MATLAB class {c:?} is not yet supported for reading (modern `string` is; \
+                 other MCOS opaque classes such as datetime/categorical/table are refused for now)"
+            ),
             MatError::Utf16Decode(msg) => write!(f, "UTF-16 decode: {msg}"),
             MatError::Custom(msg) => write!(f, "{msg}"),
         }

--- a/src/mat/mod.rs
+++ b/src/mat/mod.rs
@@ -137,6 +137,16 @@ pub fn to_file_with_options<T: Serialize + ?Sized, P: AsRef<std::path::Path>>(
 }
 
 /// Deserialize a MAT v7.3 file from a byte slice.
+///
+/// Numeric arrays, `char` strings, complex values, structs, **cell arrays**, and
+/// the modern **`string`** class are reconstructed. A cell array's element
+/// references into the hidden `#refs#` group are resolved so the [`to_bytes`]
+/// sequence fallbacks (`Vec<Struct>`, ragged `Vec<Vec<T>>`, `Vec<Option<T>>`,
+/// nested cells) round-trip; a `string` object's payload is resolved against the
+/// `#subsystem#/MCOS` store. MATLAB's reserved `#refs#` / `#subsystem#` groups
+/// are not surfaced as variables. The other MCOS opaque classes (`datetime`,
+/// `categorical`, `table`, `containers.Map`, `dictionary`, …) are refused with a
+/// typed error rather than misread.
 #[cfg(feature = "serde")]
 pub fn from_bytes<T: DeserializeOwned>(bytes: &[u8]) -> Result<T, MatError> {
     de::from_bytes(bytes)

--- a/src/mat/string_object.rs
+++ b/src/mat/string_object.rs
@@ -10,8 +10,10 @@
 //! 1. A `uint64` "saveobj" payload per string scalar/array (lives in `#refs#`).
 //!    Encodes a version, the dimensions, the per-string lengths, and packed
 //!    UTF-16 code units.
-//! 2. A `uint32` 6-element metadata array on the parent dataset:
-//!    `[MCOS_MAGIC=0xDD000000, 2, 1, 1, object_id, 1]`. Carries the
+//! 2. A `uint32` metadata array on the parent dataset. The general form is
+//!    `[MCOS_MAGIC=0xDD000000, ndims, dims…, object_ids…, class_id]`; for the
+//!    scalar string this writer emits it is the 6 elements
+//!    `[0xDD000000, 2, 1, 1, object_id, 1]`. Carries the
 //!    `MATLAB_class="string"` and `MATLAB_object_decode=3` attributes.
 //! 3. A `#subsystem#/MCOS` reference dataset that points to a `FileWrapper__`
 //!    metadata blob, a canonical empty placeholder, every per-string saveobj

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -10,7 +10,7 @@ use crate::convert::TryToUsize;
 use crate::data_layout::DataLayout;
 use crate::data_read;
 use crate::dataspace::Dataspace;
-use crate::datatype::Datatype;
+use crate::datatype::{Datatype, ReferenceType};
 use crate::error::{Error, FormatError};
 use crate::file_space_info::{FileSpaceInfo, FileSpaceStrategy};
 use crate::filter_pipeline::FilterPipeline;
@@ -645,6 +645,43 @@ impl File {
         }
     }
 
+    /// Resolve a base-relative object-header address (the value stored in an
+    /// HDF5 `H5R_OBJECT` reference element) to the [`Object`] it points at.
+    ///
+    /// The stored address is relative to the superblock base address, so any
+    /// MAT-file userblock is accounted for here. A null (`0`) or undefined
+    /// (`HADDR_UNDEF`) address, or one whose object header is neither a dataset
+    /// nor a group, yields [`FormatError::InvalidObjectReference`].
+    fn object_at_relative(&self, rel_addr: u64) -> Result<Object<'_>, Error> {
+        // HADDR_UNDEF and the null address never name a real object. (Relative
+        // address 0 is where the superblock sits, not an object header.)
+        if rel_addr == u64::MAX || rel_addr == 0 {
+            return Err(FormatError::InvalidObjectReference(rel_addr).into());
+        }
+        let abs = rel_addr
+            .checked_add(self.addr_offset)
+            .ok_or(FormatError::InvalidObjectReference(rel_addr))?;
+        let hdr = self.parse_header(abs)?;
+        if has_message(&hdr, MessageType::DataLayout) {
+            let chunk_cache =
+                DatasetAccessOptions::new().resolved_chunk_cache(self.access_options.chunk_cache);
+            Ok(Object::Dataset(Box::new(Dataset {
+                file: self,
+                address: abs,
+                header: hdr,
+                chunk_cache: ChunkCache::with_config(chunk_cache),
+                chunk_cache_config: chunk_cache,
+            })))
+        } else if is_group(&hdr) {
+            Ok(Object::Group(Group {
+                file: self,
+                address: abs,
+            }))
+        } else {
+            Err(FormatError::InvalidObjectReference(rel_addr).into())
+        }
+    }
+
     fn offset_size(&self) -> u8 {
         self.superblock.offset_size
     }
@@ -742,6 +779,40 @@ impl std::fmt::Debug for File {
             .field("size", &self.source().len())
             .field("superblock_version", &self.superblock.version)
             .finish()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Object reference target
+// ---------------------------------------------------------------------------
+
+/// The resolved target of an HDF5 object reference (`H5R_OBJECT`): either a
+/// group or a dataset.
+///
+/// Produced by [`Dataset::dereference`]. MATLAB `.mat` files use object
+/// references pervasively — a cell array stores one reference per element, and
+/// the `#subsystem#` machinery references its payloads — so resolving a
+/// reference to the group or dataset it names is the foundation for reading
+/// those structures.
+///
+/// The [`Dataset`](Object::Dataset) handle is boxed: it carries a parsed object
+/// header and is much larger than a [`Group`](Object::Group) handle, so boxing
+/// keeps `Object` (and a `Vec<Object>`) compact without a size disparity. The
+/// `Box` derefs transparently, so `&obj_dataset` is usable wherever a
+/// `&Dataset` is expected.
+pub enum Object<'f> {
+    /// The reference points at a group's object header.
+    Group(Group<'f>),
+    /// The reference points at a dataset's object header.
+    Dataset(Box<Dataset<'f>>),
+}
+
+impl std::fmt::Debug for Object<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Object::Group(_) => f.write_str("Object::Group"),
+            Object::Dataset(_) => f.write_str("Object::Dataset"),
+        }
     }
 }
 
@@ -1309,6 +1380,65 @@ impl<'f> Dataset<'f> {
         Ok(self
             .file
             .read_dataset_raw(&dl, &ds, &dt, pipeline.as_ref(), &self.chunk_cache)?)
+    }
+
+    /// Interpret this dataset as an array of HDF5 object references
+    /// (`H5R_OBJECT`) and resolve each, in storage order, to the [`Object`] it
+    /// points at.
+    ///
+    /// MATLAB cell arrays and the `#subsystem#` machinery store their members
+    /// this way: the dataset holds one object-header address per element, each
+    /// naming an object elsewhere in the file (conventionally under the hidden
+    /// `#refs#` group).
+    ///
+    /// # Errors
+    ///
+    /// - [`FormatError::TypeMismatch`] if this dataset's datatype is not an
+    ///   object reference.
+    /// - [`FormatError::InvalidObjectReference`] if an element is a null or
+    ///   undefined reference, or does not point at a group or dataset.
+    pub fn dereference(&self) -> Result<Vec<Object<'f>>, Error> {
+        let dt = self.datatype()?;
+        if !matches!(
+            dt,
+            Datatype::Reference {
+                ref_type: ReferenceType::Object,
+                ..
+            }
+        ) {
+            return Err(FormatError::TypeMismatch {
+                expected: "object reference",
+                actual: "non-reference datatype",
+            }
+            .into());
+        }
+        // An object reference stores an 8-byte object-header address. Refuse a
+        // sub-address-width element rather than read a truncated address.
+        let elem_size = dt.type_size().to_usize()?;
+        if elem_size < 8 {
+            return Err(FormatError::TypeMismatch {
+                expected: "8-byte object reference",
+                actual: "object reference narrower than 8 bytes",
+            }
+            .into());
+        }
+        let raw = self.read_raw()?;
+        if raw.is_empty() {
+            return Ok(Vec::new());
+        }
+        if !raw.len().is_multiple_of(elem_size) {
+            return Err(FormatError::DataSizeMismatch {
+                expected: elem_size,
+                actual: raw.len(),
+            }
+            .into());
+        }
+        let mut out = Vec::with_capacity(raw.len() / elem_size);
+        for chunk in raw.chunks_exact(elem_size) {
+            let addr = u64::from_le_bytes(chunk[..8].try_into().expect("chunk has >= 8 bytes"));
+            out.push(self.file.object_at_relative(addr)?);
+        }
+        Ok(out)
     }
 
     /// Decode all elements of a compound dataset field by field.

--- a/tests/cell_array.rs
+++ b/tests/cell_array.rs
@@ -269,13 +269,13 @@ fn empty_vec_of_struct_serializes_as_empty_double() {
     assert_eq!(cls.as_str(), "double");
 }
 
-/// Cell-array reading is not yet supported on the deserializer side: the
-/// reader emits `UnsupportedType("cell array")` for any dataset with
-/// `MATLAB_class="cell"`. The writer-side tests above pin the on-disk
-/// shape; full read parity (resolving `#refs#` paths back into element
-/// `MatValue`s) is a separate follow-up.
+/// Cell-array reading resolves each element's `#refs#` object reference back
+/// into a `MatValue` and reconstructs the sequence, so a `Vec<Struct>`
+/// round-trips through the pure-Rust deserializer. (Pure-Rust read coverage
+/// lives in `tests/mat_cell_read.rs`; this case pairs it with the C-library
+/// write checks above.)
 #[test]
-fn from_file_on_cell_array_currently_errors() {
+fn from_file_on_cell_array_roundtrips() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("roundtrip_cell.mat");
 
@@ -284,11 +284,8 @@ fn from_file_on_cell_array_currently_errors() {
     };
     mat::to_file(&original, &path).unwrap();
 
-    let result: Result<PathRoot, _> = mat::from_file(&path);
-    assert!(
-        result.is_err(),
-        "cell-array deserialization not yet implemented"
-    );
+    let back: PathRoot = mat::from_file(&path).expect("cell array should deserialize");
+    assert_eq!(back, original);
 }
 
 #[test]

--- a/tests/mat_cell_read.rs
+++ b/tests/mat_cell_read.rs
@@ -1,0 +1,205 @@
+#![cfg(feature = "serde")]
+//! Read-back (deserialize) tests for MATLAB cell arrays.
+//!
+//! The serializer lowers any sequence that doesn't fit a numeric matrix
+//! (`Vec<Struct>`, ragged `Vec<Vec<T>>`, `Vec<Option<T>>` with `None`
+//! interspersed, nested cells) to a MATLAB cell array: the parent dataset holds
+//! object references into the hidden `#refs#` group. These tests round-trip
+//! such values through the pure-Rust reader, which resolves those references and
+//! reconstructs the cell. They use only `hdf5_pure` (no reference C library), so
+//! they run without cmake.
+
+use std::collections::BTreeMap;
+
+use hdf5_pure::mat;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+struct Point {
+    x: f64,
+    y: f64,
+}
+
+fn roundtrip<T>(value: &T) -> T
+where
+    T: Serialize + serde::de::DeserializeOwned,
+{
+    let bytes = mat::to_bytes(value).expect("serialize");
+    mat::from_bytes(&bytes).expect("deserialize")
+}
+
+#[test]
+fn vec_of_struct_roundtrips() {
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    struct Root {
+        path: Vec<Point>,
+    }
+
+    let root = Root {
+        path: vec![
+            Point { x: 0.0, y: 0.0 },
+            Point { x: 1.0, y: 2.0 },
+            Point { x: 3.0, y: 4.5 },
+        ],
+    };
+    assert_eq!(roundtrip(&root), root);
+}
+
+#[test]
+fn single_element_vec_of_struct_roundtrips() {
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    struct Root {
+        path: Vec<Point>,
+    }
+
+    let root = Root {
+        path: vec![Point { x: -1.0, y: 7.0 }],
+    };
+    assert_eq!(roundtrip(&root), root);
+}
+
+#[test]
+fn nested_vec_of_struct_roundtrips() {
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    struct Root {
+        grid: Vec<Vec<Point>>,
+    }
+
+    let root = Root {
+        grid: vec![
+            vec![Point { x: 0.0, y: 0.0 }, Point { x: 1.0, y: 1.0 }],
+            vec![Point { x: 2.0, y: 2.0 }],
+            vec![],
+        ],
+    };
+    assert_eq!(roundtrip(&root), root);
+}
+
+#[test]
+fn ragged_vec_of_vec_f64_roundtrips() {
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    struct Root {
+        rows: Vec<Vec<f64>>,
+    }
+
+    // Ragged inner lengths cannot form a matrix, so this lowers to a cell of
+    // numeric row vectors.
+    let root = Root {
+        rows: vec![vec![1.0, 2.0, 3.0], vec![4.0], vec![5.0, 6.0]],
+    };
+    assert_eq!(roundtrip(&root), root);
+}
+
+#[test]
+fn vec_of_option_struct_roundtrips_none_slots() {
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    struct Root {
+        items: Vec<Option<Point>>,
+    }
+
+    // `None` interspersed forces a cell array; each `None` becomes `struct([])`
+    // and must read back as `None`.
+    let root = Root {
+        items: vec![
+            Some(Point { x: 1.0, y: 1.0 }),
+            None,
+            Some(Point { x: 2.0, y: 2.0 }),
+            None,
+        ],
+    };
+    assert_eq!(roundtrip(&root), root);
+}
+
+#[test]
+fn empty_vec_of_struct_roundtrips() {
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    struct Root {
+        path: Vec<Point>,
+    }
+
+    let root = Root { path: vec![] };
+    assert_eq!(roundtrip(&root), root);
+}
+
+#[test]
+fn reserved_refs_group_is_not_surfaced_as_a_field() {
+    // Writing a cell array creates the hidden `#refs#` group at the top level.
+    // The reader must skip it: a `deny_unknown_fields` target deserializes
+    // cleanly only if `#refs#` never appears as a struct field.
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    struct WriteRoot {
+        path: Vec<Point>,
+    }
+    #[derive(Deserialize, Debug, PartialEq)]
+    #[serde(deny_unknown_fields)]
+    struct StrictRoot {
+        path: Vec<Point>,
+    }
+
+    let bytes = mat::to_bytes(&WriteRoot {
+        path: vec![Point { x: 1.0, y: 2.0 }, Point { x: 3.0, y: 4.0 }],
+    })
+    .unwrap();
+
+    let back: StrictRoot = mat::from_bytes(&bytes).expect("no `#refs#` field should leak");
+    assert_eq!(back.path.len(), 2);
+}
+
+#[test]
+fn cell_field_alongside_scalars_roundtrips() {
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    struct Root {
+        name: String,
+        trial: u32,
+        path: Vec<Point>,
+        scale: f64,
+    }
+
+    let root = Root {
+        name: "run1".into(),
+        trial: 7,
+        path: vec![Point { x: 1.0, y: 2.0 }, Point { x: 3.0, y: 4.0 }],
+        scale: 2.5,
+    };
+    assert_eq!(roundtrip(&root), root);
+}
+
+#[test]
+fn self_referential_cell_errors_instead_of_overflowing() {
+    use hdf5_pure::{AttrValue, FileBuilder};
+
+    // Hand-craft a malformed cell whose single object reference points back at
+    // itself. A real `.mat` file never does this, but a hostile one could; the
+    // reader must follow it to a bounded depth and return a typed error, not
+    // recurse until the stack overflows.
+    let mut builder = FileBuilder::new();
+    builder
+        .create_dataset("loop")
+        .with_path_references(&["loop"])
+        .with_shape(&[1, 1])
+        .set_attr("MATLAB_class", AttrValue::String("cell".into()));
+    let bytes = builder.finish().unwrap();
+
+    #[derive(Deserialize, Debug)]
+    struct Any {}
+    let result: Result<Any, _> = mat::from_bytes(&bytes);
+    let err = result.expect_err("a self-referential cell must be rejected");
+    assert!(
+        err.to_string().contains("depth"),
+        "expected a nesting-depth error, got: {err}"
+    );
+}
+
+#[test]
+fn map_of_vec_struct_roundtrips() {
+    // A top-level map whose value is a cell array, deserialized into a
+    // `BTreeMap` — exercises that only the user variable is surfaced (no
+    // `#refs#` key).
+    let mut root: BTreeMap<String, Vec<Point>> = BTreeMap::new();
+    root.insert(
+        "trajectory".into(),
+        vec![Point { x: 0.0, y: 0.0 }, Point { x: 1.0, y: 1.0 }],
+    );
+    let back: BTreeMap<String, Vec<Point>> = roundtrip(&root);
+    assert_eq!(back, root);
+}

--- a/tests/mat_string_read.rs
+++ b/tests/mat_string_read.rs
@@ -1,0 +1,154 @@
+#![cfg(feature = "serde")]
+//! Read-back tests for MATLAB's modern `string` class (MCOS opaque objects).
+//!
+//! With `Options::with_modern_strings()` the serializer writes `String` values
+//! as `mxOPAQUE_CLASS` `string` objects: a `uint32` metadata array on the
+//! variable, a `uint64` saveobj payload under `#refs#`, and a `#subsystem#/MCOS`
+//! `FileWrapper__` store. These tests round-trip such values through the
+//! pure-Rust reader, which resolves the object id against the MCOS store and
+//! decodes the UTF-16 saveobj payload. They use only `hdf5_pure` (no reference C
+//! library), so they run without cmake.
+//!
+//! Validation note: this proves the reader inverts *our own writer's* `string`
+//! layout (which mirrors MATLAB's). Confirming reads of `string` arrays written
+//! by real MATLAB still wants a checked-in MATLAB-produced fixture.
+
+use hdf5_pure::mat::{self, Options};
+use serde::{Deserialize, Serialize};
+
+fn modern_string_roundtrip<T>(value: &T) -> T
+where
+    T: Serialize + serde::de::DeserializeOwned,
+{
+    let bytes = mat::to_bytes_with_options(value, &Options::with_modern_strings()).expect("ser");
+    mat::from_bytes(&bytes).expect("de")
+}
+
+#[test]
+fn scalar_string_field_roundtrips() {
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    struct Root {
+        greeting: String,
+    }
+    let root = Root {
+        greeting: "hello".into(),
+    };
+    assert_eq!(modern_string_roundtrip(&root), root);
+}
+
+#[test]
+fn multiple_string_fields_roundtrip() {
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    struct Root {
+        greeting: String,
+        name: String,
+        empty: String,
+    }
+    let root = Root {
+        greeting: "hello".into(),
+        name: "world!!".into(),
+        empty: String::new(),
+    };
+    assert_eq!(modern_string_roundtrip(&root), root);
+}
+
+#[test]
+fn string_fields_mixed_with_numbers_roundtrip() {
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    struct Root {
+        label: String,
+        trial: u32,
+        samples: Vec<f64>,
+        note: String,
+    }
+    let root = Root {
+        label: "run-1".into(),
+        trial: 7,
+        samples: vec![1.0, 2.0, 3.0],
+        note: "ok".into(),
+    };
+    assert_eq!(modern_string_roundtrip(&root), root);
+}
+
+#[test]
+fn nested_struct_string_fields_roundtrip() {
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    struct Inner {
+        title: String,
+        unit: String,
+    }
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    struct Root {
+        name: String,
+        inner: Inner,
+    }
+    let root = Root {
+        name: "outer".into(),
+        inner: Inner {
+            title: "temperature".into(),
+            unit: "°C".into(),
+        },
+    };
+    assert_eq!(modern_string_roundtrip(&root), root);
+}
+
+#[test]
+fn unicode_and_surrogate_pairs_roundtrip() {
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    struct Root {
+        emoji: String,
+        accents: String,
+        cjk: String,
+    }
+    let root = Root {
+        // Emoji require UTF-16 surrogate pairs; the saveobj packs raw code units.
+        emoji: "🌍🚀😂".into(),
+        accents: "naïve café résumé".into(),
+        cjk: "日本語テスト".into(),
+    };
+    assert_eq!(modern_string_roundtrip(&root), root);
+}
+
+#[test]
+fn vec_of_strings_roundtrips_as_cell_of_string_objects() {
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    struct Root {
+        words: Vec<String>,
+    }
+    // A `Vec<String>` lowers to a cell whose elements are individual `string`
+    // objects; reading resolves each object id against the shared MCOS store.
+    let root = Root {
+        words: vec!["alpha".into(), "beta".into(), "".into(), "δέλτα".into()],
+    };
+    assert_eq!(modern_string_roundtrip(&root), root);
+}
+
+#[test]
+fn unsupported_opaque_class_is_refused_by_name() {
+    use hdf5_pure::mat::MatError;
+    use hdf5_pure::{AttrValue, FileBuilder};
+
+    // Hand-craft an opaque dataset that claims to be `datetime` (decode = 3),
+    // which the reader does not yet decode. It must refuse by name rather than
+    // misread or panic. (The metadata shape mirrors a real opaque parent:
+    // `[MAGIC, ndims=2, 1, 1, object_id=1, class_id=1]`.)
+    let mut builder = FileBuilder::new();
+    builder
+        .create_dataset("t")
+        .with_u32_data(&[0xDD00_0000, 2, 1, 1, 1, 1])
+        .with_shape(&[1, 6])
+        .set_attr("MATLAB_class", AttrValue::String("datetime".into()))
+        .set_attr("MATLAB_object_decode", AttrValue::I32(3));
+    let bytes = builder.finish().unwrap();
+
+    #[derive(Deserialize, Debug)]
+    struct Root {
+        #[allow(dead_code)]
+        t: f64,
+    }
+    let err = mat::from_bytes::<Root>(&bytes).expect_err("datetime is not yet supported");
+    assert!(
+        matches!(err, MatError::UnsupportedMatlabClass(ref c) if c == "datetime"),
+        "expected UnsupportedMatlabClass(\"datetime\"), got: {err}"
+    );
+}


### PR DESCRIPTION
## Summary

Adds read support for MATLAB MCOS object-reference data on the `.mat` deserializer path — the foundation for reading MATLAB's opaque types. Addresses #114 (partial: cell arrays and the modern `string` class; `datetime`/`categorical`/`table`/`containers.Map`/`dictionary` remain follow-up work and are now refused by name rather than misread).

Two increments, both building on one new primitive (HDF5 object-reference resolution):

### 1. Object-reference resolution (foundation)
- New public `Object` enum and `Dataset::dereference` resolve HDF5 `H5R_OBJECT` references to the group or dataset they name (`abs = rel + base_address`, accounting for the MAT userblock).
- New `FormatError::InvalidObjectReference` for null/undefined/dangling references.

### 2. Cell arrays now deserialize
`mat::from_bytes` / `mat::from_file` reconstruct cell arrays, previously refused with `UnsupportedType("cell array")`. This closes a real write/read asymmetry (the crate already wrote cells but couldn't read them back):
- `Vec<Struct>`, ragged `Vec<Vec<T>>`, `Vec<Option<T>>` (with `None` slots restored from the `struct([])` marker), and nested cells round-trip.
- MATLAB's reserved `#refs#` / `#subsystem#` groups are skipped on read.
- A bounded recursion depth turns a cyclic reference into a typed error instead of a stack overflow.

### 3. Modern `string` class now deserializes
- New `src/mat/de/mcos_reader.rs` parses the `#subsystem#/MCOS` `FileWrapper__` store and decodes `string` opaque objects: object id from the parent's `uint32` metadata → saveobj cell → UTF-16 payload → Rust `String`. Values written with `Options::with_modern_strings()` now round-trip.
- Every other MCOS opaque class returns the new typed `MatError::UnsupportedMatlabClass` — a clearer, honest refusal than the old `UnknownClass`.

## Validation
- New pure-Rust tests (run without cmake): `tests/mat_cell_read.rs` (10 — incl. `Option::None`, nested, ragged, a `#refs#`-leak guard, and a cyclic-reference robustness test) and `tests/mat_string_read.rs` (7 — incl. Unicode/surrogate pairs and `Vec<String>`).
- Full suite green, including the existing hdf5-metno C-library crosschecks; clippy clean on `--all-targets`; non-serde build clean.
- An adversarial review of the new reader (correctness / panic-safety / generalization lenses) found no critical or high issues; its one substantive finding — reject a non-`uint64` saveobj cell instead of widening it — is applied.

**Caveat (documented in code + changelog):** both features are validated by round-tripping against the crate's own writer, which mirrors MATLAB byte-for-byte for these structures. Reading opaque data produced by *real MATLAB* (string arrays, and eventually datetime/table) still wants checked-in MATLAB-produced fixtures — flagged honestly rather than claimed, given there's no MATLAB CI here.

## Compatibility
Additive and non-breaking. The new public surface is `Object`, `Dataset::dereference`, `FormatError::InvalidObjectReference`, and `MatError::UnsupportedMatlabClass`.
