### PR TITLE
perf(mat): share cache-tiled transpose and trim read/write allocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Read HDF5 **version-1 and version-2 compound datatypes** correctly: the member layout was misparsed (the v1 dimension block skipped one 4-byte reserved field, and v2 names were left unpadded), so complex data written by MATLAB and older HDF5 writers — including real-MATLAB `datetime` arrays — now decodes instead of failing with a type mismatch ([#114](https://github.com/stephenberry/hdf5-pure/issues/114)).
 - An empty `datetime` or `duration` object stored with no `data` / `millis` property (e.g. a zero-row timetable's row-times) now decodes as empty instead of aborting the whole-file read ([#114](https://github.com/stephenberry/hdf5-pure/issues/114)).
 
+### Performance
+
+- Serializing a MATLAB v7.3 file is faster: the default `mat::to_bytes` write path now shares the cache-tiled column-major transpose (≈8% faster on a 512×512 `f64` matrix) instead of a strided copy, and numeric/field buffers across the read and write paths are pre-sized or filled in a single pass. Reading a numeric array no longer materializes an intermediate boxed-scalar buffer, and a `uint32` array nested under an MCOS object is decoded once instead of twice ([#122](https://github.com/stephenberry/hdf5-pure/pull/122)).
+
 ## [0.17.0] - 2026-06-18
 
 Repack now reproduces three more datatype classes faithfully — non-string variable-length sequences, object-reference datasets, and time datatypes — and the dataset read and write hot paths are several times faster (bulk numeric decode, contiguous-row chunk scatter, compress-once filtered writes). **Breaking:** `Datatype::Time` gained a `byte_order` field, so code matching that variant must account for it; minor bump.

--- a/benches/hot_paths.rs
+++ b/benches/hot_paths.rs
@@ -143,10 +143,64 @@ fn bench_write(c: &mut Criterion) {
     g.finish();
 }
 
+// ---------------------------------------------------------------------------
+// MATLAB v7.3 serde round-trip (write transpose + numeric seq decode)
+// ---------------------------------------------------------------------------
+
+/// Exercise the MAT serde path end to end: serializing a struct holding a large
+/// 2-D matrix (column-major transpose) and large numeric vectors, then reading
+/// it back (per-element sequence decode). This is the path `mat::to_bytes` /
+/// `mat::from_bytes` users actually pay for; the low-level benches above bypass
+/// it. No-op unless the `serde` feature is enabled.
+#[cfg(feature = "serde")]
+fn bench_mat_roundtrip(c: &mut Criterion) {
+    use hdf5_pure::mat::{self, Matrix};
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Serialize, Deserialize)]
+    struct Payload {
+        matrix: Matrix<f64>,
+        samples: Vec<f64>,
+        labels: Vec<i32>,
+    }
+
+    let rows = 512usize;
+    let cols = 512usize;
+    let matrix = Matrix::from_row_major(
+        rows,
+        cols,
+        (0..rows * cols).map(|i| i as f64 * 0.5).collect(),
+    );
+    let samples: Vec<f64> = (0..(1usize << 20)).map(|i| i as f64).collect();
+    let labels: Vec<i32> = (0..(1usize << 20)).map(|i| i as i32).collect();
+    let payload = Payload {
+        matrix,
+        samples,
+        labels,
+    };
+    let bytes = mat::to_bytes(&payload).expect("serialize payload");
+
+    let mut g = c.benchmark_group("mat_roundtrip");
+    g.bench_function("to_bytes", |b| {
+        b.iter(|| black_box(mat::to_bytes(black_box(&payload)).unwrap()))
+    });
+    g.bench_function("from_bytes", |b| {
+        b.iter(|| {
+            let p: Payload = mat::from_bytes(black_box(&bytes)).unwrap();
+            black_box(p)
+        })
+    });
+    g.finish();
+}
+
+#[cfg(not(feature = "serde"))]
+fn bench_mat_roundtrip(_c: &mut Criterion) {}
+
 criterion_group!(
     benches,
     bench_contiguous_decode,
     bench_chunked_assembly,
-    bench_write
+    bench_write,
+    bench_mat_roundtrip
 );
 criterion_main!(benches);

--- a/src/mat/de/mcos_reader.rs
+++ b/src/mat/de/mcos_reader.rs
@@ -784,8 +784,8 @@ fn decode_datetime(
         Some(data) => complex_pairs(data, "datetime `data`")?,
         None => Vec::new(),
     };
-    let millis_utc: Vec<f64> = pairs.iter().map(|&(re, _)| re).collect();
-    let sub_ms: Vec<f64> = pairs.iter().map(|&(_, im)| im).collect();
+    // Split the (real, imag) pairs into parallel vectors in a single pass.
+    let (millis_utc, sub_ms): (Vec<f64>, Vec<f64>) = pairs.into_iter().unzip();
 
     let mut out = vec![
         (

--- a/src/mat/de/reader.rs
+++ b/src/mat/de/reader.rs
@@ -299,6 +299,10 @@ fn read_dataset(
     // `string`/`datetime`/`categorical` column inside a table's `data` cell).
     // The exact-length validation in `parse_opaque_metadata`, plus the
     // reserved `MAGIC` first word, keeps genuine `uint32` data from matching.
+    // Retain the probe's decoded buffer: when the payload turns out to be a
+    // plain uint32 array rather than an object reference, it is reused below
+    // instead of reading (and decompressing) the same dataset a second time.
+    let mut probed_u32: Option<Vec<u32>> = None;
     if in_heap && !is_empty && dtype == DType::U32 {
         if let Some(mcos) = mcos {
             let raw = ds.read_u32().map_err(MatError::Hdf5)?;
@@ -307,6 +311,7 @@ fn read_dataset(
                     return decode_object_ids(mcos, &meta.object_ids, depth);
                 }
             }
+            probed_u32 = Some(raw);
         }
     }
 
@@ -329,6 +334,16 @@ fn read_dataset(
         }
         // Empty numeric/char: produce an empty 1-D vec of the correct tag.
         return Ok(empty_value_for_class(class));
+    }
+
+    // The object-reference probe above already read this uint32 payload. When
+    // the value is a plain uint32 array (the resolved class is `UInt32`, so the
+    // `UInt32` match arm below would take the non-complex `read_numeric` path),
+    // reuse that buffer rather than reading the dataset again.
+    if class == MatClass::UInt32 {
+        if let Some(raw) = probed_u32 {
+            return numeric_value_from_flat(NumVec::U32(raw), &shape);
+        }
     }
 
     match class {
@@ -597,15 +612,33 @@ fn is_complex_dtype(dtype: &DType) -> bool {
 // ---------------------------------------------------------------------------
 
 fn read_numeric(ds: &Dataset<'_>, shape: &[u64], class: MatClass) -> Result<MatValue, MatError> {
-    let (rows, cols, total) = shape_decomposition(shape)?;
+    let (_, _, total) = shape_decomposition(shape)?;
 
     // For a single-element dataset we emit a Scalar of the appropriate class.
     if total == 1 {
         return Ok(MatValue::Scalar(read_scalar(ds, class)?));
     }
 
-    // Read all elements as the MATLAB class's native type.
+    // Read all elements as the MATLAB class's native type, then apply the shape
+    // dispatch shared with the reuse path in `read_dataset`.
     let flat = read_all_elements(ds, class)?;
+    numeric_value_from_flat(flat, shape)
+}
+
+/// Build a numeric [`MatValue`] from an already-decoded column-major flat
+/// vector and the dataset's HDF5 shape. Shared by [`read_numeric`] and the
+/// uint32 object-reference probe reuse path so the two cannot diverge: a single
+/// element becomes a `Scalar`, a 1-D shape a `Vec1D`, and a 2-D shape a
+/// row-major `Matrix` (skipping the no-op transpose when a dimension is 1).
+fn numeric_value_from_flat(flat: NumVec, shape: &[u64]) -> Result<MatValue, MatError> {
+    let (rows, cols, total) = shape_decomposition(shape)?;
+
+    if total == 1 {
+        return flat
+            .get(0)
+            .map(MatValue::Scalar)
+            .ok_or_else(|| MatError::Custom("single-element dataset had no element".into()));
+    }
 
     // A 1-D HDF5 dataset (no recorded cols/rows split) is treated as a flat
     // Vec1D. Files produced by MATLAB/this library are always 2-D, but some

--- a/src/mat/de/value_de.rs
+++ b/src/mat/de/value_de.rs
@@ -602,59 +602,18 @@ fn to_f64(v: MatValue, expected: &'static str) -> Result<f64, MatError> {
 // Vec1D SeqAccess
 // ---------------------------------------------------------------------------
 
+/// `SeqAccess` over a numeric vector. The source `NumVec` is already a
+/// contiguous `Vec<Copy>`, so we walk it with a cursor and build exactly one
+/// `MatValue::Scalar` per element on demand rather than pre-expanding the whole
+/// vector into a `VecDeque<MatValue>` of widened, boxed scalars.
 struct Vec1DSeq {
-    items: VecDeque<MatValue>,
+    vec: NumVec,
+    cursor: usize,
 }
 
 impl Vec1DSeq {
     fn new(v: NumVec) -> Self {
-        let items = match v {
-            NumVec::Bool(vs) => vs
-                .into_iter()
-                .map(|b| MatValue::Scalar(ScalarNum::Bool(b)))
-                .collect(),
-            NumVec::F64(vs) => vs
-                .into_iter()
-                .map(|x| MatValue::Scalar(ScalarNum::F64(x)))
-                .collect(),
-            NumVec::F32(vs) => vs
-                .into_iter()
-                .map(|x| MatValue::Scalar(ScalarNum::F32(x)))
-                .collect(),
-            NumVec::I64(vs) => vs
-                .into_iter()
-                .map(|x| MatValue::Scalar(ScalarNum::I64(x)))
-                .collect(),
-            NumVec::I32(vs) => vs
-                .into_iter()
-                .map(|x| MatValue::Scalar(ScalarNum::I32(x)))
-                .collect(),
-            NumVec::I16(vs) => vs
-                .into_iter()
-                .map(|x| MatValue::Scalar(ScalarNum::I16(x)))
-                .collect(),
-            NumVec::I8(vs) => vs
-                .into_iter()
-                .map(|x| MatValue::Scalar(ScalarNum::I8(x)))
-                .collect(),
-            NumVec::U64(vs) => vs
-                .into_iter()
-                .map(|x| MatValue::Scalar(ScalarNum::U64(x)))
-                .collect(),
-            NumVec::U32(vs) => vs
-                .into_iter()
-                .map(|x| MatValue::Scalar(ScalarNum::U32(x)))
-                .collect(),
-            NumVec::U16(vs) => vs
-                .into_iter()
-                .map(|x| MatValue::Scalar(ScalarNum::U16(x)))
-                .collect(),
-            NumVec::U8(vs) => vs
-                .into_iter()
-                .map(|x| MatValue::Scalar(ScalarNum::U8(x)))
-                .collect(),
-        };
-        Self { items }
+        Self { vec: v, cursor: 0 }
     }
 }
 
@@ -664,13 +623,17 @@ impl<'de> SeqAccess<'de> for Vec1DSeq {
         &mut self,
         seed: T,
     ) -> Result<Option<T::Value>, MatError> {
-        match self.items.pop_front() {
-            Some(v) => seed.deserialize(MatValueDeserializer::new(v)).map(Some),
+        match self.vec.get(self.cursor) {
+            Some(scalar) => {
+                self.cursor += 1;
+                seed.deserialize(MatValueDeserializer::new(MatValue::Scalar(scalar)))
+                    .map(Some)
+            }
             None => Ok(None),
         }
     }
     fn size_hint(&self) -> Option<usize> {
-        Some(self.items.len())
+        Some(self.vec.len() - self.cursor)
     }
 }
 

--- a/src/mat/ser/emit.rs
+++ b/src/mat/ser/emit.rs
@@ -14,6 +14,8 @@ use crate::writer::FileBuilder;
 
 use crate::mat::value::{MatValue, NumVec, ScalarNum, ScalarTag};
 
+use super::transpose::{transpose_pairs, transpose_scalars};
+
 /// Hidden MATLAB conventional group that holds the targets of object
 /// references. Cell-array elements live here, addressed by absolute path.
 const REFS_GROUP: &str = "#refs#";
@@ -138,8 +140,10 @@ fn build_struct_group(
         if matches!(value, MatValue::Omit) {
             continue;
         }
-        live_names.push(fname.clone());
         emit_into_group(&mut group, &fname, value, refs)?;
+        // `emit_into_group` only borrows the name, so move it in afterward
+        // rather than cloning.
+        live_names.push(fname);
     }
     group.set_attr(
         "MATLAB_class",
@@ -376,8 +380,16 @@ fn apply_matrix(
     let shape = [cols as u64, rows as u64];
     match vec {
         NumVec::Bool(row_major) => {
-            let col_major = transpose_scalars(rows, cols, &row_major);
-            let bytes: Vec<u8> = col_major.into_iter().map(u8::from).collect();
+            // Fuse the column-major transpose with the bool->u8 conversion into
+            // a single pass, dropping the intermediate Vec<bool>. Iteration order
+            // and index expression match `transpose_scalars` exactly so the
+            // column-major byte layout is identical.
+            let mut bytes = Vec::with_capacity(rows * cols);
+            for c in 0..cols {
+                for r in 0..rows {
+                    bytes.push(u8::from(row_major[r * cols + c]));
+                }
+            }
             ds.with_u8_data(&bytes).with_shape(&shape);
             set_class(ds, MatClass::Logical);
             set_logical_decode(ds);
@@ -526,26 +538,6 @@ fn set_logical_decode(ds: &mut DatasetBuilder) {
 /// UTF-16 characters rather than a numeric array.
 fn set_char_decode(ds: &mut DatasetBuilder) {
     ds.set_attr("MATLAB_int_decode", AttrValue::I32(2));
-}
-
-fn transpose_scalars<T: Copy>(rows: usize, cols: usize, row_major: &[T]) -> Vec<T> {
-    let mut out = Vec::with_capacity(rows * cols);
-    for c in 0..cols {
-        for r in 0..rows {
-            out.push(row_major[r * cols + c]);
-        }
-    }
-    out
-}
-
-fn transpose_pairs<T: Copy>(rows: usize, cols: usize, row_major: &[(T, T)]) -> Vec<(T, T)> {
-    let mut out = Vec::with_capacity(rows * cols);
-    for c in 0..cols {
-        for r in 0..rows {
-            out.push(row_major[r * cols + c]);
-        }
-    }
-    out
 }
 
 // Silence the "unused import" on the no-test build.

--- a/src/mat/ser/emit_with_builder.rs
+++ b/src/mat/ser/emit_with_builder.rs
@@ -10,6 +10,8 @@ use crate::mat::error::MatError;
 use crate::mat::options::{Options, StringClass};
 use crate::mat::value::{MatValue, NumVec, ScalarNum, ScalarTag};
 
+use super::transpose::{transpose_pairs, transpose_scalars};
+
 /// Walk top-level fields and emit through a `MatBuilder`.
 pub(crate) fn emit_file_with_options(
     fields: Vec<(String, MatValue)>,
@@ -520,51 +522,4 @@ fn scalar_class(tag: ScalarTag) -> MatClass {
         ScalarTag::U16 => MatClass::UInt16,
         ScalarTag::U8 => MatClass::UInt8,
     }
-}
-
-/// Transpose a row-major matrix of shape `[rows, cols]` into column-major.
-/// Tiled to keep both reads and writes cache-resident on large matrices.
-fn transpose_2d<T: Copy>(rows: usize, cols: usize, row_major: &[T]) -> Vec<T> {
-    debug_assert_eq!(row_major.len(), rows * cols);
-    let n = rows * cols;
-    let mut out: Vec<T> = Vec::with_capacity(n);
-    if n == 0 {
-        return out;
-    }
-
-    const BLK: usize = 32;
-    let dst = out.as_mut_ptr();
-    for cb in (0..cols).step_by(BLK) {
-        let c_end = (cb + BLK).min(cols);
-        for rb in (0..rows).step_by(BLK) {
-            let r_end = (rb + BLK).min(rows);
-            for r in rb..r_end {
-                let src_row_base = r * cols;
-                for c in cb..c_end {
-                    let value = row_major[src_row_base + c];
-                    // SAFETY: c < cols and r < rows so c*rows + r < cols*rows = n,
-                    // and out has capacity n.
-                    unsafe {
-                        dst.add(c * rows + r).write(value);
-                    }
-                }
-            }
-        }
-    }
-    // SAFETY: every index 0..n was written above (each (r, c) maps to a unique
-    // c * rows + r in 0..n).
-    unsafe {
-        out.set_len(n);
-    }
-    out
-}
-
-#[inline]
-fn transpose_pairs<T: Copy>(rows: usize, cols: usize, row_major: &[(T, T)]) -> Vec<(T, T)> {
-    transpose_2d(rows, cols, row_major)
-}
-
-#[inline]
-fn transpose_scalars<T: Copy>(rows: usize, cols: usize, row_major: &[T]) -> Vec<T> {
-    transpose_2d(rows, cols, row_major)
 }

--- a/src/mat/ser/mod.rs
+++ b/src/mat/ser/mod.rs
@@ -3,6 +3,7 @@
 mod emit;
 mod emit_with_builder;
 mod root;
+mod transpose;
 mod value_ser;
 
 pub use root::{to_bytes, to_bytes_with_options};

--- a/src/mat/ser/transpose.rs
+++ b/src/mat/ser/transpose.rs
@@ -1,0 +1,61 @@
+//! Row-major to column-major transpose shared by both write paths.
+//!
+//! MATLAB stores 2-D arrays column-major; the serializer holds them row-major.
+//! Both the default (`emit`) and options (`emit_with_builder`) write paths need
+//! the same transpose, so it lives here once. The implementation is cache-tiled
+//! (32x32 blocks) to keep both the strided source reads and the destination
+//! writes cache-resident on large matrices.
+
+/// Transpose a row-major matrix of shape `[rows, cols]` into column-major.
+///
+/// Element `(r, c)` at `row_major[r * cols + c]` lands at `out[c * rows + r]`.
+fn transpose_2d<T: Copy>(rows: usize, cols: usize, row_major: &[T]) -> Vec<T> {
+    debug_assert_eq!(row_major.len(), rows * cols);
+    let n = rows * cols;
+    let mut out: Vec<T> = Vec::with_capacity(n);
+    if n == 0 {
+        return out;
+    }
+
+    const BLK: usize = 32;
+    let dst = out.as_mut_ptr();
+    for cb in (0..cols).step_by(BLK) {
+        let c_end = (cb + BLK).min(cols);
+        for rb in (0..rows).step_by(BLK) {
+            let r_end = (rb + BLK).min(rows);
+            for r in rb..r_end {
+                let src_row_base = r * cols;
+                for c in cb..c_end {
+                    let value = row_major[src_row_base + c];
+                    // SAFETY: c < cols and r < rows so c*rows + r < cols*rows = n,
+                    // and out has capacity n.
+                    unsafe {
+                        dst.add(c * rows + r).write(value);
+                    }
+                }
+            }
+        }
+    }
+    // SAFETY: every index 0..n was written above (each (r, c) maps to a unique
+    // c * rows + r in 0..n).
+    unsafe {
+        out.set_len(n);
+    }
+    out
+}
+
+/// Transpose a row-major matrix of scalars into column-major order.
+#[inline]
+pub(super) fn transpose_scalars<T: Copy>(rows: usize, cols: usize, row_major: &[T]) -> Vec<T> {
+    transpose_2d(rows, cols, row_major)
+}
+
+/// Transpose a row-major matrix of `(re, im)` pairs into column-major order.
+#[inline]
+pub(super) fn transpose_pairs<T: Copy>(
+    rows: usize,
+    cols: usize,
+    row_major: &[(T, T)],
+) -> Vec<(T, T)> {
+    transpose_2d(rows, cols, row_major)
+}

--- a/src/mat/ser/value_ser.rs
+++ b/src/mat/ser/value_ser.rs
@@ -170,7 +170,7 @@ impl Serializer for ValueSerializer {
         Ok(MapSer::new())
     }
 
-    fn serialize_struct(self, name: &'static str, _len: usize) -> Result<StructSer, MatError> {
+    fn serialize_struct(self, name: &'static str, len: usize) -> Result<StructSer, MatError> {
         Ok(match name {
             MATRIX_SENTINEL => StructSer::Matrix(MatrixFields::default(), MatrixKind::Numeric),
             MATRIX_COMPLEX64_SENTINEL => {
@@ -181,7 +181,9 @@ impl Serializer for ValueSerializer {
             }
             COMPLEX64_SENTINEL => StructSer::Complex64(ComplexFields::default()),
             COMPLEX32_SENTINEL => StructSer::Complex32(ComplexFields::default()),
-            _ => StructSer::Plain(PlainStructFields::default()),
+            // serde supplies the exact field count, so the field Vec can be
+            // sized once instead of growing by reallocation.
+            _ => StructSer::Plain(PlainStructFields::with_capacity(len)),
         })
     }
 
@@ -298,7 +300,7 @@ fn try_unify_homogeneous(elements: Vec<MatValue>) -> Result<MatValue, Vec<MatVal
             .iter()
             .all(|e| matches!(e, MatValue::Scalar(s) if s.tag() == first_tag))
         {
-            let mut vec = NumVec::empty_with_tag(first_tag);
+            let mut vec = NumVec::with_capacity_for_tag(first_tag, elements.len());
             for e in elements {
                 let MatValue::Scalar(s) = e else {
                     unreachable!()
@@ -317,7 +319,7 @@ fn try_unify_homogeneous(elements: Vec<MatValue>) -> Result<MatValue, Vec<MatVal
             |e| matches!(e, MatValue::Vec1D(v) if v.tag() == first_tag && v.len() == first_len),
         ) {
             let rows = elements.len();
-            let mut flat = NumVec::empty_with_tag(first_tag);
+            let mut flat = NumVec::with_capacity_for_tag(first_tag, rows * first_len);
             for e in elements {
                 let MatValue::Vec1D(v) = e else {
                     unreachable!()
@@ -500,6 +502,14 @@ pub(crate) struct ComplexFields<T> {
 #[derive(Default)]
 pub(crate) struct PlainStructFields {
     fields: Vec<(String, MatValue)>,
+}
+
+impl PlainStructFields {
+    fn with_capacity(n: usize) -> Self {
+        Self {
+            fields: Vec::with_capacity(n),
+        }
+    }
 }
 
 impl SerializeStruct for StructSer {

--- a/src/mat/utf16.rs
+++ b/src/mat/utf16.rs
@@ -11,7 +11,12 @@ use super::error::MatError;
 /// The caller can then pass the slice to `with_u16_data` to build a MATLAB
 /// char dataset.
 pub fn encode_utf16(s: &str) -> Vec<u16> {
-    s.encode_utf16().collect()
+    // The UTF-8 byte length is an exact upper bound on the UTF-16 unit count
+    // (every byte yields at most one code unit), so a single reservation sizes
+    // the buffer without ever over-allocating and `extend` never reallocates.
+    let mut units = Vec::with_capacity(s.len());
+    units.extend(s.encode_utf16());
+    units
 }
 
 /// Decode a slice of UTF-16 code units (as `u16`) into a Rust `String`.

--- a/src/mat/value.rs
+++ b/src/mat/value.rs
@@ -89,6 +89,25 @@ impl NumVec {
         self.len() == 0
     }
 
+    /// Return the scalar at `index`, or `None` if out of bounds. Lets callers
+    /// walk a numeric vector element-by-element without materializing a
+    /// `Vec<MatValue>` of boxed scalars.
+    pub(crate) fn get(&self, index: usize) -> Option<ScalarNum> {
+        match self {
+            NumVec::Bool(v) => v.get(index).copied().map(ScalarNum::Bool),
+            NumVec::F64(v) => v.get(index).copied().map(ScalarNum::F64),
+            NumVec::F32(v) => v.get(index).copied().map(ScalarNum::F32),
+            NumVec::I64(v) => v.get(index).copied().map(ScalarNum::I64),
+            NumVec::I32(v) => v.get(index).copied().map(ScalarNum::I32),
+            NumVec::I16(v) => v.get(index).copied().map(ScalarNum::I16),
+            NumVec::I8(v) => v.get(index).copied().map(ScalarNum::I8),
+            NumVec::U64(v) => v.get(index).copied().map(ScalarNum::U64),
+            NumVec::U32(v) => v.get(index).copied().map(ScalarNum::U32),
+            NumVec::U16(v) => v.get(index).copied().map(ScalarNum::U16),
+            NumVec::U8(v) => v.get(index).copied().map(ScalarNum::U8),
+        }
+    }
+
     pub(crate) fn tag(&self) -> ScalarTag {
         match self {
             NumVec::Bool(_) => ScalarTag::Bool,
@@ -118,6 +137,25 @@ impl NumVec {
             ScalarTag::U32 => NumVec::U32(Vec::new()),
             ScalarTag::U16 => NumVec::U16(Vec::new()),
             ScalarTag::U8 => NumVec::U8(Vec::new()),
+        }
+    }
+
+    /// Like [`empty_with_tag`](Self::empty_with_tag) but reserves `cap` elements
+    /// up front, so a known-size fill via [`push`](Self::push) /
+    /// [`extend`](Self::extend) never reallocates.
+    pub(crate) fn with_capacity_for_tag(tag: ScalarTag, cap: usize) -> Self {
+        match tag {
+            ScalarTag::Bool => NumVec::Bool(Vec::with_capacity(cap)),
+            ScalarTag::F64 => NumVec::F64(Vec::with_capacity(cap)),
+            ScalarTag::F32 => NumVec::F32(Vec::with_capacity(cap)),
+            ScalarTag::I64 => NumVec::I64(Vec::with_capacity(cap)),
+            ScalarTag::I32 => NumVec::I32(Vec::with_capacity(cap)),
+            ScalarTag::I16 => NumVec::I16(Vec::with_capacity(cap)),
+            ScalarTag::I8 => NumVec::I8(Vec::with_capacity(cap)),
+            ScalarTag::U64 => NumVec::U64(Vec::with_capacity(cap)),
+            ScalarTag::U32 => NumVec::U32(Vec::with_capacity(cap)),
+            ScalarTag::U16 => NumVec::U16(Vec::with_capacity(cap)),
+            ScalarTag::U8 => NumVec::U8(Vec::with_capacity(cap)),
         }
     }
 


### PR DESCRIPTION
A behavior-preserving performance optimization pass over the MATLAB v7.3 read/write code. No public API or observable output changes; every win was adversarially verified and the full test suite, `cargo fmt`, `clippy --all-targets`, and the i686 narrowing-cast gate all pass.

## Write path
- **Shared cache-tiled transpose** (`src/mat/ser/transpose.rs`, new). The default `mat::to_bytes` path used a naive strided transpose while the options path already had a 32×32-tiled one; both now import a single shared implementation and the strided copy is deleted. **≈8% faster `to_bytes`** on a 512×512 `f64` matrix (well outside the ±2% cross-run noise floor).
- Reserve exact capacity when unifying `Vec<Vec<T>>` → `Matrix` and scalars → `Vec1D` (new `NumVec::with_capacity_for_tag`); size the plain-struct field `Vec` from serde's `len`; move struct field names instead of cloning; fuse the bool-matrix transpose + `bool→u8` into one pass; pre-size `encode_utf16`.

## Read path
- `Vec1DSeq` now walks the `NumVec` with a cursor (new `NumVec::get`), building one scalar on demand instead of pre-expanding every element into a `VecDeque<MatValue>` — drops a large intermediate boxed-scalar buffer on numeric reads (wall-clock neutral, peak-memory win).
- Reuse the MCOS object-reference probe's decoded `uint32` buffer when the value is a plain `uint32` array, via a shared `numeric_value_from_flat` helper so `read_numeric` and the reuse path cannot diverge (no second read/decode of nested uint32 arrays).
- Split `datetime` `(re, im)` pairs in a single `unzip` pass.

## Verification
- Full test suite green (555-test lib suite + real-MATLAB fixture reads), `fmt`, `clippy --all-targets`, i686 narrowing-cast gate.
- Added a serde-gated MAT round-trip benchmark to `benches/hot_paths.rs` (the serde path previously had no bench coverage); before/after measured by stashing the source changes.

Found via a multi-agent profiling + adversarial-verification pass; 4 additional candidates were rejected as premature micro-optimizations.