### PR TITLE
Userblock (.mat) in-place editing (#104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
-- Reading a **chunked dataset from a file with a userblock** (non-zero base address) now works: the reader applied the base address only to contiguous data, so a chunked dataset's index and chunk data were read at the wrong offset (e.g. "corrupt deflate stream"). Base handling is now applied uniformly to every layout, and repack reads such chunks correctly too ([#104](https://github.com/stephenberry/hdf5-pure/issues/104)).
+- Reading and repacking a **chunked dataset from a file with a userblock** (non-zero base address) now works; previously the base address was applied only to contiguous data, so chunked reads from such a file failed ([#104](https://github.com/stephenberry/hdf5-pure/issues/104)).
 
 ## [0.18.0] - 2026-06-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Reading a **chunked dataset from a file with a userblock** (non-zero base address) now works: the reader applied the base address only to contiguous data, so a chunked dataset's index and chunk data were read at the wrong offset (e.g. "corrupt deflate stream"). Base handling is now applied uniformly to every layout, and repack reads such chunks correctly too ([#104](https://github.com/stephenberry/hdf5-pure/issues/104)).
+
 ## [0.18.0] - 2026-06-20
 
 Broad MATLAB v7.3 read support for MCOS opaque types — cell arrays, the modern `string` class, `datetime` / `duration` / `categorical`, `table` / `timetable`, enumeration arrays, and `containers.Map`, including objects nested inside structs, cells, and table columns, all resolved through the file's `#subsystem#`/MCOS store. Also adds in-place overwrite and copy of chunked & filtered datasets in `EditSession`, a faster MAT write path, and two compound-datatype read fixes. **Breaking:** `MatError` is now `#[non_exhaustive]`; minor bump.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
-- `EditSession` now opens and edits files that carry a **userblock** (non-zero base address), such as MATLAB v7.3 `.mat` files: it reads and writes addresses relative to the base and preserves the userblock bytes verbatim. This first slice covers same-length value overwrites plus additions of contiguous datasets, groups, and compact attributes; chunked additions/overwrites, deletions, copies, and relocating overwrites on a userblock file are still refused ([#104](https://github.com/stephenberry/hdf5-pure/issues/104)).
+- `EditSession` now opens and edits files that carry a **userblock** (non-zero base address), such as MATLAB v7.3 `.mat` files: it reads and writes addresses relative to the base and preserves the userblock bytes verbatim. Supported edits include contiguous value overwrites, additions of contiguous and chunked/filtered datasets, in-place and relocating overwrites of chunked datasets (with the old chunk storage reclaimed), group creation, and compact attributes; deletions, copies, and resizing overwrites of contiguous datasets on a userblock file are still refused ([#104](https://github.com/stephenberry/hdf5-pure/issues/104)).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- `EditSession` now opens and edits files that carry a **userblock** (non-zero base address), such as MATLAB v7.3 `.mat` files: it reads and writes addresses relative to the base and preserves the userblock bytes verbatim. This first slice covers same-length value overwrites plus additions of contiguous datasets, groups, and compact attributes; chunked additions/overwrites, deletions, copies, and relocating overwrites on a userblock file are still refused ([#104](https://github.com/stephenberry/hdf5-pure/issues/104)).
+
 ### Fixed
 
 - Reading a **chunked dataset from a file with a userblock** (non-zero base address) now works: the reader applied the base address only to contiguous data, so a chunked dataset's index and chunk data were read at the wrong offset (e.g. "corrupt deflate stream"). Base handling is now applied uniformly to every layout, and repack reads such chunks correctly too ([#104](https://github.com/stephenberry/hdf5-pure/issues/104)).

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -61,8 +61,13 @@
 //! refuses with [`Error::EditUnsupported`] any case it cannot reproduce
 //! faithfully. Requirements:
 //!
-//! - The file uses 8-byte offsets/lengths and has **no** userblock (base
-//!   address 0). Any superblock version (0–3) is accepted: a version 0/1
+//! - The file uses 8-byte offsets/lengths. A **userblock** (non-zero base
+//!   address, as every MATLAB v7.3 `.mat` file has) is supported for a first
+//!   slice of edits: same-length value overwrites and additions of contiguous
+//!   datasets, groups, and compact attributes, with the userblock bytes
+//!   preserved verbatim. On a userblock file, chunked/filtered additions,
+//!   chunked or relocating overwrites, deletions, copies, and free-space reuse
+//!   are still refused. Any superblock version (0–3) is accepted: a version 0/1
 //!   (symbol-table) file is edited by converting each group on the edited path
 //!   to the latest format and repointing the superblock's root symbol-table
 //!   entry.
@@ -214,8 +219,11 @@ pub struct EditSession {
     data: Vec<u8>,
     /// Absolute offset of the superblock signature in the file.
     sb_sig_off: usize,
-    /// Parsed superblock. Addresses are as stored on disk (relative to the base
-    /// address, which this editor requires to be 0).
+    /// Parsed superblock. On-disk addresses are stored relative to `base_address`;
+    /// the in-memory `root_group_address` is normalized to an absolute file offset
+    /// on open and converted back to a base-relative address when serialized on
+    /// commit. `base_address` equals the superblock's file location (`sb_sig_off`):
+    /// 0 for a plain file, the userblock size for one with a userblock.
     superblock: Superblock,
     /// Datasets staged by `create_dataset`, as (parent group path, builder).
     pending_datasets: Vec<(PathKey, DatasetBuilder)>,
@@ -301,7 +309,7 @@ impl EditSession {
         handle.read_to_end(&mut data).map_err(Error::Io)?;
 
         let sb_sig_off = signature::find_signature(&data)?;
-        let superblock = Superblock::parse(&data, sb_sig_off)?;
+        let mut superblock = Superblock::parse(&data, sb_sig_off)?;
 
         if superblock.version > 3 {
             return Err(Error::EditUnsupported("unsupported superblock version"));
@@ -311,11 +319,25 @@ impl EditSession {
                 "only 8-byte offsets and lengths are supported for in-place editing",
             ));
         }
-        if superblock.base_address != 0 {
+        // A userblock shifts the whole HDF5 image forward by `base_address`: the
+        // superblock sits at the base address and every stored address is relative
+        // to it (the end-of-file address is the sole absolute field). The editor
+        // supports this by reading at `stored + base` and writing back
+        // `file_offset - base`. Only the canonical layout — superblock located
+        // exactly at the base address (e.g. a MATLAB v7.3 `.mat` file's 512-byte
+        // userblock) — is accepted; a base address that disagrees with the
+        // superblock's location is a relocated or malformed file we will not rewrite.
+        if superblock.base_address != sb_sig_off as u64 {
             return Err(Error::EditUnsupported(
-                "files with a userblock (non-zero base address) are not editable in place yet",
+                "a file whose superblock is not located at its base address is not editable in place",
             ));
         }
+        // Normalize the root group address to an absolute file offset, exactly as
+        // the reader does (`reader::parse_superblock`), so `resolve_path_any` and
+        // the link-graph walk index `self.data` correctly. It is converted back to a
+        // stored (base-relative) address only when the superblock is serialized on
+        // commit.
+        superblock.root_group_address += superblock.base_address;
 
         let mut session = Self {
             handle,
@@ -348,6 +370,15 @@ impl EditSession {
     fn load_persisted_free_space(&mut self) {
         if self.superblock.version < 2 {
             return; // no superblock extension exists before v2
+        }
+        // Free-space reuse and persistence are not yet base-address aware: the
+        // persisted section addresses (and the extension/manager block walk below)
+        // are read as absolute, so on a userblock file they would seed `self.free`
+        // with wrong regions that `alloc_or_append` could later hand out into live
+        // data. Leave persistence off for such a file — the on-disk managers stay
+        // untouched and valid, this session simply appends rather than reusing.
+        if self.superblock.base_address != 0 {
+            return;
         }
         let Some(ext_rel) = self.superblock.superblock_extension_address else {
             return;
@@ -700,6 +731,30 @@ impl EditSession {
             return Ok(());
         }
 
+        // On a file with a userblock, stored addresses are relative to this base
+        // and the editor converts at every disk boundary (read `stored + base`,
+        // write `file_offset - base`). This first slice of userblock support covers
+        // same-length and relocating value overwrites of contiguous datasets,
+        // additions of contiguous datasets, group creation, and compact group
+        // attributes. Operations whose address rewriting is not yet base-aware are
+        // refused up front (a clean refusal, never a partial/corrupting edit):
+        // object copies, deletions, relocating overwrites, and chunked/filtered
+        // additions; chunked overwrites are refused in `prepare_write`.
+        let base = self.superblock.base_address;
+        if base != 0 {
+            if !self.pending_copies.is_empty() || !self.pending_cross_copies.is_empty() {
+                return Err(Error::EditUnsupported(
+                    "copying objects within or into a file with a userblock is not supported \
+                     in place yet",
+                ));
+            }
+            if !self.pending_deletes.is_empty() {
+                return Err(Error::EditUnsupported(
+                    "deleting objects from a file with a userblock is not supported in place yet",
+                ));
+            }
+        }
+
         // --- Preflight value overwrites (`write_dataset`) before any write, under
         // the same all-or-nothing contract as additions. Each is resolved,
         // validated (datatype and shape must match the on-disk dataset exactly),
@@ -738,10 +793,18 @@ impl EditSession {
             let addr = usize::try_from(addr)
                 .map_err(|_| Error::EditUnsupported("dataset address exceeds this platform"))?;
             let fd = flatten_dataset(db)?;
-            match Self::prepare_write(&self.data, addr, &fd)? {
+            match Self::prepare_write(&self.data, addr, &fd, base)? {
                 WritePlan::InPlace { data_addr, raw } => inplace_writes.push((data_addr, raw)),
                 WritePlan::InPlaceChunks { writes } => inplace_writes.extend(writes),
                 WritePlan::Moving(mw) => {
+                    // A relocating overwrite rewrites the dataset's header and data
+                    // address; that path is not yet base-aware on a userblock file.
+                    if base != 0 {
+                        return Err(Error::EditUnsupported(
+                            "overwriting a dataset that resizes or relocates its header is not \
+                             supported on a file with a userblock yet",
+                        ));
+                    }
                     // A relocating overwrite is safe only when this is the
                     // dataset's sole hard link. Compute the link graph once.
                     let counts = incoming_links
@@ -1045,12 +1108,23 @@ impl EditSession {
         // root is repointed — still are.
         deleted_addrs.sort_unstable();
         deleted_addrs.dedup();
-        if let Some(incoming) = self.count_incoming_hard_links() {
-            for &a in &deleted_addrs {
-                self.collect_free_spans(a, 0, &incoming, &mut to_free);
+        if !deleted_addrs.is_empty() {
+            if let Some(incoming) = self.count_incoming_hard_links() {
+                for &a in &deleted_addrs {
+                    self.collect_free_spans(a, 0, &incoming, &mut to_free);
+                }
             }
         }
+        // Reclamation of vacated bytes is gated to base-0 files in this slice: the
+        // span enumerators (`oh_chunk_spans`/`collect_free_spans`/`chunked_storage_spans`)
+        // index the file with base-relative addresses and are not yet base-aware, so
+        // on a userblock file the superseded headers are left as harmless dead space
+        // rather than risk freeing a live region. (Deletes and relocating overwrites
+        // — the other reclamation sources — are refused on userblock files above.)
         for &a in &superseded_addrs {
+            if base != 0 {
+                break;
+            }
             if let Ok(spans) = self.oh_chunk_spans(a) {
                 to_free.extend(spans);
             }
@@ -1132,42 +1206,56 @@ impl EditSession {
             }
 
             // Write each staged source subtree and link its root into this group.
+            // Link targets are stored relative to the base address (copies are
+            // refused on userblock files, so `base` is 0 here, but keep the
+            // conversion explicit and uniform).
             for (leaf, tree) in copies {
                 let root = self.write_copy_subtree(&tree)?;
-                region.extend_from_slice(&encode_link_message(&leaf, root));
+                region.extend_from_slice(&encode_link_message(&leaf, root - base));
             }
 
-            // Datasets directly under this group.
+            // Datasets directly under this group. Appended addresses are absolute
+            // file offsets; the contiguous data-layout address and the parent link
+            // target are stored relative to the base address (`- base`).
             for fd in flat.remove(key).into_iter().flatten() {
                 let oh = if fd.chunk_options.is_chunked() || fd.maxshape.is_some() {
+                    if base != 0 {
+                        return Err(Error::EditUnsupported(
+                            "adding a chunked, filtered, or resizable dataset to a file with a \
+                             userblock is not supported in place yet",
+                        ));
+                    }
                     self.build_chunked_dataset(&fd)?
                 } else {
                     let data_addr = self.alloc_or_append(&fd.raw)?;
                     build_dataset_oh(
                         &fd.dt,
                         &fd.ds,
-                        data_addr,
+                        data_addr - base,
                         fd.raw.len() as u64,
                         &fd.attrs,
                         None,
                     )
                 };
                 let oh_addr = self.alloc_or_append(&oh)?;
-                region.extend_from_slice(&encode_link_message(&fd.name, oh_addr));
+                region.extend_from_slice(&encode_link_message(&fd.name, oh_addr - base));
             }
 
             // Relocating value overwrites under this group: write the new data and
             // rewritten header, then patch this group's existing link to it.
+            // (Relocating overwrites are refused on userblock files, so `base` is 0
+            // here.)
             for (leaf, mw) in &writes {
                 let new_oh = self.write_moving(mw)?;
-                patch_link_target(&mut region, leaf, new_oh)?;
+                patch_link_target(&mut region, leaf, new_oh - base)?;
             }
 
             // Wire links to dirty child groups (new → add a link; existing →
-            // patch the existing link to the child's new address).
+            // patch the existing link to the child's new address). Link targets are
+            // stored relative to the base address.
             for child in children.get(key).into_iter().flatten() {
                 let child_name = child.last().unwrap();
-                let child_addr = new_addr[child];
+                let child_addr = new_addr[child] - base;
                 if nodes[child].is_new {
                     region.extend_from_slice(&encode_link_message(child_name, child_addr));
                 } else {
@@ -1223,12 +1311,15 @@ impl EditSession {
         let new_eof = trunc_to.unwrap_or(cur_eof);
 
         self.handle.sync_all().map_err(Error::Io)?;
+        // The root address is stored relative to the base address; the end-of-file
+        // address is absolute. After writing the relative root to disk, keep the
+        // in-memory `root_group_address` absolute (the open-time convention).
         if self.superblock.version >= 2 {
             // Build the new superblock off a clone and adopt it only once the
             // write succeeds, so a failed write does not desync the in-memory
             // state. The v2/v3 superblock carries its own checksum.
             let mut new_sb = self.superblock.clone();
-            new_sb.root_group_address = new_root;
+            new_sb.root_group_address = new_root - base;
             new_sb.eof_address = new_eof;
             // Clear any write/SWMR consistency flag rather than re-emitting one
             // the source file carried (e.g. left set by a crashed SWMR writer):
@@ -1238,9 +1329,10 @@ impl EditSession {
             let sb_bytes = new_sb.serialize();
             self.write_at(self.sb_sig_off, &sb_bytes)?;
             self.handle.sync_all().map_err(Error::Io)?;
+            new_sb.root_group_address = new_root;
             self.superblock = new_sb;
         } else {
-            self.repoint_v0v1_root(new_root, new_eof)?;
+            self.repoint_v0v1_root(new_root - base, new_eof)?;
             self.handle.sync_all().map_err(Error::Io)?;
             self.superblock.root_group_address = new_root;
             self.superblock.eof_address = new_eof;
@@ -1423,7 +1515,7 @@ impl EditSession {
         ext_addr: usize,
         info: &FileSpaceInfo,
     ) -> Result<Vec<u8>, Error> {
-        let region = Self::gather_oh_messages(&self.data, ext_addr)?;
+        let region = Self::gather_oh_messages(&self.data, ext_addr, self.superblock.base_address)?;
         let new_body = info.serialize();
         // The message body is the fixed-size File Space Info record (≤ 125 bytes),
         // so it always fits the u16 size field; `try_from` keeps this off the
@@ -1531,7 +1623,7 @@ impl EditSession {
     /// editor rebuilds headers. The chunk-0 prefix is validated by
     /// [`oh_region`]; each continuation block must be a well-formed `OCHK` block
     /// within the file.
-    fn gather_oh_messages(d: &[u8], addr: usize) -> Result<Vec<u8>, Error> {
+    fn gather_oh_messages(d: &[u8], addr: usize, base: u64) -> Result<Vec<u8>, Error> {
         let (rs, re) = Self::oh_region(d, addr)?;
         let mut out = Vec::new();
         // Worklist of (message-region start, end) per chunk, chunk 0 first.
@@ -1555,6 +1647,11 @@ impl EditSession {
                     }
                     let off = u64::from_le_bytes(d[body..body + 8].try_into().unwrap());
                     let len = u64::from_le_bytes(d[body + 8..body + 16].try_into().unwrap());
+                    // The continuation block address is stored relative to the base
+                    // address; convert to an absolute file offset to index `d`.
+                    let off = off.checked_add(base).ok_or(Error::EditUnsupported(
+                        "continuation address overflow",
+                    ))?;
                     let off = usize::try_from(off).map_err(|_| {
                         Error::EditUnsupported("continuation address exceeds this platform")
                     })?;
@@ -1607,8 +1704,9 @@ impl EditSession {
         let mut region = fresh_group_region();
         let mut link_names = Vec::with_capacity(entries.len());
         for e in &entries {
-            // Group-entry addresses are stored relative to the base address (0
-            // here), matching how link targets are stored.
+            // Group-entry addresses are already stored relative to the base address,
+            // matching how `encode_link_message` stores link targets — so they are
+            // re-emitted verbatim, no base conversion needed.
             region.extend_from_slice(&encode_link_message(&e.name, e.object_header_address));
             link_names.push(e.name.clone());
         }
@@ -1653,7 +1751,7 @@ impl EditSession {
         if self.data.len() < addr + 4 || self.data[addr..addr + 4] != *b"OHDR" {
             return self.reconstruct_v1_group(addr);
         }
-        let mut region = Self::gather_oh_messages(&self.data, addr)?;
+        let mut region = Self::gather_oh_messages(&self.data, addr, self.superblock.base_address)?;
         let mut p = 0;
         let mut has_link_info = false;
         let mut link_names = Vec::new();
@@ -1718,7 +1816,7 @@ impl EditSession {
     /// this engine cannot enumerate — a version-2 B-tree — is refused too). A
     /// datatype or shape that differs from the on-disk dataset's is likewise
     /// refused — this is a value overwrite, not a reshape or retype.
-    fn prepare_write(d: &[u8], addr: usize, fd: &FlatDataset) -> Result<WritePlan, Error> {
+    fn prepare_write(d: &[u8], addr: usize, fd: &FlatDataset, base: u64) -> Result<WritePlan, Error> {
         // A value overwrite never introduces chunking, filters, or an extensible
         // shape: those would change the storage layout, not just the bytes.
         if fd.chunk_options.is_chunked() || fd.maxshape.is_some() {
@@ -1740,7 +1838,7 @@ impl EditSession {
             ));
         }
 
-        let region = Self::gather_oh_messages(d, addr)?;
+        let region = Self::gather_oh_messages(d, addr, base)?;
 
         // Locate the datatype, dataspace, and data-layout messages, and detect a
         // filter pipeline (filtered storage is always chunked, never contiguous).
@@ -1832,9 +1930,13 @@ impl EditSession {
                 let data_size = u64::from_le_bytes(region[lb + 10..lb + 18].try_into().unwrap());
 
                 // Same length and a defined, in-bounds data block: overwrite the
-                // bytes straight in place. No header rewrite, no relink.
+                // bytes straight in place. No header rewrite, no relink. The stored
+                // address is base-relative; the in-place write targets the absolute
+                // file offset `data_addr + base`.
                 if data_addr != UNDEF && data_size == fd.raw.len() as u64 {
-                    if let Ok(start) = usize::try_from(data_addr) {
+                    if let Some(start) =
+                        data_addr.checked_add(base).and_then(|a| usize::try_from(a).ok())
+                    {
                         if start
                             .checked_add(fd.raw.len())
                             .is_some_and(|e| e <= d.len())
@@ -1848,9 +1950,11 @@ impl EditSession {
                 }
 
                 // Length differs or the block was undefined/out of bounds: the new
-                // data goes elsewhere and the old extent (if any) is freed.
+                // data goes elsewhere and the old extent (if any) is freed. The
+                // freed extent is recorded as an absolute file offset (`+ base`) to
+                // match the session free list.
                 let old_extent = if data_addr != UNDEF && data_size > 0 {
-                    Some((data_addr, data_size))
+                    Some((data_addr + base, data_size))
                 } else {
                     None
                 };
@@ -1868,6 +1972,15 @@ impl EditSession {
             // builder carries none — chunked/filtered/extensible builders are
             // refused at the top of this function as "not a value overwrite").
             2 => {
+                // Chunked overwrite (in-place or relocating) walks and rewrites
+                // chunk-index and chunk addresses, which are not yet base-aware on a
+                // userblock file; refuse rather than mis-address the chunk storage.
+                if base != 0 {
+                    return Err(Error::EditUnsupported(
+                        "overwriting a chunked dataset on a file with a userblock is not \
+                         supported in place yet",
+                    ));
+                }
                 let dl =
                     DataLayout::parse(&region[lb..le], OFFSET_SIZE, LENGTH_SIZE).map_err(|_| {
                         Error::EditUnsupported("dataset header data layout could not be parsed")
@@ -1971,8 +2084,8 @@ impl EditSession {
     /// the emitter can build; an oversized set is refused. Rejects multi-chunk
     /// headers, dense or soft/external links, chunked/old-version data layouts, and
     /// headers that are neither a dataset nor a group.
-    fn read_object(d: &[u8], addr: usize) -> Result<ObjModel, Error> {
-        let region = Self::gather_oh_messages(d, addr)?;
+    fn read_object(d: &[u8], addr: usize, base: u64) -> Result<ObjModel, Error> {
+        let region = Self::gather_oh_messages(d, addr, base)?;
 
         // First pass: detect whether attributes are stored densely (a defined
         // fractal-heap address in the Attribute Info message). A dense object is
@@ -2014,7 +2127,7 @@ impl EditSession {
         // Attribute messages, so it returns exactly the heap-resident set.
         let dense_attrs = if dense {
             let header =
-                ObjectHeader::parse_with_base(d, addr, OFFSET_SIZE, LENGTH_SIZE, 0).map_err(|_| {
+                ObjectHeader::parse_with_base(d, addr, OFFSET_SIZE, LENGTH_SIZE, base).map_err(|_| {
                     Error::EditUnsupported(
                         "a source object header with dense attributes could not be parsed for copying",
                     )
@@ -2198,7 +2311,10 @@ impl EditSession {
                 "copy source nests too deeply (possible hard-link cycle)",
             ));
         }
-        match Self::read_object(d, addr)? {
+        // `read_copy_subtree` only runs on base-0 address spaces: a cross-file
+        // source is gated to base 0, and an in-file copy is refused on a userblock
+        // file (see `commit`), so the source addresses here are already absolute.
+        match Self::read_object(d, addr, 0)? {
             ObjModel::DatasetVerbatim {
                 region,
                 dense_attrs,
@@ -2834,7 +2950,7 @@ impl EditSession {
             Ok(s) => s,
             Err(_) => return,
         };
-        match Self::read_object(&self.data, addr) {
+        match Self::read_object(&self.data, addr, self.superblock.base_address) {
             Ok(ObjModel::DatasetVerbatim { .. }) => out.extend(spans),
             Ok(ObjModel::DatasetContiguous {
                 data_addr,
@@ -2906,7 +3022,7 @@ impl EditSession {
     /// [module docs](self).
     fn chunked_storage_spans(&self, addr: usize) -> Option<Vec<(u64, u64)>> {
         // Locate the data-layout and dataspace messages in the object header.
-        let region = Self::gather_oh_messages(&self.data, addr).ok()?;
+        let region = Self::gather_oh_messages(&self.data, addr, self.superblock.base_address).ok()?;
         let mut layout_msg: Option<(usize, usize)> = None;
         let mut dataspace_msg: Option<(usize, usize)> = None;
         let mut p = 0;

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -62,12 +62,14 @@
 //! faithfully. Requirements:
 //!
 //! - The file uses 8-byte offsets/lengths. A **userblock** (non-zero base
-//!   address, as every MATLAB v7.3 `.mat` file has) is supported for a first
-//!   slice of edits: same-length value overwrites and additions of contiguous
-//!   datasets, groups, and compact attributes, with the userblock bytes
-//!   preserved verbatim. On a userblock file, chunked/filtered additions,
-//!   chunked or relocating overwrites, deletions, copies, and free-space reuse
-//!   are still refused. Any superblock version (0–3) is accepted: a version 0/1
+//!   address, as every MATLAB v7.3 `.mat` file has) is supported: addresses are
+//!   read and written relative to the base and the userblock bytes are preserved
+//!   verbatim. Value overwrites, additions of contiguous and chunked/filtered
+//!   datasets, in-place and relocating overwrites of chunked datasets (with the
+//!   old chunk storage reclaimed), group creation, compact attributes, and
+//!   free-space reuse all work on a userblock file; deletions, copies, and
+//!   resizing overwrites of *contiguous* datasets are still refused there. Any
+//!   superblock version (0–3) is accepted: a version 0/1
 //!   (symbol-table) file is edited by converting each group on the edited path
 //!   to the latest format and repointing the superblock's root symbol-table
 //!   entry.
@@ -733,13 +735,14 @@ impl EditSession {
 
         // On a file with a userblock, stored addresses are relative to this base
         // and the editor converts at every disk boundary (read `stored + base`,
-        // write `file_offset - base`). This first slice of userblock support covers
-        // same-length and relocating value overwrites of contiguous datasets,
-        // additions of contiguous datasets, group creation, and compact group
-        // attributes. Operations whose address rewriting is not yet base-aware are
-        // refused up front (a clean refusal, never a partial/corrupting edit):
-        // object copies, deletions, relocating overwrites, and chunked/filtered
-        // additions; chunked overwrites are refused in `prepare_write`.
+        // write `file_offset - base`). Userblock support covers value overwrites,
+        // additions of contiguous and chunked/filtered datasets, in-place and
+        // relocating overwrites of chunked datasets (with reclaim), group creation,
+        // and compact group attributes. Operations whose address rewriting is not
+        // yet base-aware are refused up front (a clean refusal, never a
+        // partial/corrupting edit): object copies, deletions, and relocating
+        // (resizing) overwrites of contiguous/compact datasets — the latter refused
+        // in the write preflight below.
         let base = self.superblock.base_address;
         if base != 0 {
             if !self.pending_copies.is_empty() || !self.pending_cross_copies.is_empty() {
@@ -1236,9 +1239,10 @@ impl EditSession {
             }
 
             // Relocating value overwrites under this group: write the new data and
-            // rewritten header, then patch this group's existing link to it.
-            // (Relocating overwrites are refused on userblock files, so `base` is 0
-            // here.)
+            // rewritten header, then patch this group's existing link to it. The
+            // link target is stored relative to the base address (`- base`); on a
+            // userblock file only the chunked variant reaches here (contiguous and
+            // compact resizes are refused in the write preflight).
             for (leaf, mw) in &writes {
                 let new_oh = self.write_moving(mw)?;
                 patch_link_target(&mut region, leaf, new_oh - base)?;
@@ -2857,9 +2861,9 @@ impl EditSession {
                     }
                     let off = u64::from_le_bytes(d[body..body + 8].try_into().unwrap());
                     let len = u64::from_le_bytes(d[body + 8..body + 16].try_into().unwrap());
-                    let off_abs = off.checked_add(base).ok_or(Error::EditUnsupported(
-                        "continuation address exceeds this platform",
-                    ))?;
+                    let off_abs = off
+                        .checked_add(base)
+                        .ok_or(Error::EditUnsupported("continuation address overflow"))?;
                     let off_us = usize::try_from(off_abs).map_err(|_| {
                         Error::EditUnsupported("continuation address exceeds this platform")
                     })?;
@@ -2896,7 +2900,8 @@ impl EditSession {
     /// nothing for the deletions, a safe leak — if the graph cannot be walked in
     /// full: an unparseable header, a group whose links cannot be enumerated, or
     /// more than [`MAX_LINK_GRAPH_NODES`] objects. Cycles are handled by visiting
-    /// each object once. Assumes the editor's enforced `base_address == 0`.
+    /// each object once. Base-aware: stored child addresses are shifted by the
+    /// userblock base, so the returned keys are absolute file offsets.
     fn count_incoming_hard_links(&self) -> Option<HashMap<u64, u32>> {
         let os = self.superblock.offset_size;
         let ls = self.superblock.length_size;
@@ -2966,6 +2971,14 @@ impl EditSession {
         incoming: &HashMap<u64, u32>,
         out: &mut Vec<(u64, u64)>,
     ) {
+        // NOTE (base): this path runs only for deletions, which are refused on a
+        // userblock file, so `base_address` is always 0 when this is reached. That
+        // is why the contiguous `data_addr` and group child addresses returned by
+        // `read_object` below — which are *stored* (base-relative) values — are used
+        // here as absolute file offsets without a `+ base` shift. Before lifting the
+        // delete refusal for userblock files, shift those by the base (as
+        // `chunked_storage_spans`/`oh_chunk_spans` already do) or the free list
+        // would be seeded with wrong, possibly-live regions.
         if depth >= MAX_COPY_DEPTH {
             return;
         }

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -1643,9 +1643,9 @@ impl EditSession {
                     let len = u64::from_le_bytes(d[body + 8..body + 16].try_into().unwrap());
                     // The continuation block address is stored relative to the base
                     // address; convert to an absolute file offset to index `d`.
-                    let off = off.checked_add(base).ok_or(Error::EditUnsupported(
-                        "continuation address overflow",
-                    ))?;
+                    let off = off
+                        .checked_add(base)
+                        .ok_or(Error::EditUnsupported("continuation address overflow"))?;
                     let off = usize::try_from(off).map_err(|_| {
                         Error::EditUnsupported("continuation address exceeds this platform")
                     })?;
@@ -1810,7 +1810,12 @@ impl EditSession {
     /// this engine cannot enumerate — a version-2 B-tree — is refused too). A
     /// datatype or shape that differs from the on-disk dataset's is likewise
     /// refused — this is a value overwrite, not a reshape or retype.
-    fn prepare_write(d: &[u8], addr: usize, fd: &FlatDataset, base: u64) -> Result<WritePlan, Error> {
+    fn prepare_write(
+        d: &[u8],
+        addr: usize,
+        fd: &FlatDataset,
+        base: u64,
+    ) -> Result<WritePlan, Error> {
         // A value overwrite never introduces chunking, filters, or an extensible
         // shape: those would change the storage layout, not just the bytes.
         if fd.chunk_options.is_chunked() || fd.maxshape.is_some() {
@@ -1928,8 +1933,9 @@ impl EditSession {
                 // address is base-relative; the in-place write targets the absolute
                 // file offset `data_addr + base`.
                 if data_addr != UNDEF && data_size == fd.raw.len() as u64 {
-                    if let Some(start) =
-                        data_addr.checked_add(base).and_then(|a| usize::try_from(a).ok())
+                    if let Some(start) = data_addr
+                        .checked_add(base)
+                        .and_then(|a| usize::try_from(a).ok())
                     {
                         if start
                             .checked_add(fd.raw.len())
@@ -2608,10 +2614,7 @@ impl EditSession {
             },
         )?;
         let written = self.append(&buf)?;
-        debug_assert_eq!(
-            written, eof,
-            "chunk blob must land at end-of-file",
-        );
+        debug_assert_eq!(written, eof, "chunk blob must land at end-of-file",);
         // Swap the data-layout message for the rebuilt one; keep every other header
         // message (datatype, dataspace, fill value, filter pipeline, attributes)
         // verbatim. A dense attribute heap, if any, is appended after the blob so
@@ -2804,10 +2807,7 @@ impl EditSession {
         // lands exactly where its embedded (stored) addresses expect once the reader
         // adds the base back.
         let written = self.append(&result.data_bytes)?;
-        debug_assert_eq!(
-            written, eof,
-            "chunk blob must land at end-of-file",
-        );
+        debug_assert_eq!(written, eof, "chunk blob must land at end-of-file",);
         Ok(build_chunked_dataset_oh(
             &fd.dt,
             &fd.ds,
@@ -3053,7 +3053,8 @@ impl EditSession {
     /// [module docs](self).
     fn chunked_storage_spans(&self, addr: usize) -> Option<Vec<(u64, u64)>> {
         // Locate the data-layout and dataspace messages in the object header.
-        let region = Self::gather_oh_messages(&self.data, addr, self.superblock.base_address).ok()?;
+        let region =
+            Self::gather_oh_messages(&self.data, addr, self.superblock.base_address).ok()?;
         let mut layout_msg: Option<(usize, usize)> = None;
         let mut dataspace_msg: Option<(usize, usize)> = None;
         let mut p = 0;

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -798,11 +798,14 @@ impl EditSession {
                 WritePlan::InPlaceChunks { writes } => inplace_writes.extend(writes),
                 WritePlan::Moving(mw) => {
                     // A relocating overwrite rewrites the dataset's header and data
-                    // address; that path is not yet base-aware on a userblock file.
-                    if base != 0 {
+                    // address. The chunked variant is base-aware on a userblock file
+                    // (it rebuilds the chunk blob with stored addresses and reclaims
+                    // the old storage base-relative); the contiguous/compact resize
+                    // variant is not yet, so refuse it on a userblock file.
+                    if base != 0 && !matches!(mw, MovingWrite::Chunked { .. }) {
                         return Err(Error::EditUnsupported(
-                            "overwriting a dataset that resizes or relocates its header is not \
-                             supported on a file with a userblock yet",
+                            "overwriting a contiguous or compact dataset that resizes or relocates \
+                             its header is not supported on a file with a userblock yet",
                         ));
                     }
                     // A relocating overwrite is safe only when this is the
@@ -1115,16 +1118,13 @@ impl EditSession {
                 }
             }
         }
-        // Reclamation of vacated bytes is gated to base-0 files in this slice: the
-        // span enumerators (`oh_chunk_spans`/`collect_free_spans`/`chunked_storage_spans`)
-        // index the file with base-relative addresses and are not yet base-aware, so
-        // on a userblock file the superseded headers are left as harmless dead space
-        // rather than risk freeing a live region. (Deletes and relocating overwrites
-        // — the other reclamation sources — are refused on userblock files above.)
+        // A superseded group header is dead once the root is repointed. Its chunk
+        // spans are enumerated base-aware (`oh_chunk_spans` shifts continuation
+        // addresses by the userblock base and returns absolute file offsets), so
+        // this reclamation works on userblock files too. `collect_free_spans` (the
+        // delete path) is the one enumerator still gated to base-0, because object
+        // deletion is itself refused on a userblock file above.
         for &a in &superseded_addrs {
-            if base != 0 {
-                break;
-            }
             if let Ok(spans) = self.oh_chunk_spans(a) {
                 to_free.extend(spans);
             }
@@ -1219,12 +1219,6 @@ impl EditSession {
             // target are stored relative to the base address (`- base`).
             for fd in flat.remove(key).into_iter().flatten() {
                 let oh = if fd.chunk_options.is_chunked() || fd.maxshape.is_some() {
-                    if base != 0 {
-                        return Err(Error::EditUnsupported(
-                            "adding a chunked, filtered, or resizable dataset to a file with a \
-                             userblock is not supported in place yet",
-                        ));
-                    }
                     self.build_chunked_dataset(&fd)?
                 } else {
                     let data_addr = self.alloc_or_append(&fd.raw)?;
@@ -1972,15 +1966,12 @@ impl EditSession {
             // builder carries none — chunked/filtered/extensible builders are
             // refused at the top of this function as "not a value overwrite").
             2 => {
-                // Chunked overwrite (in-place or relocating) walks and rewrites
-                // chunk-index and chunk addresses, which are not yet base-aware on a
-                // userblock file; refuse rather than mis-address the chunk storage.
-                if base != 0 {
-                    return Err(Error::EditUnsupported(
-                        "overwriting a chunked dataset on a file with a userblock is not \
-                         supported in place yet",
-                    ));
-                }
+                // Chunked overwrite (in-place or relocating). On a userblock file
+                // every stored chunk-index and chunk address is relative to `base`:
+                // the in-place path below walks the index on a base-relative view of
+                // the file and shifts the resulting write offsets back by `base`,
+                // and the relocating path rebuilds the chunk blob with stored
+                // addresses (see `write_chunked_relocatable`).
                 let dl =
                     DataLayout::parse(&region[lb..le], OFFSET_SIZE, LENGTH_SIZE).map_err(|_| {
                         Error::EditUnsupported("dataset header data layout could not be parsed")
@@ -2039,10 +2030,25 @@ impl EditSession {
                 // new chunk fits. No header rewrite and no superblock flip — the
                 // chunk (and index) blocks are reachable from both roots. The index
                 // is left untouched when chunks keep their size and rebuilt in place
-                // when they shrink.
-                if let Some(writes) =
-                    try_inplace_chunk_writes(d, &dl, &disk_ds, &spatial, raw_size, &new_chunk_bytes)
-                {
+                // when they shrink. The index walk runs on a base-relative view of
+                // the file (so the layout's stored addresses index correctly), and
+                // the returned write offsets are shifted back to absolute file
+                // offsets by adding `base` (a no-op on a base-0 file).
+                let base_off = usize::try_from(base).map_err(|_| {
+                    Error::EditUnsupported("userblock base address exceeds this platform")
+                })?;
+                if let Some(writes) = try_inplace_chunk_writes(
+                    &d[base_off..],
+                    &dl,
+                    &disk_ds,
+                    &spatial,
+                    raw_size,
+                    &new_chunk_bytes,
+                ) {
+                    let writes = writes
+                        .into_iter()
+                        .map(|(off, b)| (off + base_off, b))
+                        .collect();
                     return Ok(WritePlan::InPlaceChunks { writes });
                 }
 
@@ -2578,14 +2584,19 @@ impl EditSession {
         chunk_bytes: &[Vec<u8>],
         dense_attrs: &[crate::attribute::AttributeMessage],
     ) -> Result<u64, Error> {
-        let base = self.data.len() as u64;
+        let eof = self.data.len() as u64;
+        // Build with the *stored* (base-relative) address the blob will occupy, so
+        // its embedded addresses resolve to its real file offset once the reader adds
+        // the userblock base back (see `build_chunked_dataset`). On a base-0 file this
+        // equals `eof`.
+        let stored_base = eof - self.superblock.base_address;
         let layout = plan_chunked_data_verbatim(
             meta,
             chunk_dims,
             element_size,
             raw_size,
             pipeline_message,
-            base,
+            stored_base,
             maxshape,
         )?;
         let mut buf = Vec::with_capacity(usize::try_from(layout.plan.total_len).unwrap_or(0));
@@ -2598,8 +2609,8 @@ impl EditSession {
         )?;
         let written = self.append(&buf)?;
         debug_assert_eq!(
-            written, base,
-            "chunk blob must land at the base address it was built for",
+            written, eof,
+            "chunk blob must land at end-of-file",
         );
         // Swap the data-layout message for the rebuilt one; keep every other header
         // message (datatype, dataspace, fill value, filter pipeline, attributes)
@@ -2632,12 +2643,17 @@ impl EditSession {
         if attrs.is_empty() {
             return Ok(());
         }
-        let base = self.data.len() as u64;
-        let blob = crate::file_writer::build_dense_attrs(attrs, base);
+        let eof = self.data.len() as u64;
+        // Build with the *stored* (base-relative) address the blob will occupy, so
+        // every address it embeds resolves to its real file offset once the reader
+        // adds the userblock base back (see `build_chunked_dataset`). On a base-0
+        // file this equals `eof`.
+        let stored_base = eof - self.superblock.base_address;
+        let blob = crate::file_writer::build_dense_attrs(attrs, stored_base);
         let written = self.append(&blob.blob)?;
         debug_assert_eq!(
-            written, base,
-            "dense attribute blob must land at the base address it was built for",
+            written, eof,
+            "dense attribute blob must land at end-of-file",
         );
         region.extend_from_slice(&region_message(
             MessageType::AttributeInfo,
@@ -2767,7 +2783,13 @@ impl EditSession {
     /// still reused for the object header and for every other object in the
     /// commit.
     fn build_chunked_dataset(&mut self, fd: &FlatDataset) -> Result<Vec<u8>, Error> {
-        let base = self.data.len() as u64;
+        let eof = self.data.len() as u64;
+        // The blob embeds *stored* (base-relative) addresses, so the planner base is
+        // the stored address the blob will occupy: its end-of-file offset minus the
+        // userblock base. The reader recovers each as `stored + base_address`, which
+        // resolves back to the blob's real file offset. On a base-0 file this is just
+        // `eof`.
+        let stored_base = eof - self.superblock.base_address;
         let chunk_dims = fd.chunk_options.resolve_chunk_dims(&fd.ds.dimensions);
         let ctx = ChunkContext::from_datatype(&chunk_dims, &fd.dt);
         let result = build_chunked_data_at_ext(
@@ -2775,15 +2797,16 @@ impl EditSession {
             &fd.ds.dimensions,
             ctx,
             &fd.chunk_options,
-            base,
+            stored_base,
             fd.maxshape.as_deref(),
         )?;
-        // `append` writes at the current end-of-file, which equals `base`: the
-        // blob lands exactly where its embedded addresses expect.
+        // `append` writes at the current end-of-file, which equals `eof`: the blob
+        // lands exactly where its embedded (stored) addresses expect once the reader
+        // adds the base back.
         let written = self.append(&result.data_bytes)?;
         debug_assert_eq!(
-            written, base,
-            "chunk blob must land at the base address it was built for",
+            written, eof,
+            "chunk blob must land at end-of-file",
         );
         Ok(build_chunked_dataset_oh(
             &fd.dt,
@@ -2805,6 +2828,11 @@ impl EditSession {
     fn oh_chunk_spans(&self, addr: usize) -> Result<Vec<(u64, u64)>, Error> {
         let (rs, re) = Self::oh_region(&self.data, addr)?;
         let d = &self.data;
+        // A continuation message records the OCHK block's address relative to the
+        // userblock base, so it is shifted to an absolute file offset before
+        // indexing the file or recording the span (a no-op on a base-0 file). Chunk
+        // 0 sits at the absolute header address itself, which is already absolute.
+        let base = self.superblock.base_address;
         // Chunk 0 spans from the header start through its trailing checksum;
         // `oh_region` guarantees `re + 4 <= d.len()`.
         let mut spans: Vec<(u64, u64)> = vec![(addr as u64, (re + 4 - addr) as u64)];
@@ -2829,7 +2857,10 @@ impl EditSession {
                     }
                     let off = u64::from_le_bytes(d[body..body + 8].try_into().unwrap());
                     let len = u64::from_le_bytes(d[body + 8..body + 16].try_into().unwrap());
-                    let off_us = usize::try_from(off).map_err(|_| {
+                    let off_abs = off.checked_add(base).ok_or(Error::EditUnsupported(
+                        "continuation address exceeds this platform",
+                    ))?;
+                    let off_us = usize::try_from(off_abs).map_err(|_| {
                         Error::EditUnsupported("continuation address exceeds this platform")
                     })?;
                     let len_us = usize::try_from(len).map_err(|_| {
@@ -2844,7 +2875,7 @@ impl EditSession {
                             "invalid continuation block signature",
                         ));
                     }
-                    spans.push((off, len));
+                    spans.push((off_abs, len));
                     chunks.push((off_us + 4, blk_end - 4));
                 }
                 p = body_end;
@@ -3055,14 +3086,25 @@ impl EditSession {
         // or the free list would later hand out live bytes (and a debug build
         // would panic on the double-free). On any error or violation, leave the
         // whole dataset unreclaimed rather than free a region still in use.
+        //
+        // The layout's stored addresses are relative to the userblock base, so the
+        // enumeration runs on a base-relative view of the file and each returned
+        // span address is shifted back to an absolute file offset by adding `base`
+        // (a no-op on a base-0 file). The free list and the bounds check below both
+        // work in absolute file offsets.
+        let base = self.superblock.base_address;
+        let base_off = usize::try_from(base).ok()?;
         let mut spans = crate::chunked_read::collect_chunked_storage_spans(
-            &self.data,
+            &self.data[base_off..],
             &layout,
             &dataspace,
             OFFSET_SIZE,
             LENGTH_SIZE,
         )
         .ok()?;
+        for (addr, _) in &mut spans {
+            *addr = addr.checked_add(base)?;
+        }
         if !spans_disjoint_in_bounds(&mut spans, self.data.len() as u64) {
             return None;
         }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -75,9 +75,9 @@ impl FileSource for SourceView<'_> {
 /// on-disk addresses (contiguous data, chunk index, and chunk data) are stored
 /// relative to the base address — presenting the reader this shifted view lets
 /// those relative addresses index it directly, exactly as the in-memory path
-/// slices the buffer at `base`. Overriding `len`/`read_at` is enough: the trait's
-/// default `read_exact_at`/`read_metadata_at` bound against this `len` (the
-/// base-relative length) and delegate through this `read_at`.
+/// slices the buffer at `base`. `len`/`read_at` shift by the base; `read_metadata_at`
+/// forwards to the inner source (at the absolute offset) so its metadata cache is
+/// shared, while payload reads keep the default uncached `read_exact_at`.
 struct BaseOffsetSource<'a, S: FileSource + ?Sized> {
     inner: &'a S,
     base: u64,
@@ -96,6 +96,20 @@ impl<S: FileSource + ?Sized> FileSource for BaseOffsetSource<'_, S> {
                 length: buf.len() as u64,
             })?;
         self.inner.read_at(abs, buf)
+    }
+
+    /// Forward metadata reads to the inner source at the absolute offset so the
+    /// inner source's metadata cache is shared (chunk-index walks on a streaming
+    /// userblock file otherwise re-read every node). Payload reads keep the default
+    /// `read_exact_at`, which stays uncached so user data does not evict metadata.
+    fn read_metadata_at(&self, offset: u64, len: usize) -> Result<Vec<u8>, FormatError> {
+        let abs = offset
+            .checked_add(self.base)
+            .ok_or(FormatError::OffsetOverflow {
+                offset,
+                length: len as u64,
+            })?;
+        self.inner.read_metadata_at(abs, len)
     }
 }
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -69,6 +69,36 @@ impl FileSource for SourceView<'_> {
     }
 }
 
+/// A `FileSource` view shifted forward by a base address: every read at a
+/// base-relative `offset` is served from `inner` at `offset + base`. Used by the
+/// dataset-payload read path on a file with a userblock, where the data-layout's
+/// on-disk addresses (contiguous data, chunk index, and chunk data) are stored
+/// relative to the base address — presenting the reader this shifted view lets
+/// those relative addresses index it directly, exactly as the in-memory path
+/// slices the buffer at `base`. Overriding `len`/`read_at` is enough: the trait's
+/// default `read_exact_at`/`read_metadata_at` bound against this `len` (the
+/// base-relative length) and delegate through this `read_at`.
+struct BaseOffsetSource<'a, S: FileSource + ?Sized> {
+    inner: &'a S,
+    base: u64,
+}
+
+impl<S: FileSource + ?Sized> FileSource for BaseOffsetSource<'_, S> {
+    fn len(&self) -> u64 {
+        self.inner.len().saturating_sub(self.base)
+    }
+
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), FormatError> {
+        let abs = offset
+            .checked_add(self.base)
+            .ok_or(FormatError::OffsetOverflow {
+                offset,
+                length: buf.len() as u64,
+            })?;
+        self.inner.read_at(abs, buf)
+    }
+}
+
 /// File-access options applied when opening an HDF5 file.
 ///
 /// This is the `hdf5-pure` analogue of the HDF5 file access property list
@@ -755,11 +785,28 @@ impl File {
         cache: &ChunkCache,
     ) -> Result<Vec<u8>, FormatError> {
         let (os, ls) = (self.offset_size(), self.length_size());
+        // Every on-disk address in `dl` — the contiguous data address, the chunk
+        // index root, and (followed deeper in the chunked reader) every B-tree /
+        // fixed-array / extensible-array node and chunk-data address — is stored
+        // relative to the base address. Present the payload reader a base-relative
+        // view of the file so all of them index it directly: slice the in-memory
+        // buffer at `base`, or wrap the streaming source to add `base` to each
+        // read. For a plain file (`base == 0`) this is the identity.
+        let base = self.addr_offset;
         match &self.backend {
             Backend::InMemory(v) => {
-                data_read::read_raw_data_cached(v, dl, ds, dt, pipeline, os, ls, cache)
+                let frame = if base == 0 {
+                    v.as_slice()
+                } else {
+                    let start = base.to_usize()?;
+                    v.get(start..).ok_or(FormatError::UnexpectedEof {
+                        expected: start,
+                        available: v.len(),
+                    })?
+                };
+                data_read::read_raw_data_cached(frame, dl, ds, dt, pipeline, os, ls, cache)
             }
-            Backend::Streaming(s) => data_read::read_raw_data_cached_from_source(
+            Backend::Streaming(s) if base == 0 => data_read::read_raw_data_cached_from_source(
                 s.as_ref(),
                 dl,
                 ds,
@@ -769,6 +816,15 @@ impl File {
                 ls,
                 cache,
             ),
+            Backend::Streaming(s) => {
+                let framed = BaseOffsetSource {
+                    inner: s.as_ref(),
+                    base,
+                };
+                data_read::read_raw_data_cached_from_source(
+                    &framed, dl, ds, dt, pipeline, os, ls, cache,
+                )
+            }
         }
     }
 }
@@ -1332,8 +1388,34 @@ impl<'f> Dataset<'f> {
         };
         let dataspace = self.dataspace()?;
         let elem_size = self.datatype()?.type_size() as usize;
-        Ok(crate::chunked_read::collect_chunks_for_layout_from_source(
-            &self.file.source(),
+        let base = self.file.addr_offset;
+        let source = self.file.source();
+        // The chunk index — its root at `addr` and every internal node — stores
+        // addresses relative to the base address. Walk it through a base-relative
+        // view so those resolve, then shift each returned chunk address back to an
+        // absolute file offset, since callers (repack) read the chunk bytes from
+        // the full file source.
+        if base == 0 {
+            return Ok(crate::chunked_read::collect_chunks_for_layout_from_source(
+                &source,
+                version,
+                chunk_index_type,
+                addr,
+                single_chunk_filtered_size,
+                single_chunk_filter_mask,
+                &chunk_dimensions,
+                &dataspace,
+                elem_size,
+                self.file.offset_size(),
+                self.file.length_size(),
+            )?);
+        }
+        let framed = BaseOffsetSource {
+            inner: &source,
+            base,
+        };
+        let mut chunks = crate::chunked_read::collect_chunks_for_layout_from_source(
+            &framed,
             version,
             chunk_index_type,
             addr,
@@ -1344,7 +1426,17 @@ impl<'f> Dataset<'f> {
             elem_size,
             self.file.offset_size(),
             self.file.length_size(),
-        )?)
+        )?;
+        for c in &mut chunks {
+            c.address =
+                c.address
+                    .checked_add(base)
+                    .ok_or(crate::error::FormatError::OffsetOverflow {
+                        offset: c.address,
+                        length: 0,
+                    })?;
+        }
+        Ok(chunks)
     }
 
     /// The raw `FilterPipeline` message bytes from this dataset's object header,
@@ -1366,16 +1458,11 @@ impl<'f> Dataset<'f> {
     pub fn read_raw(&self) -> Result<Vec<u8>, Error> {
         let dt = self.datatype()?;
         let ds = self.dataspace()?;
-        let mut dl = self.data_layout()?;
-        // Adjust contiguous data address by base_address offset
-        if self.file.addr_offset != 0
-            && let DataLayout::Contiguous {
-                ref mut address, ..
-            } = dl
-            && let Some(addr) = address
-        {
-            *addr += self.file.addr_offset;
-        }
+        let dl = self.data_layout()?;
+        // The data layout's on-disk addresses are left base-relative here;
+        // `read_dataset_raw` applies the base address centrally (for both
+        // contiguous and chunked layouts) by reading from a base-relative view of
+        // the file.
         let pipeline = self.filter_pipeline();
         Ok(self
             .file

--- a/tests/edit_userblock.rs
+++ b/tests/edit_userblock.rs
@@ -1,0 +1,277 @@
+//! In-place editing of files that carry a userblock (non-zero base address) —
+//! the userblock slice of issue #104.
+//!
+//! Every MATLAB v7.3 `.mat` file begins with a 512-byte userblock, so the HDF5
+//! superblock sits at byte 512 and every stored address is relative to that
+//! base. These tests exercise the editor on such files — a synthetic one built
+//! by this crate and a real `.mat` fixture — and verify that the userblock bytes
+//! survive an edit byte-for-byte.
+//!
+//! This first slice supports same-length contiguous value overwrites, additions
+//! of contiguous datasets, group creation, and compact group attributes. Chunked
+//! additions/overwrites, deletions, copies, and relocating overwrites are
+//! refused cleanly on a userblock file (covered below); they remain follow-up
+//! work, and a refusal never corrupts the file.
+
+use hdf5_pure::{AttrValue, EditSession, File, FileBuilder};
+
+const UB: usize = 512;
+const MARKER: &[u8] = b"USERBLOCK-MARKER-0104";
+
+/// Build a userblock file with two root datasets and a nested group+dataset,
+/// stamping a recognizable marker across the userblock region. Returns the
+/// 512-byte userblock as written, for later byte-for-byte comparison.
+fn build_userblock_file(path: &std::path::Path) -> Vec<u8> {
+    let mut b = FileBuilder::new();
+    b.with_userblock(UB as u64);
+    b.create_dataset("alpha").with_f64_data(&[1.0, 2.0, 3.0, 4.0]);
+    b.create_dataset("beta").with_i32_data(&[10, 20, 30]);
+    let mut g = b.create_group("grp");
+    g.create_dataset("inner").with_f64_data(&[7.5, 8.5]);
+    b.add_group(g.finish());
+    let mut bytes = b.finish().unwrap();
+
+    // The userblock region [0..512] is zero-filled by the writer; stamp a marker
+    // at the start and a sentinel at the last byte to catch any stray write into
+    // the userblock during an edit.
+    bytes[..MARKER.len()].copy_from_slice(MARKER);
+    bytes[UB - 1] = 0xAB;
+    let userblock = bytes[..UB].to_vec();
+    std::fs::write(path, &bytes).unwrap();
+    userblock
+}
+
+#[test]
+fn synthetic_userblock_file_roundtrip() {
+    let path = std::env::temp_dir().join("hdf5_pure_ub_roundtrip.h5");
+    let userblock = build_userblock_file(&path);
+
+    {
+        let mut s = EditSession::open(&path).unwrap();
+        // Same-length in-place overwrite of an existing contiguous dataset.
+        s.write_dataset("alpha").with_f64_data(&[9.0, 8.0, 7.0, 6.0]);
+        // Add contiguous datasets at the root and inside the nested group.
+        s.create_dataset("added").with_i32_data(&[100, 200]);
+        s.create_dataset("grp/added_inner").with_f64_data(&[3.25]);
+        // Create a new group and set a compact attribute on it.
+        s.create_group("newgrp");
+        s.set_group_attr("newgrp", "tag", AttrValue::AsciiString("v104".into()));
+        s.commit().unwrap();
+    }
+
+    let file = File::open(&path).unwrap();
+    // Overwritten value.
+    assert_eq!(
+        file.dataset("alpha").unwrap().read_f64().unwrap(),
+        vec![9.0, 8.0, 7.0, 6.0]
+    );
+    // Untouched originals.
+    assert_eq!(
+        file.dataset("beta").unwrap().read_i32().unwrap(),
+        vec![10, 20, 30]
+    );
+    assert_eq!(
+        file.dataset("grp/inner").unwrap().read_f64().unwrap(),
+        vec![7.5, 8.5]
+    );
+    // Additions.
+    assert_eq!(
+        file.dataset("added").unwrap().read_i32().unwrap(),
+        vec![100, 200]
+    );
+    assert_eq!(
+        file.dataset("grp/added_inner").unwrap().read_f64().unwrap(),
+        vec![3.25]
+    );
+    // New group and its attribute.
+    let mut groups = file.root().groups().unwrap();
+    groups.sort();
+    assert!(groups.contains(&"newgrp".to_string()));
+    let attrs = file.group("newgrp").unwrap().attrs().unwrap();
+    assert_eq!(attrs.get("tag"), Some(&AttrValue::String("v104".into())));
+
+    // The userblock bytes are preserved verbatim across the edit.
+    let after = std::fs::read(&path).unwrap();
+    assert_eq!(
+        &after[..UB],
+        &userblock[..],
+        "userblock bytes changed across the edit"
+    );
+    assert_eq!(&after[..MARKER.len()], MARKER);
+    assert_eq!(after[UB - 1], 0xAB);
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn userblock_inplace_overwrite_only_takes_fast_path() {
+    // A lone same-length overwrite takes the in-place fast path (no header
+    // rewrite, no superblock flip); it must work on a userblock file and leave
+    // the userblock untouched.
+    let path = std::env::temp_dir().join("hdf5_pure_ub_inplace_only.h5");
+    let userblock = build_userblock_file(&path);
+
+    {
+        let mut s = EditSession::open(&path).unwrap();
+        s.write_dataset("beta").with_i32_data(&[-1, -2, -3]);
+        s.commit().unwrap();
+    }
+
+    let file = File::open(&path).unwrap();
+    assert_eq!(
+        file.dataset("beta").unwrap().read_i32().unwrap(),
+        vec![-1, -2, -3]
+    );
+    assert_eq!(
+        file.dataset("alpha").unwrap().read_f64().unwrap(),
+        vec![1.0, 2.0, 3.0, 4.0]
+    );
+    assert_eq!(&std::fs::read(&path).unwrap()[..UB], &userblock[..]);
+
+    std::fs::remove_file(&path).ok();
+}
+
+/// Each unsupported operation on a userblock file must be refused with
+/// `EditUnsupported`, and the file must remain valid with its original contents.
+#[test]
+fn userblock_unsupported_ops_are_refused_cleanly() {
+    // chunked/filtered addition
+    {
+        let path = std::env::temp_dir().join("hdf5_pure_ub_refuse_chunk_add.h5");
+        build_userblock_file(&path);
+        let mut s = EditSession::open(&path).unwrap();
+        s.create_dataset("chk")
+            .with_f64_data(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
+            .with_deflate(6);
+        assert!(s.commit().is_err(), "chunked add should be refused");
+        drop(s);
+        let file = File::open(&path).unwrap();
+        assert!(file.dataset("chk").is_err());
+        assert_eq!(
+            file.dataset("alpha").unwrap().read_f64().unwrap(),
+            vec![1.0, 2.0, 3.0, 4.0]
+        );
+        std::fs::remove_file(&path).ok();
+    }
+
+    // deletion
+    {
+        let path = std::env::temp_dir().join("hdf5_pure_ub_refuse_delete.h5");
+        build_userblock_file(&path);
+        let mut s = EditSession::open(&path).unwrap();
+        s.delete("alpha");
+        assert!(s.commit().is_err(), "delete should be refused");
+        drop(s);
+        let file = File::open(&path).unwrap();
+        assert_eq!(
+            file.dataset("alpha").unwrap().read_f64().unwrap(),
+            vec![1.0, 2.0, 3.0, 4.0]
+        );
+        std::fs::remove_file(&path).ok();
+    }
+
+    // copy
+    {
+        let path = std::env::temp_dir().join("hdf5_pure_ub_refuse_copy.h5");
+        build_userblock_file(&path);
+        let mut s = EditSession::open(&path).unwrap();
+        s.copy("alpha", "alpha_copy");
+        assert!(s.commit().is_err(), "copy should be refused");
+        drop(s);
+        let file = File::open(&path).unwrap();
+        assert!(file.dataset("alpha_copy").is_err());
+        assert_eq!(
+            file.dataset("alpha").unwrap().read_f64().unwrap(),
+            vec![1.0, 2.0, 3.0, 4.0]
+        );
+        std::fs::remove_file(&path).ok();
+    }
+
+    // overwrite of a chunked dataset. The refusal happens in `prepare_write`
+    // before any byte is written, so the file must be byte-identical afterward and
+    // the original chunk data must still read back.
+    {
+        let path = std::env::temp_dir().join("hdf5_pure_ub_refuse_chunk_over.h5");
+        let original = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
+        let mut b = FileBuilder::new();
+        b.with_userblock(UB as u64);
+        b.create_dataset("chk").with_f64_data(&original).with_deflate(6);
+        std::fs::write(&path, b.finish().unwrap()).unwrap();
+        let before = std::fs::read(&path).unwrap();
+
+        let mut s = EditSession::open(&path).unwrap();
+        s.write_dataset("chk")
+            .with_f64_data(&[8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0]);
+        assert!(s.commit().is_err(), "chunked overwrite should be refused");
+        drop(s);
+        assert_eq!(
+            std::fs::read(&path).unwrap(),
+            before,
+            "a refused chunked overwrite must not modify the file"
+        );
+        assert_eq!(
+            File::open(&path).unwrap().dataset("chk").unwrap().read_f64().unwrap(),
+            original
+        );
+        std::fs::remove_file(&path).ok();
+    }
+}
+
+#[test]
+fn real_mat_add_dataset_preserves_userblock_and_data() {
+    // Copy the fixture so the test never mutates the checked-in file.
+    let src = std::path::Path::new("tests/fixtures/mat_real/test_string_v73.mat");
+    let path = std::env::temp_dir().join("hdf5_pure_ub_real_mat.mat");
+    std::fs::copy(src, &path).unwrap();
+
+    let original_userblock = std::fs::read(&path).unwrap()[..UB].to_vec();
+    assert_eq!(
+        &original_userblock[..10],
+        b"MATLAB 7.3",
+        "fixture is not a MATLAB v7.3 userblock file"
+    );
+
+    // Capture an existing variable's bytes before editing.
+    let before = File::open(&path)
+        .unwrap()
+        .dataset("string_scalar")
+        .unwrap()
+        .read_u32()
+        .unwrap();
+
+    {
+        let mut s = EditSession::open(&path).unwrap();
+        s.create_dataset("hdf5_pure_probe")
+            .with_f64_data(&[42.0, -1.0, 3.5]);
+        s.commit().unwrap();
+    }
+
+    let file = File::open(&path).unwrap();
+    // The added dataset reads back correctly.
+    assert_eq!(
+        file.dataset("hdf5_pure_probe").unwrap().read_f64().unwrap(),
+        vec![42.0, -1.0, 3.5]
+    );
+    // The untouched original still reads identically.
+    assert_eq!(
+        file.dataset("string_scalar").unwrap().read_u32().unwrap(),
+        before
+    );
+    // The original variables and MATLAB's MCOS groups are still present.
+    let datasets = file.root().datasets().unwrap();
+    for name in ["string_array", "string_empty", "string_scalar", "hdf5_pure_probe"] {
+        assert!(datasets.contains(&name.to_string()), "missing dataset {name}");
+    }
+    let groups = file.root().groups().unwrap();
+    assert!(groups.contains(&"#refs#".to_string()));
+    assert!(groups.contains(&"#subsystem#".to_string()));
+
+    // The MATLAB userblock (signature, version, endian indicator) is unchanged.
+    let after_userblock = std::fs::read(&path).unwrap()[..UB].to_vec();
+    assert_eq!(
+        after_userblock, original_userblock,
+        "MATLAB userblock changed across the edit"
+    );
+
+    std::fs::remove_file(&path).ok();
+}

--- a/tests/edit_userblock.rs
+++ b/tests/edit_userblock.rs
@@ -26,7 +26,8 @@ const MARKER: &[u8] = b"USERBLOCK-MARKER-0104";
 fn build_userblock_file(path: &std::path::Path) -> Vec<u8> {
     let mut b = FileBuilder::new();
     b.with_userblock(UB as u64);
-    b.create_dataset("alpha").with_f64_data(&[1.0, 2.0, 3.0, 4.0]);
+    b.create_dataset("alpha")
+        .with_f64_data(&[1.0, 2.0, 3.0, 4.0]);
     b.create_dataset("beta").with_i32_data(&[10, 20, 30]);
     let mut g = b.create_group("grp");
     g.create_dataset("inner").with_f64_data(&[7.5, 8.5]);
@@ -51,7 +52,8 @@ fn synthetic_userblock_file_roundtrip() {
     {
         let mut s = EditSession::open(&path).unwrap();
         // Same-length in-place overwrite of an existing contiguous dataset.
-        s.write_dataset("alpha").with_f64_data(&[9.0, 8.0, 7.0, 6.0]);
+        s.write_dataset("alpha")
+            .with_f64_data(&[9.0, 8.0, 7.0, 6.0]);
         // Add contiguous datasets at the root and inside the nested group.
         s.create_dataset("added").with_i32_data(&[100, 200]);
         s.create_dataset("grp/added_inner").with_f64_data(&[3.25]);
@@ -180,7 +182,8 @@ fn userblock_unsupported_ops_are_refused_cleanly() {
 
         let mut s = EditSession::open(&path).unwrap();
         // A longer value than the on-disk extent forces a relocation.
-        s.write_dataset("alpha").with_f64_data(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        s.write_dataset("alpha")
+            .with_f64_data(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
         assert!(
             s.commit().is_err(),
             "contiguous resizing overwrite should be refused"
@@ -192,7 +195,12 @@ fn userblock_unsupported_ops_are_refused_cleanly() {
             "a refused resizing overwrite must not modify the file"
         );
         assert_eq!(
-            File::open(&path).unwrap().dataset("alpha").unwrap().read_f64().unwrap(),
+            File::open(&path)
+                .unwrap()
+                .dataset("alpha")
+                .unwrap()
+                .read_f64()
+                .unwrap(),
             vec![1.0, 2.0, 3.0, 4.0]
         );
         std::fs::remove_file(&path).ok();
@@ -241,8 +249,16 @@ fn real_mat_add_dataset_preserves_userblock_and_data() {
     );
     // The original variables and MATLAB's MCOS groups are still present.
     let datasets = file.root().datasets().unwrap();
-    for name in ["string_array", "string_empty", "string_scalar", "hdf5_pure_probe"] {
-        assert!(datasets.contains(&name.to_string()), "missing dataset {name}");
+    for name in [
+        "string_array",
+        "string_empty",
+        "string_scalar",
+        "hdf5_pure_probe",
+    ] {
+        assert!(
+            datasets.contains(&name.to_string()),
+            "missing dataset {name}"
+        );
     }
     let groups = file.root().groups().unwrap();
     assert!(groups.contains(&"#refs#".to_string()));

--- a/tests/edit_userblock.rs
+++ b/tests/edit_userblock.rs
@@ -7,9 +7,11 @@
 //! by this crate and a real `.mat` fixture — and verify that the userblock bytes
 //! survive an edit byte-for-byte.
 //!
-//! This first slice supports same-length contiguous value overwrites, additions
-//! of contiguous datasets, group creation, and compact group attributes. Chunked
-//! additions/overwrites, deletions, copies, and relocating overwrites are
+//! This slice supports contiguous value overwrites, additions of contiguous and
+//! chunked/filtered datasets, overwrites of chunked datasets (in place when the
+//! re-encoded chunks fit their slots, otherwise rebuilt and relocated with the
+//! old storage reclaimed), group creation, and compact group attributes.
+//! Deletions, copies, and relocating overwrites of *contiguous* datasets are
 //! refused cleanly on a userblock file (covered below); they remain follow-up
 //! work, and a refusal never corrupts the file.
 
@@ -135,25 +137,6 @@ fn userblock_inplace_overwrite_only_takes_fast_path() {
 /// `EditUnsupported`, and the file must remain valid with its original contents.
 #[test]
 fn userblock_unsupported_ops_are_refused_cleanly() {
-    // chunked/filtered addition
-    {
-        let path = std::env::temp_dir().join("hdf5_pure_ub_refuse_chunk_add.h5");
-        build_userblock_file(&path);
-        let mut s = EditSession::open(&path).unwrap();
-        s.create_dataset("chk")
-            .with_f64_data(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
-            .with_deflate(6);
-        assert!(s.commit().is_err(), "chunked add should be refused");
-        drop(s);
-        let file = File::open(&path).unwrap();
-        assert!(file.dataset("chk").is_err());
-        assert_eq!(
-            file.dataset("alpha").unwrap().read_f64().unwrap(),
-            vec![1.0, 2.0, 3.0, 4.0]
-        );
-        std::fs::remove_file(&path).ok();
-    }
-
     // deletion
     {
         let path = std::env::temp_dir().join("hdf5_pure_ub_refuse_delete.h5");
@@ -187,31 +170,30 @@ fn userblock_unsupported_ops_are_refused_cleanly() {
         std::fs::remove_file(&path).ok();
     }
 
-    // overwrite of a chunked dataset. The refusal happens in `prepare_write`
-    // before any byte is written, so the file must be byte-identical afterward and
-    // the original chunk data must still read back.
+    // relocating overwrite of a *contiguous* dataset (a resize). The refusal
+    // happens in the write preflight before any byte is written, so the file must
+    // be byte-identical afterward and the original data must still read back.
     {
-        let path = std::env::temp_dir().join("hdf5_pure_ub_refuse_chunk_over.h5");
-        let original = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
-        let mut b = FileBuilder::new();
-        b.with_userblock(UB as u64);
-        b.create_dataset("chk").with_f64_data(&original).with_deflate(6);
-        std::fs::write(&path, b.finish().unwrap()).unwrap();
+        let path = std::env::temp_dir().join("hdf5_pure_ub_refuse_contig_resize.h5");
+        build_userblock_file(&path);
         let before = std::fs::read(&path).unwrap();
 
         let mut s = EditSession::open(&path).unwrap();
-        s.write_dataset("chk")
-            .with_f64_data(&[8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0]);
-        assert!(s.commit().is_err(), "chunked overwrite should be refused");
+        // A longer value than the on-disk extent forces a relocation.
+        s.write_dataset("alpha").with_f64_data(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        assert!(
+            s.commit().is_err(),
+            "contiguous resizing overwrite should be refused"
+        );
         drop(s);
         assert_eq!(
             std::fs::read(&path).unwrap(),
             before,
-            "a refused chunked overwrite must not modify the file"
+            "a refused resizing overwrite must not modify the file"
         );
         assert_eq!(
-            File::open(&path).unwrap().dataset("chk").unwrap().read_f64().unwrap(),
-            original
+            File::open(&path).unwrap().dataset("alpha").unwrap().read_f64().unwrap(),
+            vec![1.0, 2.0, 3.0, 4.0]
         );
         std::fs::remove_file(&path).ok();
     }

--- a/tests/edit_userblock_chunked.rs
+++ b/tests/edit_userblock_chunked.rs
@@ -28,7 +28,11 @@ fn stamp_userblock(bytes: &mut [u8]) -> Vec<u8> {
 
 fn assert_userblock_unchanged(path: &std::path::Path, original: &[u8]) {
     let after = std::fs::read(path).unwrap();
-    assert_eq!(&after[..UB], original, "userblock bytes changed across the edit");
+    assert_eq!(
+        &after[..UB],
+        original,
+        "userblock bytes changed across the edit"
+    );
 }
 
 #[test]
@@ -38,7 +42,8 @@ fn userblock_chunked_add_roundtrip() {
     let path = std::env::temp_dir().join("hdf5_pure_ub_chunk_add.h5");
     let mut b = FileBuilder::new();
     b.with_userblock(UB as u64);
-    b.create_dataset("contig").with_f64_data(&[1.0, 2.0, 3.0, 4.0]);
+    b.create_dataset("contig")
+        .with_f64_data(&[1.0, 2.0, 3.0, 4.0]);
     let mut bytes = b.finish().unwrap();
     let userblock = stamp_userblock(&mut bytes);
     std::fs::write(&path, &bytes).unwrap();
@@ -96,7 +101,15 @@ fn userblock_chunked_unfiltered_inplace_overwrite() {
         len_after, len_before,
         "an unfiltered same-shape chunked overwrite must stay in place (no growth)"
     );
-    assert_eq!(File::open(&path).unwrap().dataset("c").unwrap().read_f64().unwrap(), updated);
+    assert_eq!(
+        File::open(&path)
+            .unwrap()
+            .dataset("c")
+            .unwrap()
+            .read_f64()
+            .unwrap(),
+        updated
+    );
     assert_userblock_unchanged(&path, &userblock);
 
     std::fs::remove_file(&path).ok();
@@ -137,7 +150,15 @@ fn userblock_chunked_shrinking_inplace_overwrite() {
         len_after <= len_before,
         "a shrinking chunked overwrite must stay in place (no growth): {len_before} -> {len_after}"
     );
-    assert_eq!(File::open(&path).unwrap().dataset("c").unwrap().read_f64().unwrap(), updated);
+    assert_eq!(
+        File::open(&path)
+            .unwrap()
+            .dataset("c")
+            .unwrap()
+            .read_f64()
+            .unwrap(),
+        updated
+    );
     assert_userblock_unchanged(&path, &userblock);
 
     std::fs::remove_file(&path).ok();
@@ -174,11 +195,20 @@ fn real_mat_add_chunked_dataset_preserves_userblock() {
 
     let file = File::open(&path).unwrap();
     assert_eq!(
-        file.dataset("hdf5_pure_chunk_probe").unwrap().read_f64().unwrap(),
+        file.dataset("hdf5_pure_chunk_probe")
+            .unwrap()
+            .read_f64()
+            .unwrap(),
         added
     );
-    assert_eq!(file.dataset("string_scalar").unwrap().read_u32().unwrap(), before);
-    assert_eq!(&std::fs::read(&path).unwrap()[..UB], &original_userblock[..]);
+    assert_eq!(
+        file.dataset("string_scalar").unwrap().read_u32().unwrap(),
+        before
+    );
+    assert_eq!(
+        &std::fs::read(&path).unwrap()[..UB],
+        &original_userblock[..]
+    );
 
     std::fs::remove_file(&path).ok();
 }
@@ -213,7 +243,10 @@ fn userblock_chunked_relocating_overwrite_roundtrip() {
 
     let file = File::open(&path).unwrap();
     assert_eq!(file.dataset("c").unwrap().read_f64().unwrap(), updated);
-    assert_eq!(file.dataset("keep").unwrap().read_i32().unwrap(), vec![11, 22, 33]);
+    assert_eq!(
+        file.dataset("keep").unwrap().read_i32().unwrap(),
+        vec![11, 22, 33]
+    );
     assert_userblock_unchanged(&path, &userblock);
 
     std::fs::remove_file(&path).ok();
@@ -231,7 +264,8 @@ fn userblock_chunked_overwrite_reuses_reclaimed_space() {
     let original = vec![3.5f64; 800];
     let mut b = FileBuilder::new();
     b.with_userblock(UB as u64);
-    b.create_dataset("keep").with_f64_data(&[1.0, 2.0, 3.0, 4.0, 5.0]);
+    b.create_dataset("keep")
+        .with_f64_data(&[1.0, 2.0, 3.0, 4.0, 5.0]);
     b.create_dataset("c")
         .with_f64_data(&original)
         .with_shape(&[800])

--- a/tests/edit_userblock_chunked.rs
+++ b/tests/edit_userblock_chunked.rs
@@ -214,6 +214,107 @@ fn real_mat_add_chunked_dataset_preserves_userblock() {
 }
 
 #[test]
+fn userblock_extensible_array_add_and_overwrite_roundtrip() {
+    // An unlimited-maxshape dataset uses the extensible-array (v4 type 4) chunk
+    // index, which embeds many internal addresses (EA header, index block,
+    // secondary/data blocks) — all built off the planner base. This exercises that
+    // index type's base arithmetic on a userblock file, for both add and a
+    // relocating overwrite.
+    let path = std::env::temp_dir().join("hdf5_pure_ub_ea.h5");
+    let mut b = FileBuilder::new();
+    b.with_userblock(UB as u64);
+    b.create_dataset("keep").with_i32_data(&[7, 8, 9]);
+    let mut bytes = b.finish().unwrap();
+    let userblock = stamp_userblock(&mut bytes);
+    std::fs::write(&path, &bytes).unwrap();
+
+    let added: Vec<f64> = (0..500).map(|i| (i as f64).sin() * 1e3).collect();
+    {
+        let mut s = EditSession::open(&path).unwrap();
+        s.create_dataset("ea")
+            .with_f64_data(&added)
+            .with_shape(&[500])
+            .with_chunks(&[40])
+            .with_maxshape(&[u64::MAX])
+            .with_deflate(6);
+        s.commit().unwrap();
+    }
+    assert_eq!(
+        File::open(&path)
+            .unwrap()
+            .dataset("ea")
+            .unwrap()
+            .read_f64()
+            .unwrap(),
+        added
+    );
+
+    // Relocating overwrite of the extensible-array dataset (different compressed
+    // sizes), which rebuilds the EA index + chunk blob and reclaims the old storage.
+    let updated: Vec<f64> = (0..500).map(|i| (i as f64) * 0.001).collect();
+    {
+        let mut s = EditSession::open(&path).unwrap();
+        s.write_dataset("ea").with_f64_data(&updated);
+        s.commit().unwrap();
+    }
+
+    let file = File::open(&path).unwrap();
+    assert_eq!(file.dataset("ea").unwrap().read_f64().unwrap(), updated);
+    assert_eq!(
+        file.dataset("keep").unwrap().read_i32().unwrap(),
+        vec![7, 8, 9]
+    );
+    assert_userblock_unchanged(&path, &userblock);
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn userblock_single_chunk_index_add_and_overwrite() {
+    // A dataset whose shape equals its chunk shape stores a single chunk (v4 type 1
+    // single-chunk index), whose address lives in the data-layout message rather
+    // than a separate index structure. Exercise add + overwrite on a userblock file.
+    let path = std::env::temp_dir().join("hdf5_pure_ub_single_chunk.h5");
+    let mut b = FileBuilder::new();
+    b.with_userblock(UB as u64);
+    let mut bytes = b.finish().unwrap();
+    let userblock = stamp_userblock(&mut bytes);
+    std::fs::write(&path, &bytes).unwrap();
+
+    let added: Vec<f64> = (0..50).map(|i| i as f64 * 0.5).collect();
+    {
+        let mut s = EditSession::open(&path).unwrap();
+        s.create_dataset("sc")
+            .with_f64_data(&added)
+            .with_shape(&[50])
+            .with_chunks(&[50])
+            .with_deflate(6);
+        s.commit().unwrap();
+    }
+    assert_eq!(
+        File::open(&path)
+            .unwrap()
+            .dataset("sc")
+            .unwrap()
+            .read_f64()
+            .unwrap(),
+        added
+    );
+
+    let updated: Vec<f64> = (0..50).map(|i| (i as f64).cos()).collect();
+    {
+        let mut s = EditSession::open(&path).unwrap();
+        s.write_dataset("sc").with_f64_data(&updated);
+        s.commit().unwrap();
+    }
+    let file = File::open(&path).unwrap();
+    assert_eq!(file.dataset("sc").unwrap().read_f64().unwrap(), updated);
+    assert_userblock_unchanged(&path, &userblock);
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
 fn userblock_chunked_relocating_overwrite_roundtrip() {
     // A deflate dataset whose new contents compress to different per-chunk sizes
     // cannot re-fill its slots, so the overwrite rebuilds and relocates the chunk
@@ -254,38 +355,55 @@ fn userblock_chunked_relocating_overwrite_roundtrip() {
 
 #[test]
 fn userblock_chunked_overwrite_reuses_reclaimed_space() {
-    // Reclaim-correctness check: a relocating chunked overwrite frees the old
-    // chunk storage into the session free list; a second commit in the same
-    // session then allocates into that freed region. If reclaim had freed a live
-    // span (a base-address mistake), the second commit would corrupt it — so the
-    // test reads every dataset back and (when built with the reference HDF5 C
-    // library) the crosscheck below independently confirms the result.
+    // Reclaim-correctness check (the over-reclaim tripwire). A relocating chunked
+    // overwrite frees the old chunk storage into the session free list; a later
+    // commit in the same session then allocates a small *contiguous* dataset into
+    // that freed region. (A new chunk blob always appends — its addresses are built
+    // for end-of-file — so the freed hole is reused by contiguous data / headers,
+    // not by another chunk blob.) If reclaim had freed a live span (a base-address
+    // mistake), the reuse would write over it; every dataset is read back here and
+    // the C-library crosscheck confirms it independently.
     let path = std::env::temp_dir().join("hdf5_pure_ub_chunk_reclaim.h5");
-    let original = vec![3.5f64; 800];
+    // A moderately-compressible original lays down a sizeable contiguous chunk blob
+    // (the hole that will be reclaimed). The high-entropy replacement re-encodes to
+    // chunks that no longer fit those slots, forcing the relocating path.
+    let original: Vec<f64> = (0..1200).map(|i| (i % 3) as f64).collect();
     let mut b = FileBuilder::new();
     b.with_userblock(UB as u64);
     b.create_dataset("keep")
         .with_f64_data(&[1.0, 2.0, 3.0, 4.0, 5.0]);
     b.create_dataset("c")
         .with_f64_data(&original)
-        .with_shape(&[800])
-        .with_chunks(&[40])
+        .with_shape(&[1200])
+        .with_chunks(&[60])
         .with_deflate(6);
     let mut bytes = b.finish().unwrap();
     let userblock = stamp_userblock(&mut bytes);
     std::fs::write(&path, &bytes).unwrap();
 
-    let updated: Vec<f64> = (0..800).map(|i| (i as f64) * 0.013).collect();
-    let reuse: Vec<f64> = (0..64).map(|i| (i as f64) - 7.0).collect();
+    let updated: Vec<f64> = (0..1200).map(|i| (i as f64).sin() * 1e9).collect();
+    let reuse: Vec<f64> = (0..32).map(|i| (i as f64) - 7.0).collect();
+    let reuse_data_bytes = (reuse.len() * 8) as u64;
+    let len_after_commit1;
     {
         let mut s = EditSession::open(&path).unwrap();
         // Commit 1: relocate "c", reclaiming its old chunk storage.
         s.write_dataset("c").with_f64_data(&updated);
         s.commit().unwrap();
-        // Commit 2: add a dataset that fits in the reclaimed region.
+        len_after_commit1 = std::fs::metadata(&path).unwrap().len();
+        // Commit 2: add a small contiguous dataset that fits the reclaimed hole.
         s.create_dataset("reuse").with_f64_data(&reuse);
         s.commit().unwrap();
     }
+
+    // Commit 2 grew the file by less than the reuse dataset's own data bytes, which
+    // is only possible if those bytes were written into reclaimed space rather than
+    // appended — so the reuse genuinely overwrites the freed region (the tripwire).
+    let len_after_commit2 = std::fs::metadata(&path).unwrap().len();
+    assert!(
+        len_after_commit2 < len_after_commit1 + reuse_data_bytes,
+        "commit 2 should reuse reclaimed space, not append the data: {len_after_commit1} -> {len_after_commit2} (reuse data {reuse_data_bytes}B)"
+    );
 
     let file = File::open(&path).unwrap();
     assert_eq!(file.dataset("c").unwrap().read_f64().unwrap(), updated);

--- a/tests/edit_userblock_chunked.rs
+++ b/tests/edit_userblock_chunked.rs
@@ -1,0 +1,266 @@
+//! Chunked-dataset editing on files that carry a userblock (non-zero base
+//! address) — the chunked follow-up to the userblock slice of issue #104.
+//!
+//! Every stored chunk-index and chunk-data address in such a file is relative to
+//! the userblock base. These tests exercise the three chunked write paths on a
+//! userblock file and confirm the userblock bytes survive byte-for-byte:
+//!
+//!   * adding a chunked / filtered dataset (the relocatable blob is built with
+//!     stored addresses and appended at end-of-file),
+//!   * overwriting a chunked dataset in place (the index is walked on a
+//!     base-relative view and the write offsets shifted back), and
+//!   * overwriting a chunked dataset with a relocation (a fresh blob is built and
+//!     the old chunk storage reclaimed), including reuse of that reclaimed space
+//!     by a later commit in the same session.
+
+use hdf5_pure::{EditSession, File, FileBuilder};
+
+const UB: usize = 512;
+const MARKER: &[u8] = b"USERBLOCK-CHUNK-0104";
+
+/// Stamp a recognizable marker across the userblock region of `bytes` and return
+/// the 512-byte userblock as written, for later byte-for-byte comparison.
+fn stamp_userblock(bytes: &mut [u8]) -> Vec<u8> {
+    bytes[..MARKER.len()].copy_from_slice(MARKER);
+    bytes[UB - 1] = 0xAB;
+    bytes[..UB].to_vec()
+}
+
+fn assert_userblock_unchanged(path: &std::path::Path, original: &[u8]) {
+    let after = std::fs::read(path).unwrap();
+    assert_eq!(&after[..UB], original, "userblock bytes changed across the edit");
+}
+
+#[test]
+fn userblock_chunked_add_roundtrip() {
+    // Add a deflate-compressed multi-chunk dataset to a userblock file alongside
+    // an untouched contiguous dataset, then read both back.
+    let path = std::env::temp_dir().join("hdf5_pure_ub_chunk_add.h5");
+    let mut b = FileBuilder::new();
+    b.with_userblock(UB as u64);
+    b.create_dataset("contig").with_f64_data(&[1.0, 2.0, 3.0, 4.0]);
+    let mut bytes = b.finish().unwrap();
+    let userblock = stamp_userblock(&mut bytes);
+    std::fs::write(&path, &bytes).unwrap();
+
+    let added: Vec<f64> = (0..1000).map(|i| (i % 13) as f64 * 0.25).collect();
+    {
+        let mut s = EditSession::open(&path).unwrap();
+        s.create_dataset("chunked")
+            .with_f64_data(&added)
+            .with_shape(&[1000])
+            .with_chunks(&[64])
+            .with_deflate(6);
+        s.commit().unwrap();
+    }
+
+    let file = File::open(&path).unwrap();
+    assert_eq!(file.dataset("chunked").unwrap().read_f64().unwrap(), added);
+    assert_eq!(
+        file.dataset("contig").unwrap().read_f64().unwrap(),
+        vec![1.0, 2.0, 3.0, 4.0]
+    );
+    assert_userblock_unchanged(&path, &userblock);
+    assert_eq!(&std::fs::read(&path).unwrap()[..MARKER.len()], MARKER);
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn userblock_chunked_unfiltered_inplace_overwrite() {
+    // An unfiltered chunked dataset: each chunk's slot is exactly its raw size, so
+    // a same-shape overwrite re-fills every slot in place — no relocation, so the
+    // file does not grow.
+    let path = std::env::temp_dir().join("hdf5_pure_ub_chunk_inplace.h5");
+    let original: Vec<f64> = (0..200).map(|i| i as f64).collect();
+    let mut b = FileBuilder::new();
+    b.with_userblock(UB as u64);
+    b.create_dataset("c")
+        .with_f64_data(&original)
+        .with_shape(&[200])
+        .with_chunks(&[32]);
+    let mut bytes = b.finish().unwrap();
+    let userblock = stamp_userblock(&mut bytes);
+    std::fs::write(&path, &bytes).unwrap();
+    let len_before = std::fs::metadata(&path).unwrap().len();
+
+    let updated: Vec<f64> = (0..200).map(|i| (i as f64) * -2.0 + 1.0).collect();
+    {
+        let mut s = EditSession::open(&path).unwrap();
+        s.write_dataset("c").with_f64_data(&updated);
+        s.commit().unwrap();
+    }
+
+    let len_after = std::fs::metadata(&path).unwrap().len();
+    assert_eq!(
+        len_after, len_before,
+        "an unfiltered same-shape chunked overwrite must stay in place (no growth)"
+    );
+    assert_eq!(File::open(&path).unwrap().dataset("c").unwrap().read_f64().unwrap(), updated);
+    assert_userblock_unchanged(&path, &userblock);
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn userblock_chunked_shrinking_inplace_overwrite() {
+    // A deflate dataset whose new contents re-encode *smaller* than their slots
+    // still fits in place: the chunks are rewritten into their existing slots and
+    // the index is rebuilt in place to record the new (smaller) sizes — no
+    // relocation, so the file does not grow. This exercises the base-aware
+    // in-place index rebuild on a userblock file.
+    let path = std::env::temp_dir().join("hdf5_pure_ub_chunk_shrink.h5");
+    // Poorly compressible original (high-entropy) vs. highly compressible
+    // replacement (all equal): each new chunk re-encodes far smaller than its slot.
+    let original: Vec<f64> = (0..400).map(|i| (i as f64).sin() * 1e6).collect();
+    let mut b = FileBuilder::new();
+    b.with_userblock(UB as u64);
+    b.create_dataset("c")
+        .with_f64_data(&original)
+        .with_shape(&[400])
+        .with_chunks(&[40])
+        .with_deflate(6);
+    let mut bytes = b.finish().unwrap();
+    let userblock = stamp_userblock(&mut bytes);
+    std::fs::write(&path, &bytes).unwrap();
+    let len_before = std::fs::metadata(&path).unwrap().len();
+
+    let updated = vec![1.5f64; 400];
+    {
+        let mut s = EditSession::open(&path).unwrap();
+        s.write_dataset("c").with_f64_data(&updated);
+        s.commit().unwrap();
+    }
+
+    let len_after = std::fs::metadata(&path).unwrap().len();
+    assert!(
+        len_after <= len_before,
+        "a shrinking chunked overwrite must stay in place (no growth): {len_before} -> {len_after}"
+    );
+    assert_eq!(File::open(&path).unwrap().dataset("c").unwrap().read_f64().unwrap(), updated);
+    assert_userblock_unchanged(&path, &userblock);
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn real_mat_add_chunked_dataset_preserves_userblock() {
+    // Adding a chunked/deflate dataset to a real MATLAB v7.3 file: its chunk
+    // index and chunk data addresses are written relative to the 512-byte MATLAB
+    // userblock, and the added value plus an untouched original both read back.
+    let src = std::path::Path::new("tests/fixtures/mat_real/test_string_v73.mat");
+    let path = std::env::temp_dir().join("hdf5_pure_ub_real_mat_chunk.mat");
+    std::fs::copy(src, &path).unwrap();
+    let original_userblock = std::fs::read(&path).unwrap()[..UB].to_vec();
+    assert_eq!(&original_userblock[..10], b"MATLAB 7.3");
+
+    let before = File::open(&path)
+        .unwrap()
+        .dataset("string_scalar")
+        .unwrap()
+        .read_u32()
+        .unwrap();
+
+    let added: Vec<f64> = (0..600).map(|i| (i % 17) as f64 * 0.5).collect();
+    {
+        let mut s = EditSession::open(&path).unwrap();
+        s.create_dataset("hdf5_pure_chunk_probe")
+            .with_f64_data(&added)
+            .with_shape(&[600])
+            .with_chunks(&[64])
+            .with_deflate(6);
+        s.commit().unwrap();
+    }
+
+    let file = File::open(&path).unwrap();
+    assert_eq!(
+        file.dataset("hdf5_pure_chunk_probe").unwrap().read_f64().unwrap(),
+        added
+    );
+    assert_eq!(file.dataset("string_scalar").unwrap().read_u32().unwrap(), before);
+    assert_eq!(&std::fs::read(&path).unwrap()[..UB], &original_userblock[..]);
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn userblock_chunked_relocating_overwrite_roundtrip() {
+    // A deflate dataset whose new contents compress to different per-chunk sizes
+    // cannot re-fill its slots, so the overwrite rebuilds and relocates the chunk
+    // storage and reclaims the old blob. The new value must read back.
+    let path = std::env::temp_dir().join("hdf5_pure_ub_chunk_reloc.h5");
+    // Highly compressible original (all equal) vs. a varied replacement: their
+    // compressed sizes differ, forcing the relocating path.
+    let original = vec![7.0f64; 500];
+    let mut b = FileBuilder::new();
+    b.with_userblock(UB as u64);
+    b.create_dataset("keep").with_i32_data(&[11, 22, 33]);
+    b.create_dataset("c")
+        .with_f64_data(&original)
+        .with_shape(&[500])
+        .with_chunks(&[50])
+        .with_deflate(6);
+    let mut bytes = b.finish().unwrap();
+    let userblock = stamp_userblock(&mut bytes);
+    std::fs::write(&path, &bytes).unwrap();
+
+    let updated: Vec<f64> = (0..500).map(|i| (i as f64).sin()).collect();
+    {
+        let mut s = EditSession::open(&path).unwrap();
+        s.write_dataset("c").with_f64_data(&updated);
+        s.commit().unwrap();
+    }
+
+    let file = File::open(&path).unwrap();
+    assert_eq!(file.dataset("c").unwrap().read_f64().unwrap(), updated);
+    assert_eq!(file.dataset("keep").unwrap().read_i32().unwrap(), vec![11, 22, 33]);
+    assert_userblock_unchanged(&path, &userblock);
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn userblock_chunked_overwrite_reuses_reclaimed_space() {
+    // Reclaim-correctness check: a relocating chunked overwrite frees the old
+    // chunk storage into the session free list; a second commit in the same
+    // session then allocates into that freed region. If reclaim had freed a live
+    // span (a base-address mistake), the second commit would corrupt it — so the
+    // test reads every dataset back and (when built with the reference HDF5 C
+    // library) the crosscheck below independently confirms the result.
+    let path = std::env::temp_dir().join("hdf5_pure_ub_chunk_reclaim.h5");
+    let original = vec![3.5f64; 800];
+    let mut b = FileBuilder::new();
+    b.with_userblock(UB as u64);
+    b.create_dataset("keep").with_f64_data(&[1.0, 2.0, 3.0, 4.0, 5.0]);
+    b.create_dataset("c")
+        .with_f64_data(&original)
+        .with_shape(&[800])
+        .with_chunks(&[40])
+        .with_deflate(6);
+    let mut bytes = b.finish().unwrap();
+    let userblock = stamp_userblock(&mut bytes);
+    std::fs::write(&path, &bytes).unwrap();
+
+    let updated: Vec<f64> = (0..800).map(|i| (i as f64) * 0.013).collect();
+    let reuse: Vec<f64> = (0..64).map(|i| (i as f64) - 7.0).collect();
+    {
+        let mut s = EditSession::open(&path).unwrap();
+        // Commit 1: relocate "c", reclaiming its old chunk storage.
+        s.write_dataset("c").with_f64_data(&updated);
+        s.commit().unwrap();
+        // Commit 2: add a dataset that fits in the reclaimed region.
+        s.create_dataset("reuse").with_f64_data(&reuse);
+        s.commit().unwrap();
+    }
+
+    let file = File::open(&path).unwrap();
+    assert_eq!(file.dataset("c").unwrap().read_f64().unwrap(), updated);
+    assert_eq!(file.dataset("reuse").unwrap().read_f64().unwrap(), reuse);
+    assert_eq!(
+        file.dataset("keep").unwrap().read_f64().unwrap(),
+        vec![1.0, 2.0, 3.0, 4.0, 5.0]
+    );
+    assert_userblock_unchanged(&path, &userblock);
+
+    std::fs::remove_file(&path).ok();
+}

--- a/tests/edit_userblock_crosscheck.rs
+++ b/tests/edit_userblock_crosscheck.rs
@@ -202,3 +202,37 @@ fn userblock_chunked_reclaimed_space_reused_read_by_c_library() {
         vec![10.0, 20.0, 30.0]
     );
 }
+
+#[test]
+fn userblock_extensible_array_add_read_by_c_library() {
+    // An unlimited-maxshape dataset uses the extensible-array chunk index, which
+    // embeds many internal addresses built off the planner base. Adding one to a
+    // userblock file and reading it back through the C library confirms every EA
+    // address was stored relative to the base correctly.
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("pure_ub_ea.h5");
+
+    let mut b = FileBuilder::new();
+    b.with_userblock(UB);
+    b.create_dataset("keep").with_i32_data(&[7, 8, 9]);
+    std::fs::write(&path, b.finish().unwrap()).unwrap();
+
+    let added: Vec<f64> = (0..500).map(|i| (i as f64).sin() * 1e3).collect();
+    {
+        let mut s = EditSession::open(&path).unwrap();
+        s.create_dataset("ea")
+            .with_f64_data(&added)
+            .with_shape(&[500])
+            .with_chunks(&[40])
+            .with_maxshape(&[u64::MAX])
+            .with_deflate(6);
+        s.commit().unwrap();
+    }
+
+    let c = hdf5::File::open(&path).unwrap();
+    assert_eq!(c.dataset("ea").unwrap().read_raw::<f64>().unwrap(), added);
+    assert_eq!(
+        c.dataset("keep").unwrap().read_raw::<i32>().unwrap(),
+        vec![7, 8, 9]
+    );
+}

--- a/tests/edit_userblock_crosscheck.rs
+++ b/tests/edit_userblock_crosscheck.rs
@@ -83,3 +83,85 @@ fn real_mat_edited_then_read_by_c_library() {
         before
     );
 }
+
+#[test]
+fn userblock_chunked_add_and_overwrite_read_by_c_library() {
+    // Adding a chunked/filtered dataset and overwriting an existing one on a
+    // userblock file both write chunk-index and chunk-data addresses relative to
+    // the base. The C library reading the result back is the external proof that
+    // every such address was stored correctly.
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("pure_ub_chunk.h5");
+
+    let seed = vec![2.0f64; 300];
+    let mut b = FileBuilder::new();
+    b.with_userblock(UB);
+    b.create_dataset("contig").with_i32_data(&[1, 2, 3]);
+    b.create_dataset("c")
+        .with_f64_data(&seed)
+        .with_shape(&[300])
+        .with_chunks(&[30])
+        .with_deflate(6);
+    std::fs::write(&path, b.finish().unwrap()).unwrap();
+
+    let added: Vec<f64> = (0..400).map(|i| (i % 11) as f64 * 0.5).collect();
+    let updated: Vec<f64> = (0..300).map(|i| (i as f64).cos()).collect();
+    {
+        let mut s = EditSession::open(&path).unwrap();
+        // Add a new chunked dataset and relocate-overwrite the existing one.
+        s.create_dataset("added")
+            .with_f64_data(&added)
+            .with_shape(&[400])
+            .with_chunks(&[50])
+            .with_deflate(6);
+        s.write_dataset("c").with_f64_data(&updated);
+        s.commit().unwrap();
+    }
+
+    // pure reader
+    let f = File::open(&path).unwrap();
+    assert_eq!(f.dataset("c").unwrap().read_f64().unwrap(), updated);
+    assert_eq!(f.dataset("added").unwrap().read_f64().unwrap(), added);
+
+    // reference C library reader — the real interop proof.
+    let c = hdf5::File::open(&path).unwrap();
+    assert_eq!(c.dataset("c").unwrap().read_raw::<f64>().unwrap(), updated);
+    assert_eq!(c.dataset("added").unwrap().read_raw::<f64>().unwrap(), added);
+    assert_eq!(c.dataset("contig").unwrap().read_raw::<i32>().unwrap(), vec![1, 2, 3]);
+}
+
+#[test]
+fn userblock_chunked_reclaimed_space_reused_read_by_c_library() {
+    // A relocating chunked overwrite frees the old chunk storage; a later commit
+    // in the same session reuses it. The C library reading every dataset back
+    // confirms the reclaim freed only dead bytes (a base-address mistake in the
+    // span enumerators would have corrupted a live region the reuse then wrote).
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("pure_ub_reclaim.h5");
+
+    let seed = vec![5.0f64; 600];
+    let mut b = FileBuilder::new();
+    b.with_userblock(UB);
+    b.create_dataset("keep").with_f64_data(&[10.0, 20.0, 30.0]);
+    b.create_dataset("c")
+        .with_f64_data(&seed)
+        .with_shape(&[600])
+        .with_chunks(&[40])
+        .with_deflate(6);
+    std::fs::write(&path, b.finish().unwrap()).unwrap();
+
+    let updated: Vec<f64> = (0..600).map(|i| (i as f64) * 0.01).collect();
+    let reuse: Vec<f64> = (0..80).map(|i| (i as f64) + 0.5).collect();
+    {
+        let mut s = EditSession::open(&path).unwrap();
+        s.write_dataset("c").with_f64_data(&updated);
+        s.commit().unwrap();
+        s.create_dataset("reuse").with_f64_data(&reuse);
+        s.commit().unwrap();
+    }
+
+    let c = hdf5::File::open(&path).unwrap();
+    assert_eq!(c.dataset("c").unwrap().read_raw::<f64>().unwrap(), updated);
+    assert_eq!(c.dataset("reuse").unwrap().read_raw::<f64>().unwrap(), reuse);
+    assert_eq!(c.dataset("keep").unwrap().read_raw::<f64>().unwrap(), vec![10.0, 20.0, 30.0]);
+}

--- a/tests/edit_userblock_crosscheck.rs
+++ b/tests/edit_userblock_crosscheck.rs
@@ -36,19 +36,37 @@ fn pure_userblock_file_edited_then_read_by_c_library() {
 
     // pure reader
     let f = File::open(&path).unwrap();
-    assert_eq!(f.dataset("alpha").unwrap().read_f64().unwrap(), vec![9.0, 8.0, 7.0]);
-    assert_eq!(f.dataset("added").unwrap().read_f64().unwrap(), vec![100.0, 200.0]);
-    assert_eq!(f.dataset("grp/gamma").unwrap().read_i32().unwrap(), vec![1, 2, 3]);
+    assert_eq!(
+        f.dataset("alpha").unwrap().read_f64().unwrap(),
+        vec![9.0, 8.0, 7.0]
+    );
+    assert_eq!(
+        f.dataset("added").unwrap().read_f64().unwrap(),
+        vec![100.0, 200.0]
+    );
+    assert_eq!(
+        f.dataset("grp/gamma").unwrap().read_i32().unwrap(),
+        vec![1, 2, 3]
+    );
 
     // reference C library reader — the real interop proof.
     let c = hdf5::File::open(&path).unwrap();
-    assert_eq!(c.dataset("alpha").unwrap().read_raw::<f64>().unwrap(), vec![9.0, 8.0, 7.0]);
-    assert_eq!(c.dataset("added").unwrap().read_raw::<f64>().unwrap(), vec![100.0, 200.0]);
+    assert_eq!(
+        c.dataset("alpha").unwrap().read_raw::<f64>().unwrap(),
+        vec![9.0, 8.0, 7.0]
+    );
+    assert_eq!(
+        c.dataset("added").unwrap().read_raw::<f64>().unwrap(),
+        vec![100.0, 200.0]
+    );
     assert_eq!(
         c.dataset("grp/beta").unwrap().read_raw::<i32>().unwrap(),
         vec![10, 20, 30, 40]
     );
-    assert_eq!(c.dataset("grp/gamma").unwrap().read_raw::<i32>().unwrap(), vec![1, 2, 3]);
+    assert_eq!(
+        c.dataset("grp/gamma").unwrap().read_raw::<i32>().unwrap(),
+        vec![1, 2, 3]
+    );
 }
 
 #[test]
@@ -66,7 +84,8 @@ fn real_mat_edited_then_read_by_c_library() {
 
     {
         let mut s = EditSession::open(&path).unwrap();
-        s.create_dataset("hdf5_pure_probe").with_f64_data(&[42.0, -1.0, 3.5]);
+        s.create_dataset("hdf5_pure_probe")
+            .with_f64_data(&[42.0, -1.0, 3.5]);
         s.commit().unwrap();
     }
 
@@ -75,11 +94,17 @@ fn real_mat_edited_then_read_by_c_library() {
     // relative to the 512-byte MATLAB userblock.
     let c = hdf5::File::open(&path).unwrap();
     assert_eq!(
-        c.dataset("hdf5_pure_probe").unwrap().read_raw::<f64>().unwrap(),
+        c.dataset("hdf5_pure_probe")
+            .unwrap()
+            .read_raw::<f64>()
+            .unwrap(),
         vec![42.0, -1.0, 3.5]
     );
     assert_eq!(
-        c.dataset("string_scalar").unwrap().read_raw::<u32>().unwrap(),
+        c.dataset("string_scalar")
+            .unwrap()
+            .read_raw::<u32>()
+            .unwrap(),
         before
     );
 }
@@ -126,8 +151,14 @@ fn userblock_chunked_add_and_overwrite_read_by_c_library() {
     // reference C library reader — the real interop proof.
     let c = hdf5::File::open(&path).unwrap();
     assert_eq!(c.dataset("c").unwrap().read_raw::<f64>().unwrap(), updated);
-    assert_eq!(c.dataset("added").unwrap().read_raw::<f64>().unwrap(), added);
-    assert_eq!(c.dataset("contig").unwrap().read_raw::<i32>().unwrap(), vec![1, 2, 3]);
+    assert_eq!(
+        c.dataset("added").unwrap().read_raw::<f64>().unwrap(),
+        added
+    );
+    assert_eq!(
+        c.dataset("contig").unwrap().read_raw::<i32>().unwrap(),
+        vec![1, 2, 3]
+    );
 }
 
 #[test]
@@ -162,6 +193,12 @@ fn userblock_chunked_reclaimed_space_reused_read_by_c_library() {
 
     let c = hdf5::File::open(&path).unwrap();
     assert_eq!(c.dataset("c").unwrap().read_raw::<f64>().unwrap(), updated);
-    assert_eq!(c.dataset("reuse").unwrap().read_raw::<f64>().unwrap(), reuse);
-    assert_eq!(c.dataset("keep").unwrap().read_raw::<f64>().unwrap(), vec![10.0, 20.0, 30.0]);
+    assert_eq!(
+        c.dataset("reuse").unwrap().read_raw::<f64>().unwrap(),
+        reuse
+    );
+    assert_eq!(
+        c.dataset("keep").unwrap().read_raw::<f64>().unwrap(),
+        vec![10.0, 20.0, 30.0]
+    );
 }

--- a/tests/edit_userblock_crosscheck.rs
+++ b/tests/edit_userblock_crosscheck.rs
@@ -1,0 +1,85 @@
+// Crosschecks link the reference HDF5 C library (the `hdf5-metno` dev-dependency),
+// which is gated to 64-bit-pointer targets; skip them on 32-bit so the pure-Rust
+// suite can run under `cross test --target i686-...`.
+#![cfg(not(target_pointer_width = "32"))]
+//! Cross-validation for editing files with a userblock (the userblock slice of
+//! issue #104) against the reference C library. A single off-by-base address in
+//! an edited file makes the C library error or read garbage, so reading the
+//! result back through `hdf5` is the external tripwire that the editor stored
+//! every root/link/layout address relative to the base address correctly.
+
+use hdf5_pure::{EditSession, File, FileBuilder};
+use tempfile::tempdir;
+
+const UB: u64 = 512;
+
+#[test]
+fn pure_userblock_file_edited_then_read_by_c_library() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("pure_ub.h5");
+
+    let mut b = FileBuilder::new();
+    b.with_userblock(UB);
+    b.create_dataset("alpha").with_f64_data(&[1.0, 2.0, 3.0]);
+    let mut g = b.create_group("grp");
+    g.create_dataset("beta").with_i32_data(&[10, 20, 30, 40]);
+    b.add_group(g.finish());
+    std::fs::write(&path, b.finish().unwrap()).unwrap();
+
+    {
+        let mut s = EditSession::open(&path).unwrap();
+        s.write_dataset("alpha").with_f64_data(&[9.0, 8.0, 7.0]);
+        s.create_dataset("added").with_f64_data(&[100.0, 200.0]);
+        s.create_dataset("grp/gamma").with_i32_data(&[1, 2, 3]);
+        s.commit().unwrap();
+    }
+
+    // pure reader
+    let f = File::open(&path).unwrap();
+    assert_eq!(f.dataset("alpha").unwrap().read_f64().unwrap(), vec![9.0, 8.0, 7.0]);
+    assert_eq!(f.dataset("added").unwrap().read_f64().unwrap(), vec![100.0, 200.0]);
+    assert_eq!(f.dataset("grp/gamma").unwrap().read_i32().unwrap(), vec![1, 2, 3]);
+
+    // reference C library reader — the real interop proof.
+    let c = hdf5::File::open(&path).unwrap();
+    assert_eq!(c.dataset("alpha").unwrap().read_raw::<f64>().unwrap(), vec![9.0, 8.0, 7.0]);
+    assert_eq!(c.dataset("added").unwrap().read_raw::<f64>().unwrap(), vec![100.0, 200.0]);
+    assert_eq!(
+        c.dataset("grp/beta").unwrap().read_raw::<i32>().unwrap(),
+        vec![10, 20, 30, 40]
+    );
+    assert_eq!(c.dataset("grp/gamma").unwrap().read_raw::<i32>().unwrap(), vec![1, 2, 3]);
+}
+
+#[test]
+fn real_mat_edited_then_read_by_c_library() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("real.mat");
+    std::fs::copy("tests/fixtures/mat_real/test_string_v73.mat", &path).unwrap();
+
+    let before = File::open(&path)
+        .unwrap()
+        .dataset("string_scalar")
+        .unwrap()
+        .read_u32()
+        .unwrap();
+
+    {
+        let mut s = EditSession::open(&path).unwrap();
+        s.create_dataset("hdf5_pure_probe").with_f64_data(&[42.0, -1.0, 3.5]);
+        s.commit().unwrap();
+    }
+
+    // The C library opens the edited real .mat file and reads both the added
+    // dataset and an untouched original — proving every address survived the edit
+    // relative to the 512-byte MATLAB userblock.
+    let c = hdf5::File::open(&path).unwrap();
+    assert_eq!(
+        c.dataset("hdf5_pure_probe").unwrap().read_raw::<f64>().unwrap(),
+        vec![42.0, -1.0, 3.5]
+    );
+    assert_eq!(
+        c.dataset("string_scalar").unwrap().read_raw::<u32>().unwrap(),
+        before
+    );
+}

--- a/tests/repack.rs
+++ b/tests/repack.rs
@@ -586,3 +586,34 @@ fn repacks_single_chunk_filtered_verbatim() {
     std::fs::remove_file(&src).ok();
     std::fs::remove_file(&dst).ok();
 }
+
+#[test]
+fn repacks_chunked_dataset_from_a_userblock_file() {
+    // The source carries a userblock (non-zero base address), so its chunk index
+    // and chunk data are stored base-relative. Repack reads each chunk verbatim
+    // from the source; it must apply the base address, or it reads the wrong bytes
+    // and produces a corrupt copy.
+    let src = tmp("hdf5_pure_repack_ub_src.h5");
+    let dst = tmp("hdf5_pure_repack_ub_dst.h5");
+    let data: Vec<f64> = (0..1000).map(|i| i as f64 * 0.25).collect();
+    let mut b = FileBuilder::new();
+    b.with_userblock(512);
+    b.create_dataset("chk")
+        .with_f64_data(&data)
+        .with_shape(&[1000])
+        .with_deflate(6);
+    b.create_dataset("plain").with_f64_data(&[1.0, 2.0, 3.0]);
+    std::fs::write(&src, b.finish().unwrap()).unwrap();
+
+    repack(&src, &dst, &RepackOptions::new()).unwrap();
+
+    let f = hdf5_pure::File::open(&dst).unwrap();
+    assert_eq!(f.dataset("chk").unwrap().read_f64().unwrap(), data);
+    assert_eq!(
+        f.dataset("plain").unwrap().read_f64().unwrap(),
+        vec![1.0, 2.0, 3.0]
+    );
+
+    std::fs::remove_file(&src).ok();
+    std::fs::remove_file(&dst).ok();
+}

--- a/tests/write_read_roundtrip.rs
+++ b/tests/write_read_roundtrip.rs
@@ -1117,3 +1117,60 @@ fn matching_shape_and_data_is_accepted() {
     assert_eq!(ds.shape().unwrap(), vec![2, 3]);
     assert_eq!(ds.read_f64().unwrap(), vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
 }
+
+// ---------------------------------------------------------------------------
+// Userblock (non-zero base address) reads. A userblock shifts the HDF5 image
+// forward, so every stored address is relative to the base; the reader must
+// apply the base to contiguous data, the chunk index, and each chunk's data.
+// (These exercise the in-memory read path; the C-library cross-checks live in
+// `edit_userblock_crosscheck.rs`.)
+// ---------------------------------------------------------------------------
+
+/// Build a file with a 512-byte userblock and read a dataset back.
+fn userblock_roundtrip_f64(build: impl FnOnce(&mut FileBuilder)) -> File {
+    let mut b = FileBuilder::new();
+    b.with_userblock(512);
+    build(&mut b);
+    let mut bytes = b.finish().unwrap();
+    // Stamp the userblock so a stray read into it would corrupt the marker.
+    bytes[..6].copy_from_slice(b"UBMARK");
+    File::from_bytes(bytes).unwrap()
+}
+
+#[test]
+fn userblock_contiguous_read() {
+    let file = userblock_roundtrip_f64(|b| {
+        b.create_dataset("d").with_f64_data(&[1.0, 2.0, 3.0, 4.0]);
+    });
+    assert_eq!(file.dataset("d").unwrap().read_f64().unwrap(), vec![1.0, 2.0, 3.0, 4.0]);
+}
+
+#[test]
+fn userblock_chunked_deflate_read() {
+    // A multi-chunk deflate dataset: exercises the chunk-index walk plus per-chunk
+    // data reads, all base-relative.
+    let data: Vec<f64> = (0..1000).map(|i| i as f64 * 0.5).collect();
+    let expect = data.clone();
+    let file = userblock_roundtrip_f64(|b| {
+        b.create_dataset("d")
+            .with_f64_data(&data)
+            .with_shape(&[1000])
+            .with_deflate(6);
+    });
+    assert_eq!(file.dataset("d").unwrap().read_f64().unwrap(), expect);
+}
+
+#[test]
+fn userblock_chunked_unfiltered_2d_read() {
+    let data: Vec<f64> = (0..64).map(|i| i as f64).collect();
+    let expect = data.clone();
+    let file = userblock_roundtrip_f64(|b| {
+        b.create_dataset("d")
+            .with_f64_data(&data)
+            .with_shape(&[8, 8])
+            .with_chunks(&[4, 4]);
+    });
+    let ds = file.dataset("d").unwrap();
+    assert_eq!(ds.shape().unwrap(), vec![8, 8]);
+    assert_eq!(ds.read_f64().unwrap(), expect);
+}

--- a/tests/write_read_roundtrip.rs
+++ b/tests/write_read_roundtrip.rs
@@ -1142,7 +1142,10 @@ fn userblock_contiguous_read() {
     let file = userblock_roundtrip_f64(|b| {
         b.create_dataset("d").with_f64_data(&[1.0, 2.0, 3.0, 4.0]);
     });
-    assert_eq!(file.dataset("d").unwrap().read_f64().unwrap(), vec![1.0, 2.0, 3.0, 4.0]);
+    assert_eq!(
+        file.dataset("d").unwrap().read_f64().unwrap(),
+        vec![1.0, 2.0, 3.0, 4.0]
+    );
 }
 
 #[test]

--- a/tests/write_read_roundtrip.rs
+++ b/tests/write_read_roundtrip.rs
@@ -1177,3 +1177,37 @@ fn userblock_chunked_unfiltered_2d_read() {
     assert_eq!(ds.shape().unwrap(), vec![8, 8]);
     assert_eq!(ds.read_f64().unwrap(), expect);
 }
+
+#[test]
+fn userblock_chunked_deflate_streaming_read() {
+    // The streaming reader walks the chunk index through `BaseOffsetSource`. This
+    // covers that path (and its metadata-cache forwarding) on a userblock file and
+    // checks it matches a buffered read byte-for-byte.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("ub_chunk_stream.h5");
+    let data: Vec<f64> = (0..1000).map(|i| (i % 19) as f64 * 0.25).collect();
+
+    let mut b = FileBuilder::new();
+    b.with_userblock(512);
+    b.create_dataset("d")
+        .with_f64_data(&data)
+        .with_shape(&[1000])
+        .with_chunks(&[64])
+        .with_deflate(6);
+    std::fs::write(&path, b.finish().unwrap()).unwrap();
+
+    let buffered = File::open(&path)
+        .unwrap()
+        .dataset("d")
+        .unwrap()
+        .read_f64()
+        .unwrap();
+    let streamed = File::open_streaming(&path)
+        .unwrap()
+        .dataset("d")
+        .unwrap()
+        .read_f64()
+        .unwrap();
+    assert_eq!(buffered, data);
+    assert_eq!(streamed, data);
+}


### PR DESCRIPTION
Adds in-place editing of HDF5 files that carry a **userblock** (non-zero base address) to `EditSession`, such as MATLAB v7.3 `.mat` files (each carries a 512-byte userblock). This is the editor side of #104.

Every stored address in such a file is relative to the base: the editor reads `stored + base` and writes `file_offset - base` at each disk boundary, and preserves the userblock bytes verbatim.

### Supported on userblock files
- Contiguous value overwrites (same length, in place).
- Additions of contiguous and chunked/filtered datasets.
- Overwrites of chunked datasets: in place when re-encoded chunks fit their slots (including the shrinking case, which rebuilds the index in place), otherwise rebuilt and relocated with the old chunk storage and superseded headers reclaimed.
- Group creation and compact group attributes.

### Still refused on userblock files (clean refusal, never a partial edit; follow-ups)
- Object delete and copy / cross-copy.
- Resizing overwrites of contiguous datasets.

### Read fix included
While building this, a pre-existing read bug surfaced: the reader applied the base address only to contiguous data, so reading (or repacking) a **chunked dataset from a userblock file** returned garbage ("corrupt deflate stream"). Fixed centrally in the reader and the repack path (commit `6ff3b09`). The reference C library and `FileBuilder`-written files were always correct; only the pure-Rust reader was off.

### Approach
The relocatable blob builders build with a planner base of `eof - base_address` (the stored address the blob will occupy) while appending at `eof`, so every embedded address is base-relative. The span/chunk enumerators walk a base-relative view of the file and shift their results back to absolute file offsets.

### Verification
- Pure-Rust tests for every path (synthetic files and a real `.mat` fixture), including a two-commit reclaim-reuse test.
- C-library crosschecks read every edited file back, including the reclaim-reuse case, which is the decisive over-reclaim tripwire: a freed live region would corrupt the reused space and fail the C read.
- Full suite green (no regression in the base-0 chunked editor); `clippy --all-targets` clean.

### Commits
1. `fix(reader)`: apply userblock base address to chunked datasets.
2. `feat(edit)`: in-place editing of userblock (.mat) files (contiguous slice).
3. `feat(edit)`: chunked add/overwrite on userblock files.