### PR TITLE
Complete userblock edit parity: delete, copy, contiguous/compact resize (#104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
-- `EditSession` now opens and edits files that carry a **userblock** (non-zero base address), such as MATLAB v7.3 `.mat` files: it reads and writes addresses relative to the base and preserves the userblock bytes verbatim. Supported edits include contiguous value overwrites, additions of contiguous and chunked/filtered datasets, in-place and relocating overwrites of chunked datasets (with the old chunk storage reclaimed), group creation, and compact attributes; deletions, copies, and resizing overwrites of contiguous datasets on a userblock file are still refused ([#104](https://github.com/stephenberry/hdf5-pure/issues/104)).
+- `EditSession` now opens and edits files that carry a **userblock** (non-zero base address), such as MATLAB v7.3 `.mat` files: it reads and writes addresses relative to the base and preserves the userblock bytes verbatim. Every edit is supported — value overwrites, additions, relocating overwrites of every layout (with old storage reclaimed), object deletion, in-file and cross-file copy, group creation, and compact attributes; only cross-file copy from a userblock *source* is still refused ([#104](https://github.com/stephenberry/hdf5-pure/issues/104)).
 
 ### Fixed
 

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -64,12 +64,14 @@
 //! - The file uses 8-byte offsets/lengths. A **userblock** (non-zero base
 //!   address, as every MATLAB v7.3 `.mat` file has) is supported: addresses are
 //!   read and written relative to the base and the userblock bytes are preserved
-//!   verbatim. Value overwrites, additions of contiguous and chunked/filtered
-//!   datasets, in-place and relocating overwrites of chunked datasets (with the
-//!   old chunk storage reclaimed), group creation, compact attributes, and
-//!   free-space reuse all work on a userblock file; deletions, copies, and
-//!   resizing overwrites of *contiguous* datasets are still refused there. Any
-//!   superblock version (0–3) is accepted: a version 0/1
+//!   verbatim. Every edit works on a userblock file — value overwrites, additions
+//!   of contiguous and chunked/filtered datasets, in-place and relocating
+//!   overwrites of every layout (with the old storage reclaimed), object deletion
+//!   (with base-aware subtree reclaim), in-file copy, cross-file copy into a
+//!   userblock destination, group creation, compact attributes, and free-space
+//!   reuse. The one userblock-specific limitation left is cross-file copy *from* a
+//!   userblock source (the source must have base 0; see [`copy_from`](EditSession::copy_from)).
+//!   Any superblock version (0–3) is accepted: a version 0/1
 //!   (symbol-table) file is edited by converting each group on the edited path
 //!   to the latest format and repointing the superblock's root symbol-table
 //!   entry.
@@ -701,8 +703,9 @@ impl EditSession {
         let src_addr = usize::try_from(src_addr)
             .map_err(|_| Error::EditUnsupported("source address exceeds this platform"))?;
         // Read (and foreign-address-screen) the whole subtree now, while `source`
-        // is borrowed; the owned tree carries every byte the commit will write.
-        let tree = Self::read_copy_subtree(src_data, src_addr, 0, true)?;
+        // is borrowed; the owned tree carries every byte the commit will write. The
+        // source is gated to base 0 above, so its stored addresses are absolute.
+        let tree = Self::read_copy_subtree(src_data, src_addr, 0, true, 0)?;
         self.pending_cross_copies.push((dst, tree));
         Ok(())
     }
@@ -737,26 +740,12 @@ impl EditSession {
         // and the editor converts at every disk boundary (read `stored + base`,
         // write `file_offset - base`). Userblock support covers value overwrites,
         // additions of contiguous and chunked/filtered datasets, in-place and
-        // relocating overwrites of chunked datasets (with reclaim), group creation,
-        // and compact group attributes. Operations whose address rewriting is not
-        // yet base-aware are refused up front (a clean refusal, never a
-        // partial/corrupting edit): object copies, deletions, and relocating
-        // (resizing) overwrites of contiguous/compact datasets — the latter refused
-        // in the write preflight below.
+        // relocating overwrites of every layout (chunked, contiguous, compact) with
+        // reclaim, object deletion (with base-aware subtree reclaim), object copy
+        // (in-file, and cross-file into a userblock destination), group creation,
+        // and compact group attributes. Cross-file copy still requires a base-0
+        // *source* (see [`copy_from`](Self::copy_from)).
         let base = self.superblock.base_address;
-        if base != 0 {
-            if !self.pending_copies.is_empty() || !self.pending_cross_copies.is_empty() {
-                return Err(Error::EditUnsupported(
-                    "copying objects within or into a file with a userblock is not supported \
-                     in place yet",
-                ));
-            }
-            if !self.pending_deletes.is_empty() {
-                return Err(Error::EditUnsupported(
-                    "deleting objects from a file with a userblock is not supported in place yet",
-                ));
-            }
-        }
 
         // --- Preflight value overwrites (`write_dataset`) before any write, under
         // the same all-or-nothing contract as additions. Each is resolved,
@@ -801,16 +790,14 @@ impl EditSession {
                 WritePlan::InPlaceChunks { writes } => inplace_writes.extend(writes),
                 WritePlan::Moving(mw) => {
                     // A relocating overwrite rewrites the dataset's header and data
-                    // address. The chunked variant is base-aware on a userblock file
-                    // (it rebuilds the chunk blob with stored addresses and reclaims
-                    // the old storage base-relative); the contiguous/compact resize
-                    // variant is not yet, so refuse it on a userblock file.
-                    if base != 0 && !matches!(mw, MovingWrite::Chunked { .. }) {
-                        return Err(Error::EditUnsupported(
-                            "overwriting a contiguous or compact dataset that resizes or relocates \
-                             its header is not supported on a file with a userblock yet",
-                        ));
-                    }
+                    // address. Every variant is base-aware on a userblock file: the
+                    // chunked one rebuilds the chunk blob with stored addresses and
+                    // reclaims the old storage base-relative, the contiguous one
+                    // stores the relocated data address base-relative (and frees the
+                    // old extent at its absolute offset), and the compact one carries
+                    // its data inline. The parent link to the rewritten header is
+                    // patched base-relative below.
+                    //
                     // A relocating overwrite is safe only when this is the
                     // dataset's sole hard link. Compute the link graph once.
                     let counts = incoming_links
@@ -927,8 +914,10 @@ impl EditSession {
             let src_addr = usize::try_from(src_addr)
                 .map_err(|_| Error::EditUnsupported("source address exceeds this platform"))?;
             // Read the source subtree from this file's own mirror (`cross_file`
-            // false: same address space, so verbatim addresses stay valid).
-            let tree = Self::read_copy_subtree(&self.data, src_addr, 0, false)?;
+            // false: same address space, so verbatim addresses stay valid). On a
+            // userblock file the stored addresses are base-relative, so pass this
+            // session's base for the read to absolutize them.
+            let tree = Self::read_copy_subtree(&self.data, src_addr, 0, false, base)?;
             add_targets.push(dst.clone());
             let leaf = dst.last().unwrap().clone();
             let parent = dst[..dst.len() - 1].to_vec();
@@ -1123,10 +1112,9 @@ impl EditSession {
         }
         // A superseded group header is dead once the root is repointed. Its chunk
         // spans are enumerated base-aware (`oh_chunk_spans` shifts continuation
-        // addresses by the userblock base and returns absolute file offsets), so
-        // this reclamation works on userblock files too. `collect_free_spans` (the
-        // delete path) is the one enumerator still gated to base-0, because object
-        // deletion is itself refused on a userblock file above.
+        // addresses by the userblock base and returns absolute file offsets), as is
+        // the delete path (`collect_free_spans`), so all of this reclamation works
+        // on userblock files too.
         for &a in &superseded_addrs {
             if let Ok(spans) = self.oh_chunk_spans(a) {
                 to_free.extend(spans);
@@ -1209,9 +1197,8 @@ impl EditSession {
             }
 
             // Write each staged source subtree and link its root into this group.
-            // Link targets are stored relative to the base address (copies are
-            // refused on userblock files, so `base` is 0 here, but keep the
-            // conversion explicit and uniform).
+            // `write_copy_subtree` returns an absolute header address; the parent
+            // link stores it relative to the userblock base.
             for (leaf, tree) in copies {
                 let root = self.write_copy_subtree(&tree)?;
                 region.extend_from_slice(&encode_link_message(&leaf, root - base));
@@ -2310,27 +2297,36 @@ impl EditSession {
     ///
     /// `d` is the buffer the source object lives in: this session's own mirror for
     /// an in-file [`copy`](Self::copy), or another file's image for a cross-file
-    /// [`copy_from`](Self::copy_from). When `cross_file` is set, every copied
-    /// object header is additionally screened by [`reject_foreign_addresses`] —
-    /// verbatim bytes that embed a *source-file* absolute address (variable-length
-    /// or reference data, a committed datatype) would dangle in another file and
-    /// are refused, whereas an in-file copy keeps them valid by sharing the source
-    /// file's heaps and objects.
+    /// [`copy_from`](Self::copy_from). `base` is that buffer's userblock base (the
+    /// session's own base for an in-file copy, always 0 for a cross-file copy, whose
+    /// source is gated to base 0): the stored, base-relative addresses read out of
+    /// the source headers are shifted by it to index `d`. When `cross_file` is set,
+    /// every copied object header is additionally screened by
+    /// [`reject_foreign_addresses`] — verbatim bytes that embed a *source-file*
+    /// absolute address (variable-length or reference data, a committed datatype)
+    /// would dangle in another file and are refused, whereas an in-file copy keeps
+    /// them valid by sharing the source file's heaps and objects.
     fn read_copy_subtree(
         d: &[u8],
         addr: usize,
         depth: u32,
         cross_file: bool,
+        base: u64,
     ) -> Result<CopyTree, Error> {
         if depth >= MAX_COPY_DEPTH {
             return Err(Error::EditUnsupported(
                 "copy source nests too deeply (possible hard-link cycle)",
             ));
         }
-        // `read_copy_subtree` only runs on base-0 address spaces: a cross-file
-        // source is gated to base 0, and an in-file copy is refused on a userblock
-        // file (see `commit`), so the source addresses here are already absolute.
-        match Self::read_object(d, addr, 0)? {
+        // `base` is the userblock base of the buffer `d`: this session's own base
+        // for an in-file copy, and always 0 for a cross-file copy (the source is
+        // gated to base 0 in `copy_from`). `addr` is an absolute offset into `d`;
+        // the stored (base-relative) addresses `read_object` returns for contiguous
+        // data, chunk storage, and child links are converted to absolute offsets by
+        // adding `base` before `d` is indexed or a child is descended into.
+        let base_off = usize::try_from(base)
+            .map_err(|_| Error::EditUnsupported("userblock base address exceeds this platform"))?;
+        match Self::read_object(d, addr, base)? {
             ObjModel::DatasetVerbatim {
                 region,
                 dense_attrs,
@@ -2355,8 +2351,12 @@ impl EditSession {
                     reject_foreign_addresses(&region)?;
                     reject_foreign_dense_attrs(&dense_attrs)?;
                 }
-                let start = usize::try_from(data_addr)
-                    .map_err(|_| Error::EditUnsupported("data address exceeds this platform"))?;
+                // The stored data address is base-relative; shift it to an absolute
+                // offset into `d` before slicing out the data block.
+                let start = data_addr
+                    .checked_add(base)
+                    .and_then(|a| usize::try_from(a).ok())
+                    .ok_or(Error::EditUnsupported("data address exceeds this platform"))?;
                 let len = usize::try_from(data_size)
                     .map_err(|_| Error::EditUnsupported("data size exceeds this platform"))?;
                 let end = start
@@ -2411,10 +2411,17 @@ impl EditSession {
                     maxshape,
                 } = chunked_geometry(&dt, &ds, &layout)?;
 
+                // The layout's chunk-index address and every chunk address it leads
+                // to are stored base-relative, so enumerate and read on a
+                // base-relative view of the source buffer (a no-op slice on a base-0
+                // file). The returned addresses are then offsets into `dview`.
+                let dview = &d[base_off..];
+
                 // Enumerate the source chunks and map them onto a dense grid; a
                 // sparse (holed/unallocated) dataset cannot be reproduced by the
                 // verbatim layout path, which needs every grid slot filled.
-                let infos = enumerate_chunks_buffered(d, &layout, &ds, OFFSET_SIZE, LENGTH_SIZE)?;
+                let infos =
+                    enumerate_chunks_buffered(dview, &layout, &ds, OFFSET_SIZE, LENGTH_SIZE)?;
                 let grid = plan_dense_grid(infos, &ds.dimensions, &chunk_dims).ok_or(
                     Error::EditUnsupported(
                         "a chunked dataset with unallocated (sparse) chunks cannot be copied in place yet",
@@ -2439,9 +2446,9 @@ impl EditSession {
                     let len = ci.chunk_size as usize;
                     let end = start
                         .checked_add(len)
-                        .filter(|&e| e <= d.len())
+                        .filter(|&e| e <= dview.len())
                         .ok_or(Error::EditUnsupported("chunk data is out of bounds"))?;
-                    chunk_bytes.push(d[start..end].to_vec());
+                    chunk_bytes.push(dview[start..end].to_vec());
                     meta.push(ChunkMeta {
                         compressed_size: ci.chunk_size as u64,
                         filter_mask: ci.filter_mask,
@@ -2471,12 +2478,17 @@ impl EditSession {
                 }
                 let mut kids = Vec::with_capacity(children.len());
                 for (name, child) in children {
-                    let child = usize::try_from(child).map_err(|_| {
-                        Error::EditUnsupported("child address exceeds this platform")
-                    })?;
+                    // Child link targets are stored base-relative; re-absolutize
+                    // before descending so `addr` stays an absolute offset into `d`.
+                    let child = child
+                        .checked_add(base)
+                        .and_then(|a| usize::try_from(a).ok())
+                        .ok_or(Error::EditUnsupported(
+                            "child address exceeds this platform",
+                        ))?;
                     kids.push((
                         name,
-                        Self::read_copy_subtree(d, child, depth + 1, cross_file)?,
+                        Self::read_copy_subtree(d, child, depth + 1, cross_file, base)?,
                     ));
                 }
                 Ok(CopyTree::Group {
@@ -2493,8 +2505,12 @@ impl EditSession {
     /// new object-header address of the copied root. The write half of an object
     /// copy; children are written before their parent group so each parent links
     /// its children's new addresses, and a contiguous dataset's data-address field
-    /// is repointed at the freshly-written copy.
+    /// is repointed at the freshly-written copy. Every address the copy writes into
+    /// a header (a contiguous data block, a child link) is stored relative to the
+    /// userblock base (`- base`, a no-op on a base-0 file); the chunked storage and
+    /// dense attribute heaps are laid out base-relative by their own builders.
     fn write_copy_subtree(&mut self, node: &CopyTree) -> Result<u64, Error> {
+        let base = self.superblock.base_address;
         match node {
             CopyTree::DatasetVerbatim {
                 region,
@@ -2513,7 +2529,10 @@ impl EditSession {
             } => {
                 let new_data_addr = self.alloc_or_append(data)?;
                 let mut region = region.clone();
-                region[*addr_off..*addr_off + 8].copy_from_slice(&new_data_addr.to_le_bytes());
+                // `alloc_or_append` returns an absolute offset; the data-layout
+                // address field stores it relative to the userblock base.
+                region[*addr_off..*addr_off + 8]
+                    .copy_from_slice(&(new_data_addr - base).to_le_bytes());
                 // Append the dense heap *after* the data so the heap's base
                 // equals end-of-file (see `append_dense_attrs`).
                 self.append_dense_attrs(&mut region, dense_attrs)?;
@@ -2549,7 +2568,8 @@ impl EditSession {
                 let mut region = non_link_region.clone();
                 for (name, child) in children {
                     let new_child = self.write_copy_subtree(child)?;
-                    region.extend_from_slice(&encode_link_message(name, new_child));
+                    // The link target is stored relative to the userblock base.
+                    region.extend_from_slice(&encode_link_message(name, new_child - base));
                 }
                 // Append the dense heap after the children's headers/data so its
                 // base equals end-of-file (see `append_dense_attrs`).
@@ -2676,6 +2696,7 @@ impl EditSession {
     /// extent (for a resized contiguous dataset) is freed separately, after the
     /// commit's superblock repoint, so it is never reused mid-commit.
     fn write_moving(&mut self, mw: &MovingWrite) -> Result<u64, Error> {
+        let base = self.superblock.base_address;
         match mw {
             MovingWrite::Contiguous {
                 region,
@@ -2685,7 +2706,11 @@ impl EditSession {
             } => {
                 let new_data_addr = self.alloc_or_append(raw)?;
                 let mut region = region.clone();
-                region[*addr_off..*addr_off + 8].copy_from_slice(&new_data_addr.to_le_bytes());
+                // `alloc_or_append` returns an absolute file offset; the contiguous
+                // data-layout field stores it relative to the userblock base (`-
+                // base`, a no-op on a base-0 file).
+                region[*addr_off..*addr_off + 8]
+                    .copy_from_slice(&(new_data_addr - base).to_le_bytes());
                 // The data size field follows the 8-byte address in the contiguous
                 // layout body; keep it in sync with the new length.
                 let size_off = *addr_off + 8;
@@ -2971,14 +2996,16 @@ impl EditSession {
         incoming: &HashMap<u64, u32>,
         out: &mut Vec<(u64, u64)>,
     ) {
-        // NOTE (base): this path runs only for deletions, which are refused on a
-        // userblock file, so `base_address` is always 0 when this is reached. That
-        // is why the contiguous `data_addr` and group child addresses returned by
-        // `read_object` below — which are *stored* (base-relative) values — are used
-        // here as absolute file offsets without a `+ base` shift. Before lifting the
-        // delete refusal for userblock files, shift those by the base (as
-        // `chunked_storage_spans`/`oh_chunk_spans` already do) or the free list
-        // would be seeded with wrong, possibly-live regions.
+        // `addr` is an absolute file offset (the caller resolves it from the live
+        // file, and the group recursion below re-absolutizes each child). `incoming`
+        // is keyed by absolute offset, and `oh_chunk_spans`/`chunked_storage_spans`
+        // both take an absolute address and return absolute spans, so the whole
+        // walk works in absolute file offsets. The one shift this method must apply
+        // itself is on the *stored* (base-relative) addresses `read_object` returns
+        // for a contiguous data block and a group's child links: each is converted
+        // to an absolute offset by adding `base` (a no-op on a base-0 file) before
+        // it is bounds-checked, recorded, or descended into.
+        let base = self.superblock.base_address;
         if depth >= MAX_COPY_DEPTH {
             return;
         }
@@ -3003,21 +3030,31 @@ impl EditSession {
             }) => {
                 out.extend(spans);
                 // A defined, in-bounds contiguous data block is owned outright;
-                // an empty dataset stores the undefined address and owns none.
+                // an empty dataset stores the undefined address and owns none. The
+                // stored address is base-relative, so shift it to an absolute file
+                // offset before bounds-checking and recording it.
                 if data_addr != u64::MAX && data_size > 0 {
-                    if let (Ok(start), Ok(len)) =
-                        (usize::try_from(data_addr), usize::try_from(data_size))
+                    if let (Some(abs), Ok(len)) =
+                        (data_addr.checked_add(base), usize::try_from(data_size))
                     {
-                        if start.checked_add(len).is_some_and(|e| e <= self.data.len()) {
-                            out.push((data_addr, data_size));
+                        if let Ok(start) = usize::try_from(abs) {
+                            if start.checked_add(len).is_some_and(|e| e <= self.data.len()) {
+                                out.push((abs, data_size));
+                            }
                         }
                     }
                 }
             }
             Ok(ObjModel::Group { children, .. }) => {
                 out.extend(spans);
+                // Child link targets are stored base-relative; re-absolutize each
+                // before descending so the recursion keeps working in absolute
+                // offsets (matching `incoming`'s keys and `oh_chunk_spans`).
                 for (_, child) in children {
-                    if let Ok(c) = usize::try_from(child) {
+                    if let Some(c) = child
+                        .checked_add(base)
+                        .and_then(|a| usize::try_from(a).ok())
+                    {
                         self.collect_free_spans(c, depth + 1, incoming, out);
                     }
                 }

--- a/tests/edit_userblock.rs
+++ b/tests/edit_userblock.rs
@@ -10,10 +10,11 @@
 //! This slice supports contiguous value overwrites, additions of contiguous and
 //! chunked/filtered datasets, overwrites of chunked datasets (in place when the
 //! re-encoded chunks fit their slots, otherwise rebuilt and relocated with the
-//! old storage reclaimed), group creation, and compact group attributes.
-//! Deletions, copies, and relocating overwrites of *contiguous* datasets are
-//! refused cleanly on a userblock file (covered below); they remain follow-up
-//! work, and a refusal never corrupts the file.
+//! old storage reclaimed), group creation, and compact group attributes. The
+//! delete, copy, and relocating contiguous/compact overwrite paths are covered in
+//! `edit_userblock_followups.rs` and `edit_userblock_crosscheck.rs`. The one
+//! userblock-specific operation still refused — cross-file copy from a userblock
+//! *source* — is covered below; a refusal never corrupts the file.
 
 use hdf5_pure::{AttrValue, EditSession, File, FileBuilder};
 
@@ -135,76 +136,37 @@ fn userblock_inplace_overwrite_only_takes_fast_path() {
     std::fs::remove_file(&path).ok();
 }
 
-/// Each unsupported operation on a userblock file must be refused with
-/// `EditUnsupported`, and the file must remain valid with its original contents.
+/// Cross-file copy *from* a userblock source is still refused (the source-file
+/// base-address restriction in `copy_from`); the destination file must be left
+/// byte-identical by the refusal. Delete, in-file copy, cross-file copy into a
+/// userblock destination, and resizing overwrites are all supported now and are
+/// exercised in `edit_userblock_followups.rs` / `edit_userblock_crosscheck.rs`.
 #[test]
-fn userblock_unsupported_ops_are_refused_cleanly() {
-    // deletion
-    {
-        let path = std::env::temp_dir().join("hdf5_pure_ub_refuse_delete.h5");
-        build_userblock_file(&path);
-        let mut s = EditSession::open(&path).unwrap();
-        s.delete("alpha");
-        assert!(s.commit().is_err(), "delete should be refused");
-        drop(s);
-        let file = File::open(&path).unwrap();
-        assert_eq!(
-            file.dataset("alpha").unwrap().read_f64().unwrap(),
-            vec![1.0, 2.0, 3.0, 4.0]
-        );
-        std::fs::remove_file(&path).ok();
-    }
+fn userblock_cross_file_copy_from_userblock_source_is_refused() {
+    let src_path = std::env::temp_dir().join("hdf5_pure_ub_xcopy_src_refuse.h5");
+    let dst_path = std::env::temp_dir().join("hdf5_pure_ub_xcopy_dst_refuse.h5");
+    build_userblock_file(&src_path);
+    build_userblock_file(&dst_path);
+    let dst_before = std::fs::read(&dst_path).unwrap();
 
-    // copy
-    {
-        let path = std::env::temp_dir().join("hdf5_pure_ub_refuse_copy.h5");
-        build_userblock_file(&path);
-        let mut s = EditSession::open(&path).unwrap();
-        s.copy("alpha", "alpha_copy");
-        assert!(s.commit().is_err(), "copy should be refused");
-        drop(s);
-        let file = File::open(&path).unwrap();
-        assert!(file.dataset("alpha_copy").is_err());
-        assert_eq!(
-            file.dataset("alpha").unwrap().read_f64().unwrap(),
-            vec![1.0, 2.0, 3.0, 4.0]
-        );
-        std::fs::remove_file(&path).ok();
-    }
+    let source = File::open(&src_path).unwrap();
+    let mut s = EditSession::open(&dst_path).unwrap();
+    // The eager read happens in `copy_from`, so the refusal surfaces there.
+    let err = s.copy_from(&source, "alpha", "imported");
+    assert!(
+        err.is_err(),
+        "cross-file copy from a userblock source should be refused"
+    );
+    drop(s);
 
-    // relocating overwrite of a *contiguous* dataset (a resize). The refusal
-    // happens in the write preflight before any byte is written, so the file must
-    // be byte-identical afterward and the original data must still read back.
-    {
-        let path = std::env::temp_dir().join("hdf5_pure_ub_refuse_contig_resize.h5");
-        build_userblock_file(&path);
-        let before = std::fs::read(&path).unwrap();
+    assert_eq!(
+        std::fs::read(&dst_path).unwrap(),
+        dst_before,
+        "a refused cross-file copy must not modify the destination"
+    );
 
-        let mut s = EditSession::open(&path).unwrap();
-        // A longer value than the on-disk extent forces a relocation.
-        s.write_dataset("alpha")
-            .with_f64_data(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
-        assert!(
-            s.commit().is_err(),
-            "contiguous resizing overwrite should be refused"
-        );
-        drop(s);
-        assert_eq!(
-            std::fs::read(&path).unwrap(),
-            before,
-            "a refused resizing overwrite must not modify the file"
-        );
-        assert_eq!(
-            File::open(&path)
-                .unwrap()
-                .dataset("alpha")
-                .unwrap()
-                .read_f64()
-                .unwrap(),
-            vec![1.0, 2.0, 3.0, 4.0]
-        );
-        std::fs::remove_file(&path).ok();
-    }
+    std::fs::remove_file(&src_path).ok();
+    std::fs::remove_file(&dst_path).ok();
 }
 
 #[test]

--- a/tests/edit_userblock_crosscheck.rs
+++ b/tests/edit_userblock_crosscheck.rs
@@ -8,10 +8,34 @@
 //! result back through `hdf5` is the external tripwire that the editor stored
 //! every root/link/layout address relative to the base address correctly.
 
+use hdf5::dataset::Layout;
+use hdf5::file::LibraryVersion;
 use hdf5_pure::{EditSession, File, FileBuilder};
 use tempfile::tempdir;
 
 const UB: u64 = 512;
+
+/// Create a userblock file with the reference C library. The closure adds
+/// datasets; the file is created with a 512-byte userblock and the modern library
+/// bounds so its on-disk format matches what a real `.mat`-style file carries.
+fn c_userblock_file(path: &std::path::Path, build: impl FnOnce(&hdf5::File)) {
+    let file = hdf5::File::with_options()
+        .with_fcpl(|p| {
+            p.userblock(UB);
+            p
+        })
+        .with_fapl(|p| p.libver_bounds(LibraryVersion::V110, LibraryVersion::latest()))
+        .create(path)
+        .unwrap();
+    build(&file);
+    file.close().unwrap();
+    // Sanity: the file really carries a userblock.
+    assert_eq!(
+        hdf5::File::open(path).unwrap().userblock(),
+        UB,
+        "C library did not produce a userblock file"
+    );
+}
 
 #[test]
 fn pure_userblock_file_edited_then_read_by_c_library() {
@@ -200,6 +224,232 @@ fn userblock_chunked_reclaimed_space_reused_read_by_c_library() {
     assert_eq!(
         c.dataset("keep").unwrap().read_raw::<f64>().unwrap(),
         vec![10.0, 20.0, 30.0]
+    );
+}
+
+#[test]
+fn userblock_contiguous_undefined_address_relocates_read_by_c_library() {
+    // A contiguous dataset the C library created but never wrote has an undefined
+    // data address, so overwriting it relocates the header and writes a fresh data
+    // block. On a userblock file the new data address must be stored relative to
+    // the base; the C library reading it back confirms it was.
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("ub_contig_reloc.h5");
+    c_userblock_file(&path, |file| {
+        // Created without a write: the contiguous data address stays undefined.
+        file.new_dataset::<i32>()
+            .shape((3,))
+            .create("blank")
+            .unwrap();
+        file.new_dataset::<f64>()
+            .shape((2,))
+            .create("keep")
+            .unwrap()
+            .write(&[1.0f64, 2.0])
+            .unwrap();
+    });
+
+    {
+        let mut s = EditSession::open(&path).unwrap();
+        s.write_dataset("blank").with_i32_data(&[5, 6, 7]);
+        s.commit().unwrap();
+    }
+
+    let f = File::open(&path).unwrap();
+    assert_eq!(
+        f.dataset("blank").unwrap().read_i32().unwrap(),
+        vec![5, 6, 7]
+    );
+    assert_eq!(
+        f.dataset("keep").unwrap().read_f64().unwrap(),
+        vec![1.0, 2.0]
+    );
+
+    let c = hdf5::File::open(&path).unwrap();
+    assert_eq!(
+        c.dataset("blank").unwrap().read_raw::<i32>().unwrap(),
+        vec![5, 6, 7]
+    );
+    assert_eq!(
+        c.dataset("keep").unwrap().read_raw::<f64>().unwrap(),
+        vec![1.0, 2.0]
+    );
+}
+
+#[test]
+fn userblock_compact_overwrite_read_by_c_library() {
+    // A compact dataset carries its data inline in the header, so any overwrite
+    // rewrites and relocates the header and relinks the parent. On a userblock file
+    // that relink must be stored relative to the base; the C library reading the
+    // new values back confirms it was.
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("ub_compact.h5");
+    c_userblock_file(&path, |file| {
+        file.new_dataset::<i32>()
+            .shape((4,))
+            .layout(Layout::Compact)
+            .create("cpt")
+            .unwrap()
+            .write(&[1i32, 2, 3, 4])
+            .unwrap();
+        file.new_dataset::<f64>()
+            .shape((2,))
+            .create("keep")
+            .unwrap()
+            .write(&[1.0f64, 2.0])
+            .unwrap();
+    });
+
+    {
+        let mut s = EditSession::open(&path).unwrap();
+        // Same shape, but a compact overwrite always relocates the header.
+        s.write_dataset("cpt").with_i32_data(&[9, 8, 7, 6]);
+        s.commit().unwrap();
+    }
+
+    let f = File::open(&path).unwrap();
+    assert_eq!(
+        f.dataset("cpt").unwrap().read_i32().unwrap(),
+        vec![9, 8, 7, 6]
+    );
+
+    let c = hdf5::File::open(&path).unwrap();
+    assert_eq!(
+        c.dataset("cpt").unwrap().read_raw::<i32>().unwrap(),
+        vec![9, 8, 7, 6]
+    );
+    assert_eq!(
+        c.dataset("keep").unwrap().read_raw::<f64>().unwrap(),
+        vec![1.0, 2.0]
+    );
+}
+
+#[test]
+fn userblock_delete_then_reuse_read_by_c_library() {
+    // Deleting objects from a userblock file reclaims their storage base-relative;
+    // a later add reuses a freed hole. The C library reading every survivor back
+    // confirms the reclaim freed only dead bytes — a base mistake in the subtree
+    // walk would have freed a live region the reuse then overwrote, corrupting it.
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("ub_delete_reuse.h5");
+    c_userblock_file(&path, |file| {
+        let big: Vec<f64> = (0..256).map(|i| i as f64).collect();
+        file.new_dataset::<f64>()
+            .shape((256,))
+            .create("doomed")
+            .unwrap()
+            .write(&big)
+            .unwrap();
+        file.new_dataset::<f64>()
+            .shape((3,))
+            .create("keep")
+            .unwrap()
+            .write(&[10.0f64, 20.0, 30.0])
+            .unwrap();
+        // A chunked dataset whose storage is reclaimed via the index walker.
+        let chunked: Vec<i32> = (0..512).collect();
+        file.new_dataset::<i32>()
+            .shape((512,))
+            .chunk((64,))
+            .create("c")
+            .unwrap()
+            .write(&chunked)
+            .unwrap();
+    });
+
+    let reuse: Vec<f64> = (0..64).map(|i| (i as f64) * -1.5).collect();
+    {
+        let mut s = EditSession::open(&path).unwrap();
+        s.delete("doomed");
+        s.delete("c");
+        s.commit().unwrap();
+        s.create_dataset("reuse").with_f64_data(&reuse);
+        s.commit().unwrap();
+    }
+
+    let f = File::open(&path).unwrap();
+    assert!(f.dataset("doomed").is_err());
+    assert!(f.dataset("c").is_err());
+    assert_eq!(f.dataset("reuse").unwrap().read_f64().unwrap(), reuse);
+
+    let c = hdf5::File::open(&path).unwrap();
+    assert_eq!(
+        c.dataset("reuse").unwrap().read_raw::<f64>().unwrap(),
+        reuse
+    );
+    assert_eq!(
+        c.dataset("keep").unwrap().read_raw::<f64>().unwrap(),
+        vec![10.0, 20.0, 30.0]
+    );
+    assert!(c.dataset("doomed").is_err());
+    assert!(c.dataset("c").is_err());
+}
+
+#[test]
+fn userblock_copy_read_by_c_library() {
+    // Copying objects within a userblock file writes fresh data, chunk storage, and
+    // link addresses, all base-relative. The C library reading every copy back is
+    // the external proof those addresses were stored correctly (a base mistake
+    // would dangle the copy's data/index pointer and error or read garbage).
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("ub_copy.h5");
+    c_userblock_file(&path, |file| {
+        file.new_dataset::<f64>()
+            .shape((4,))
+            .create("alpha")
+            .unwrap()
+            .write(&[1.0f64, 2.0, 3.0, 4.0])
+            .unwrap();
+        let chunked: Vec<i32> = (0..400).collect();
+        file.new_dataset::<i32>()
+            .shape((400,))
+            .chunk((50,))
+            .create("c")
+            .unwrap()
+            .write(&chunked)
+            .unwrap();
+        let grp = file.create_group("grp").unwrap();
+        grp.new_dataset::<f64>()
+            .shape((2,))
+            .create("leaf")
+            .unwrap()
+            .write(&[7.5f64, 8.5])
+            .unwrap();
+    });
+
+    {
+        let mut s = EditSession::open(&path).unwrap();
+        s.copy("alpha", "alpha_copy");
+        s.copy("c", "c_copy");
+        s.copy("grp", "grp_copy");
+        s.commit().unwrap();
+    }
+
+    let expected_c: Vec<i32> = (0..400).collect();
+    let c = hdf5::File::open(&path).unwrap();
+    assert_eq!(
+        c.dataset("alpha_copy").unwrap().read_raw::<f64>().unwrap(),
+        vec![1.0, 2.0, 3.0, 4.0]
+    );
+    assert_eq!(
+        c.dataset("c_copy").unwrap().read_raw::<i32>().unwrap(),
+        expected_c
+    );
+    assert_eq!(
+        c.dataset("grp_copy/leaf")
+            .unwrap()
+            .read_raw::<f64>()
+            .unwrap(),
+        vec![7.5, 8.5]
+    );
+    // Originals untouched.
+    assert_eq!(
+        c.dataset("alpha").unwrap().read_raw::<f64>().unwrap(),
+        vec![1.0, 2.0, 3.0, 4.0]
+    );
+    assert_eq!(
+        c.dataset("c").unwrap().read_raw::<i32>().unwrap(),
+        expected_c
     );
 }
 

--- a/tests/edit_userblock_followups.rs
+++ b/tests/edit_userblock_followups.rs
@@ -1,0 +1,373 @@
+//! Delete and copy editing on files that carry a userblock (non-zero base
+//! address) — the follow-up parity work to the userblock slice of issue #104.
+//!
+//! Both operations rewrite or reclaim on-disk addresses, all of which are stored
+//! relative to the userblock base on such a file. Each test edits a synthetic
+//! userblock file and reads the result back through the pure-Rust reader, and
+//! every test asserts the 512-byte userblock survives the edit byte-for-byte.
+//!
+//! (The resizing-overwrite parity for the contiguous and compact layouts is
+//! exercised in `edit_userblock_crosscheck.rs`: only the reference C library can
+//! create the never-written-contiguous and compact-layout fixtures those paths
+//! need.)
+
+use hdf5_pure::{AttrValue, EditSession, File, FileBuilder};
+
+const UB: usize = 512;
+const MARKER: &[u8] = b"USERBLOCK-FOLLOWUP-104";
+
+/// Stamp a recognizable marker across the userblock region of `bytes` and return
+/// the 512-byte userblock as written, for later byte-for-byte comparison.
+fn stamp_userblock(bytes: &mut [u8]) -> Vec<u8> {
+    bytes[..MARKER.len()].copy_from_slice(MARKER);
+    bytes[UB - 1] = 0xAB;
+    bytes[..UB].to_vec()
+}
+
+fn assert_userblock_unchanged(path: &std::path::Path, original: &[u8]) {
+    let after = std::fs::read(path).unwrap();
+    assert_eq!(
+        &after[..UB],
+        original,
+        "userblock bytes changed across the edit"
+    );
+}
+
+/// Build a userblock file with two root datasets and a nested group+dataset.
+fn build_userblock_file(path: &std::path::Path) -> Vec<u8> {
+    let mut b = FileBuilder::new();
+    b.with_userblock(UB as u64);
+    b.create_dataset("alpha")
+        .with_f64_data(&[1.0, 2.0, 3.0, 4.0]);
+    b.create_dataset("beta").with_i32_data(&[10, 20, 30]);
+    let mut g = b.create_group("grp");
+    g.create_dataset("inner").with_f64_data(&[7.5, 8.5]);
+    b.add_group(g.finish());
+    let mut bytes = b.finish().unwrap();
+    let userblock = stamp_userblock(&mut bytes);
+    std::fs::write(path, &bytes).unwrap();
+    userblock
+}
+
+// ---- delete ----
+
+#[test]
+fn userblock_delete_dataset_roundtrip() {
+    let path = std::env::temp_dir().join("hdf5_pure_ub_fu_delete_ds.h5");
+    let userblock = build_userblock_file(&path);
+
+    {
+        let mut s = EditSession::open(&path).unwrap();
+        s.delete("alpha");
+        s.commit().unwrap();
+    }
+
+    let file = File::open(&path).unwrap();
+    assert!(file.dataset("alpha").is_err(), "alpha should be deleted");
+    // Neighbours survive.
+    assert_eq!(
+        file.dataset("beta").unwrap().read_i32().unwrap(),
+        vec![10, 20, 30]
+    );
+    assert_eq!(
+        file.dataset("grp/inner").unwrap().read_f64().unwrap(),
+        vec![7.5, 8.5]
+    );
+    let mut datasets = file.root().datasets().unwrap();
+    datasets.sort();
+    assert_eq!(datasets, vec!["beta".to_string()]);
+    assert_userblock_unchanged(&path, &userblock);
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn userblock_delete_group_subtree_roundtrip() {
+    // Deleting a group reclaims its whole subtree (its header plus the nested
+    // dataset's header and data). On a userblock file every child link and data
+    // address is base-relative, so the subtree walk must re-absolutize them.
+    let path = std::env::temp_dir().join("hdf5_pure_ub_fu_delete_grp.h5");
+    let userblock = build_userblock_file(&path);
+
+    {
+        let mut s = EditSession::open(&path).unwrap();
+        s.delete("grp");
+        s.commit().unwrap();
+    }
+
+    let file = File::open(&path).unwrap();
+    assert!(file.group("grp").is_err(), "grp should be deleted");
+    assert!(file.dataset("grp/inner").is_err());
+    assert!(file.root().groups().unwrap().is_empty());
+    assert_eq!(
+        file.dataset("alpha").unwrap().read_f64().unwrap(),
+        vec![1.0, 2.0, 3.0, 4.0]
+    );
+    assert_userblock_unchanged(&path, &userblock);
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn userblock_delete_chunked_dataset_roundtrip() {
+    // Deleting a chunked/filtered dataset reclaims its chunk index and chunk data
+    // blocks via the base-aware `chunked_storage_spans`.
+    let path = std::env::temp_dir().join("hdf5_pure_ub_fu_delete_chunk.h5");
+    let mut b = FileBuilder::new();
+    b.with_userblock(UB as u64);
+    b.create_dataset("keep").with_i32_data(&[1, 2, 3]);
+    let chunked: Vec<f64> = (0..800).map(|i| (i % 7) as f64 * 0.5).collect();
+    b.create_dataset("c")
+        .with_f64_data(&chunked)
+        .with_shape(&[800])
+        .with_chunks(&[50])
+        .with_deflate(6);
+    let mut bytes = b.finish().unwrap();
+    let userblock = stamp_userblock(&mut bytes);
+    std::fs::write(&path, &bytes).unwrap();
+
+    {
+        let mut s = EditSession::open(&path).unwrap();
+        s.delete("c");
+        s.commit().unwrap();
+    }
+
+    let file = File::open(&path).unwrap();
+    assert!(file.dataset("c").is_err(), "c should be deleted");
+    assert_eq!(
+        file.dataset("keep").unwrap().read_i32().unwrap(),
+        vec![1, 2, 3]
+    );
+    assert_userblock_unchanged(&path, &userblock);
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn userblock_delete_then_reuse_freed_space() {
+    // Deleting a sizeable contiguous dataset frees its data extent; a later commit
+    // in the same session should reuse that freed hole for a contiguous add rather
+    // than only appending. The reused write lands at the freed *absolute* offset,
+    // so a base mistake in `collect_free_spans` would either leak (no reuse) or, far
+    // worse, free a still-live region the reuse then corrupts.
+    let path = std::env::temp_dir().join("hdf5_pure_ub_fu_delete_reuse.h5");
+    let mut b = FileBuilder::new();
+    b.with_userblock(UB as u64);
+    let big: Vec<f64> = (0..256).map(|i| i as f64).collect();
+    b.create_dataset("big").with_f64_data(&big);
+    b.create_dataset("keep").with_i32_data(&[7, 8, 9]);
+    let mut bytes = b.finish().unwrap();
+    let userblock = stamp_userblock(&mut bytes);
+    std::fs::write(&path, &bytes).unwrap();
+
+    let reuse: Vec<f64> = (0..64).map(|i| (i as f64) * -1.5).collect();
+    {
+        let mut s = EditSession::open(&path).unwrap();
+        s.delete("big");
+        s.commit().unwrap();
+        let len_after_delete = std::fs::metadata(&path).unwrap().len();
+        s.create_dataset("reuse").with_f64_data(&reuse);
+        s.commit().unwrap();
+        let len_after_reuse = std::fs::metadata(&path).unwrap().len();
+        assert!(
+            len_after_reuse < len_after_delete + (reuse.len() * 8) as u64,
+            "reuse commit did not reclaim freed delete space \
+             (delete={len_after_delete}, reuse={len_after_reuse})"
+        );
+    }
+
+    let file = File::open(&path).unwrap();
+    assert!(file.dataset("big").is_err());
+    assert_eq!(file.dataset("reuse").unwrap().read_f64().unwrap(), reuse);
+    assert_eq!(
+        file.dataset("keep").unwrap().read_i32().unwrap(),
+        vec![7, 8, 9]
+    );
+    assert_userblock_unchanged(&path, &userblock);
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn userblock_delete_one_of_several_then_read_attr() {
+    // A delete rewrites the parent group's header (relinking survivors) and frees
+    // the removed object. A sibling group's compact attribute must remain readable.
+    let path = std::env::temp_dir().join("hdf5_pure_ub_fu_delete_attr.h5");
+    let mut b = FileBuilder::new();
+    b.with_userblock(UB as u64);
+    b.create_dataset("doomed").with_f64_data(&[1.0, 2.0]);
+    b.create_dataset("survivor").with_i32_data(&[5, 6]);
+    let mut g = b.create_group("grp");
+    g.set_attr("tag", AttrValue::AsciiString("kept".into()));
+    b.add_group(g.finish());
+    let mut bytes = b.finish().unwrap();
+    let userblock = stamp_userblock(&mut bytes);
+    std::fs::write(&path, &bytes).unwrap();
+
+    {
+        let mut s = EditSession::open(&path).unwrap();
+        s.delete("doomed");
+        s.commit().unwrap();
+    }
+
+    let file = File::open(&path).unwrap();
+    assert!(file.dataset("doomed").is_err());
+    assert_eq!(
+        file.dataset("survivor").unwrap().read_i32().unwrap(),
+        vec![5, 6]
+    );
+    let attrs = file.group("grp").unwrap().attrs().unwrap();
+    assert_eq!(attrs.get("tag"), Some(&AttrValue::String("kept".into())));
+    assert_userblock_unchanged(&path, &userblock);
+
+    std::fs::remove_file(&path).ok();
+}
+
+// ---- copy (in-file) ----
+
+#[test]
+fn userblock_copy_dataset_roundtrip() {
+    // Copying a contiguous dataset writes a fresh data block and header; on a
+    // userblock file the new data address and the parent link to the copy must both
+    // be stored base-relative.
+    let path = std::env::temp_dir().join("hdf5_pure_ub_fu_copy_ds.h5");
+    let userblock = build_userblock_file(&path);
+
+    {
+        let mut s = EditSession::open(&path).unwrap();
+        s.copy("alpha", "alpha_copy");
+        s.copy("grp/inner", "grp/inner_copy");
+        s.commit().unwrap();
+    }
+
+    let file = File::open(&path).unwrap();
+    // Original untouched, copy reads identical values.
+    assert_eq!(
+        file.dataset("alpha").unwrap().read_f64().unwrap(),
+        vec![1.0, 2.0, 3.0, 4.0]
+    );
+    assert_eq!(
+        file.dataset("alpha_copy").unwrap().read_f64().unwrap(),
+        vec![1.0, 2.0, 3.0, 4.0]
+    );
+    assert_eq!(
+        file.dataset("grp/inner_copy").unwrap().read_f64().unwrap(),
+        vec![7.5, 8.5]
+    );
+    assert_userblock_unchanged(&path, &userblock);
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn userblock_copy_group_subtree_roundtrip() {
+    // Copying a whole group deep-copies its nested dataset too; every child link
+    // and data address in the copy is written base-relative.
+    let path = std::env::temp_dir().join("hdf5_pure_ub_fu_copy_grp.h5");
+    let userblock = build_userblock_file(&path);
+
+    {
+        let mut s = EditSession::open(&path).unwrap();
+        s.copy("grp", "grp_copy");
+        s.commit().unwrap();
+    }
+
+    let file = File::open(&path).unwrap();
+    // Both the original subtree and the copy are present and identical.
+    assert_eq!(
+        file.dataset("grp/inner").unwrap().read_f64().unwrap(),
+        vec![7.5, 8.5]
+    );
+    assert_eq!(
+        file.dataset("grp_copy/inner").unwrap().read_f64().unwrap(),
+        vec![7.5, 8.5]
+    );
+    let mut groups = file.root().groups().unwrap();
+    groups.sort();
+    assert_eq!(groups, vec!["grp".to_string(), "grp_copy".to_string()]);
+    assert_userblock_unchanged(&path, &userblock);
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn userblock_copy_chunked_dataset_roundtrip() {
+    // Copying a chunked/filtered dataset enumerates the source chunks (on a
+    // base-relative view of the file) and rebuilds the index at the new location.
+    let path = std::env::temp_dir().join("hdf5_pure_ub_fu_copy_chunk.h5");
+    let mut b = FileBuilder::new();
+    b.with_userblock(UB as u64);
+    let data: Vec<f64> = (0..600).map(|i| (i % 9) as f64 * 0.25).collect();
+    b.create_dataset("c")
+        .with_f64_data(&data)
+        .with_shape(&[600])
+        .with_chunks(&[40])
+        .with_deflate(6);
+    let mut bytes = b.finish().unwrap();
+    let userblock = stamp_userblock(&mut bytes);
+    std::fs::write(&path, &bytes).unwrap();
+
+    {
+        let mut s = EditSession::open(&path).unwrap();
+        s.copy("c", "c_copy");
+        s.commit().unwrap();
+    }
+
+    let file = File::open(&path).unwrap();
+    assert_eq!(file.dataset("c").unwrap().read_f64().unwrap(), data);
+    assert_eq!(file.dataset("c_copy").unwrap().read_f64().unwrap(), data);
+    assert_userblock_unchanged(&path, &userblock);
+
+    std::fs::remove_file(&path).ok();
+}
+
+// ---- copy (cross-file, into a userblock destination) ----
+
+#[test]
+fn userblock_cross_file_copy_into_userblock_dest() {
+    // A base-0 source file is copied into a userblock destination. The destination
+    // writes the copy base-relative even though the source was read base-0.
+    let dst_path = std::env::temp_dir().join("hdf5_pure_ub_fu_xcopy_dst.h5");
+    let src_path = std::env::temp_dir().join("hdf5_pure_ub_fu_xcopy_src.h5");
+    let userblock = build_userblock_file(&dst_path);
+
+    // A plain (no-userblock) source file.
+    {
+        let mut b = FileBuilder::new();
+        b.create_dataset("payload").with_i32_data(&[100, 200, 300]);
+        let mut g = b.create_group("sub");
+        g.create_dataset("leaf").with_f64_data(&[1.25, 2.5]);
+        b.add_group(g.finish());
+        b.write(&src_path).unwrap();
+    }
+
+    {
+        let source = File::open(&src_path).unwrap();
+        let mut s = EditSession::open(&dst_path).unwrap();
+        s.copy_from(&source, "payload", "imported").unwrap();
+        s.copy_from(&source, "sub", "imported_grp").unwrap();
+        s.commit().unwrap();
+    }
+
+    let file = File::open(&dst_path).unwrap();
+    assert_eq!(
+        file.dataset("imported").unwrap().read_i32().unwrap(),
+        vec![100, 200, 300]
+    );
+    assert_eq!(
+        file.dataset("imported_grp/leaf")
+            .unwrap()
+            .read_f64()
+            .unwrap(),
+        vec![1.25, 2.5]
+    );
+    // Destination originals untouched.
+    assert_eq!(
+        file.dataset("alpha").unwrap().read_f64().unwrap(),
+        vec![1.0, 2.0, 3.0, 4.0]
+    );
+    assert_userblock_unchanged(&dst_path, &userblock);
+
+    std::fs::remove_file(&dst_path).ok();
+    std::fs::remove_file(&src_path).ok();
+}


### PR DESCRIPTION
Finishes the userblock (#104) follow-up work begun in #125. After #125, in-place editing of files with a userblock (non-zero base address, e.g. MATLAB v7.3 `.mat`) supported value overwrites, contiguous/chunked adds, and chunked overwrites with reclaim, but still refused **delete**, **copy**, and **resizing overwrites of contiguous/compact datasets**. This lifts all three, each made base-aware and verified against the reference C library.

## Changes (`src/edit.rs`)

- **Contiguous/compact resizing overwrite** — removed the `Moving(non-Chunked)` refusal in the commit preflight; `write_moving`'s contiguous arm stores `new_data_addr - base`. Compact carries data inline and was already relinked base-relative.
- **Object delete** — removed the delete refusal; `collect_free_spans` shifts `read_object`'s base-relative contiguous data address and group child links by `+base`. The rest of the walk (`oh_chunk_spans`, `chunked_storage_spans`, the `incoming` hard-link keys) already worked in absolute offsets.
- **Object copy** (in-file, and cross-file into a userblock destination) — threaded `base` through `read_copy_subtree` (read headers with base, shift the contiguous data read, enumerate+read chunks on a base-relative view, re-absolutize group children) and made `write_copy_subtree` store the copied contiguous data address and child links `- base`.

The one userblock-specific operation still refused is **cross-file copy _from_ a userblock source** — `copy_from` keeps its base-0 source gate. That's a distinct feature (cross-copy *from* a userblock) beyond editing a userblock file; `reject_foreign_addresses` screening would need base-aware detection.

## Tests (885 pass, 0 fail; clippy + fmt clean)

- `tests/edit_userblock_followups.rs` (new, 9): 5 delete (incl. group-subtree, chunked, and a delete-then-reuse over-reclaim tripwire), 4 copy (incl. group-subtree, chunked, cross-file-into-userblock).
- `tests/edit_userblock_crosscheck.rs` (+4): contiguous-undefined-address relocation, compact overwrite, delete-then-reuse, and copy of chunked + group subtree — all read back through the C library, via a new `c_userblock_file` helper that builds a C-library userblock fixture.
- `tests/edit_userblock.rs` — the stale "all refused" test repurposed to the one remaining refusal.

The contiguous/compact relocation paths are crosscheck-only because the genuine relocation needs a never-written-contiguous or compact-layout fixture that only the C library can create (the pure `FileBuilder` always writes data with a fixed shape, so an overwrite is either same-length in-place or a refused reshape).