### PR TITLE
fix(read): decode HDF5 enum datasets via their integer base; add enum test coverage (#129)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Typed integer and float readers (`Dataset::read_i32`, `read_u8`, …) now decode an **HDF5 enumeration dataset** as its integer base type, so an enum dataset written with `EnumTypeBuilder` / `DatasetBuilder::with_enum_i32_data` reads its codes back instead of failing with a `TypeMismatch`; member names stay available via `DType::Enum`, and no name-based enum-to-enum conversion is performed ([#129](https://github.com/stephenberry/hdf5-pure/issues/129)).
+
 ## [0.20.0] - 2026-06-24
 
 MATLAB **struct arrays** now read: a `MATLAB_class="struct"` group whose fields are datasets of per-element object references is transposed into an array-of-structs, so `mat::from_file` / `mat::from_bytes` read a `1×N` / `N×1` struct array into `Vec<T>` and an `M×N` array into `Vec<Vec<T>>`. Additive minor bump.

--- a/src/data_read.rs
+++ b/src/data_read.rs
@@ -267,6 +267,22 @@ fn ensure_numeric(dt: &Datatype, expected: &'static str) -> Result<(), FormatErr
     }
 }
 
+/// Returns the datatype that governs numeric decoding of `dt`.
+///
+/// An HDF5 enumeration is stored as values of its integer base type, so — like
+/// `hdf5-rs`, which reads an enum dataset as its base — the numeric readers
+/// decode enum data through that base type, inheriting its signedness, byte
+/// order, precision, and width. The unwrap is recursive for defensiveness (an
+/// enum's base is always a leaf integer in practice) and returns any non-enum
+/// datatype unchanged, so the value+name round-trip works: the readers surface
+/// the codes while [`crate::DType::Enum`] surfaces the member names.
+fn effective_numeric(dt: &Datatype) -> &Datatype {
+    match dt {
+        Datatype::Enumeration { base_type, .. } => effective_numeric(base_type),
+        other => other,
+    }
+}
+
 fn get_byte_order(dt: &Datatype) -> DatatypeByteOrder {
     match dt {
         Datatype::FixedPoint { byte_order, .. } => byte_order.clone(),
@@ -346,6 +362,7 @@ macro_rules! bulk_decode {
 
 /// Convert raw bytes to `f64` values.
 pub fn read_as_f64(raw: &[u8], datatype: &Datatype) -> Result<Vec<f64>, FormatError> {
+    let datatype = effective_numeric(datatype);
     ensure_numeric(datatype, "FloatingPoint or FixedPoint")?;
     let elem_size = get_size(datatype);
     if elem_size == 0 || !raw.len().is_multiple_of(elem_size) {
@@ -442,6 +459,7 @@ fn convert_to_f64(
 
 /// Convert raw bytes to `i64` values.
 pub fn read_as_i64(raw: &[u8], datatype: &Datatype) -> Result<Vec<i64>, FormatError> {
+    let datatype = effective_numeric(datatype);
     ensure_numeric(datatype, "FixedPoint (signed)")?;
     let elem_size = get_size(datatype);
     if elem_size == 0 || !raw.len().is_multiple_of(elem_size) {
@@ -478,6 +496,7 @@ pub fn read_as_i64(raw: &[u8], datatype: &Datatype) -> Result<Vec<i64>, FormatEr
 
 /// Convert raw bytes to `u64` values.
 pub fn read_as_u64(raw: &[u8], datatype: &Datatype) -> Result<Vec<u64>, FormatError> {
+    let datatype = effective_numeric(datatype);
     ensure_numeric(datatype, "FixedPoint (unsigned)")?;
     let elem_size = get_size(datatype);
     if elem_size == 0 || !raw.len().is_multiple_of(elem_size) {
@@ -513,6 +532,7 @@ pub fn read_as_u64(raw: &[u8], datatype: &Datatype) -> Result<Vec<u64>, FormatEr
 
 /// Convert raw bytes to `f32` values.
 pub fn read_as_f32(raw: &[u8], datatype: &Datatype) -> Result<Vec<f32>, FormatError> {
+    let datatype = effective_numeric(datatype);
     ensure_numeric(datatype, "FloatingPoint")?;
     let elem_size = get_size(datatype);
     if elem_size == 0 || !raw.len().is_multiple_of(elem_size) {
@@ -613,6 +633,7 @@ pub fn read_as_f32(raw: &[u8], datatype: &Datatype) -> Result<Vec<f32>, FormatEr
 
 /// Convert raw bytes to `i32` values.
 pub fn read_as_i32(raw: &[u8], datatype: &Datatype) -> Result<Vec<i32>, FormatError> {
+    let datatype = effective_numeric(datatype);
     ensure_numeric(datatype, "FixedPoint")?;
     let elem_size = get_size(datatype);
     if elem_size == 0 || !raw.len().is_multiple_of(elem_size) {
@@ -653,6 +674,7 @@ pub fn read_as_i32(raw: &[u8], datatype: &Datatype) -> Result<Vec<i32>, FormatEr
 /// Convert raw bytes to `i16` values (counterpart of [`read_as_i32`] for the
 /// narrower element type, used by [`crate::Dataset::read_i16`]).
 pub fn read_as_i16(raw: &[u8], datatype: &Datatype) -> Result<Vec<i16>, FormatError> {
+    let datatype = effective_numeric(datatype);
     ensure_numeric(datatype, "FixedPoint")?;
     let elem_size = get_size(datatype);
     if elem_size == 0 || !raw.len().is_multiple_of(elem_size) {
@@ -690,6 +712,7 @@ pub fn read_as_i16(raw: &[u8], datatype: &Datatype) -> Result<Vec<i16>, FormatEr
 /// Convert raw bytes to `u32` values (counterpart of [`read_as_u64`] for the
 /// narrower element type, used by [`crate::Dataset::read_u32`]).
 pub fn read_as_u32(raw: &[u8], datatype: &Datatype) -> Result<Vec<u32>, FormatError> {
+    let datatype = effective_numeric(datatype);
     ensure_numeric(datatype, "FixedPoint (unsigned)")?;
     let elem_size = get_size(datatype);
     if elem_size == 0 || !raw.len().is_multiple_of(elem_size) {
@@ -725,6 +748,7 @@ pub fn read_as_u32(raw: &[u8], datatype: &Datatype) -> Result<Vec<u32>, FormatEr
 /// Convert raw bytes to `u16` values (counterpart of [`read_as_u64`] for the
 /// narrower element type, used by [`crate::Dataset::read_u16`]).
 pub fn read_as_u16(raw: &[u8], datatype: &Datatype) -> Result<Vec<u16>, FormatError> {
+    let datatype = effective_numeric(datatype);
     ensure_numeric(datatype, "FixedPoint (unsigned)")?;
     let elem_size = get_size(datatype);
     if elem_size == 0 || !raw.len().is_multiple_of(elem_size) {
@@ -1042,6 +1066,39 @@ mod tests {
         let raw = read_raw_data(&[], &layout, &ds, &dt).unwrap();
         let result = read_as_u64(&raw, &dt).unwrap();
         assert_eq!(result, vec![10, 20, 30, 40, 50]);
+    }
+
+    fn make_enum_type(base: Datatype, members: &[(&str, i64)]) -> Datatype {
+        let width = base.type_size() as usize;
+        Datatype::Enumeration {
+            size: base.type_size(),
+            base_type: Box::new(base),
+            members: members
+                .iter()
+                .map(|(name, v)| crate::datatype::EnumMember {
+                    name: (*name).to_string(),
+                    value: v.to_le_bytes()[..width].to_vec(),
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn read_enum_decodes_through_base_type() {
+        // An enum datatype is decoded via its integer base type; before the
+        // enum-unwrap this hit `ensure_numeric` and returned a `TypeMismatch`.
+        let dt = make_enum_type(make_i32_le_type(), &[("A", 0), ("B", 1), ("C", 2)]);
+        let mut raw = Vec::new();
+        for v in [0i32, 2, 1, 0] {
+            raw.extend_from_slice(&v.to_le_bytes());
+        }
+        assert_eq!(read_as_i32(&raw, &dt).unwrap(), vec![0, 2, 1, 0]);
+        assert_eq!(read_as_i64(&raw, &dt).unwrap(), vec![0, 2, 1, 0]);
+
+        // A u8-based enum decodes unsigned through its u8 base.
+        let dt8 = make_enum_type(make_u8_type(), &[("OFF", 0), ("ON", 1)]);
+        let raw8 = vec![0u8, 1, 1, 0];
+        assert_eq!(read_as_u64(&raw8, &dt8).unwrap(), vec![0, 1, 1, 0]);
     }
 
     #[test]

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -1606,7 +1606,10 @@ mod tests {
         };
         let bytes = dt.serialize();
         let (parsed, _) = Datatype::parse(&bytes).unwrap();
-        assert_ne!(parsed, dt, "a value wider than the base silently truncates on parse");
+        assert_ne!(
+            parsed, dt,
+            "a value wider than the base silently truncates on parse"
+        );
         match parsed {
             Datatype::Enumeration { members, .. } => assert_eq!(members[0].value, vec![5]),
             other => panic!("expected Enumeration, got {other:?}"),

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -1515,6 +1515,104 @@ mod tests {
         assert_eq!(parsed, dt);
     }
 
+    /// Fixed-point base type for enum round-trip tests.
+    fn enum_base_fp(size: u32, be: bool, signed: bool) -> Datatype {
+        Datatype::FixedPoint {
+            size,
+            byte_order: if be {
+                DatatypeByteOrder::BigEndian
+            } else {
+                DatatypeByteOrder::LittleEndian
+            },
+            signed,
+            bit_offset: 0,
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "test builds byte-width base types; size*8 is well within u16"
+            )]
+            bit_precision: (size * 8) as u16,
+        }
+    }
+
+    /// Build an enum datatype over `base`, storing each member value truncated to
+    /// the base width (the value blob is opaque bytes, so any content round-trips).
+    fn make_enum(base: Datatype, members: &[(&str, i64)]) -> Datatype {
+        let size = base.type_size();
+        let width = size as usize;
+        Datatype::Enumeration {
+            size,
+            base_type: Box::new(base),
+            members: members
+                .iter()
+                .map(|(name, v)| EnumMember {
+                    name: (*name).to_string(),
+                    value: v.to_le_bytes()[..width].to_vec(),
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn serialize_parse_enum_base_type_variety() {
+        // The i32 base is already covered above; here u8, big-endian i16, and i64
+        // bases all round-trip through the enum wrapper.
+        for base in [
+            enum_base_fp(1, false, false), // u8
+            enum_base_fp(2, true, true),   // i16 big-endian
+            enum_base_fp(8, false, true),  // i64
+        ] {
+            let dt = make_enum(base.clone(), &[("A", 0), ("B", 1), ("NEG", -1)]);
+            let bytes = dt.serialize();
+            let (parsed, consumed) = Datatype::parse(&bytes).unwrap();
+            assert_eq!(parsed, dt, "round-trip failed for base {base:?}");
+            assert_eq!(consumed, bytes.len());
+        }
+    }
+
+    #[test]
+    fn serialize_parse_enum_large_member_count() {
+        // More than 256 members exercises the 2-byte member-count field, which is
+        // split across bf0/bf1 in the datatype message header.
+        let owned: Vec<(String, i64)> = (0..300).map(|i| (format!("M{i}"), i)).collect();
+        let members: Vec<(&str, i64)> = owned.iter().map(|(n, v)| (n.as_str(), *v)).collect();
+        let dt = make_enum(enum_base_fp(4, false, true), &members);
+        let bytes = dt.serialize();
+        let (parsed, _) = Datatype::parse(&bytes).unwrap();
+        assert_eq!(parsed, dt);
+        match parsed {
+            Datatype::Enumeration { members, .. } => {
+                assert_eq!(members.len(), 300);
+                assert_eq!(members[299].name, "M299");
+            }
+            other => panic!("expected Enumeration, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn enum_value_width_is_not_validated_against_base_size() {
+        // `EnumTypeBuilder::build`/`Datatype::Enumeration` take the element size
+        // from the base type only, with no check that member value blobs match it.
+        // A 4-byte value on a 1-byte base therefore serializes in full but parses
+        // back reading just `base_size` (1) byte per member, silently truncating.
+        // This documents the current permissiveness; it is NOT a supported
+        // round-trip, and the assertion guards against a silent change either way.
+        let dt = Datatype::Enumeration {
+            size: 1,
+            base_type: Box::new(enum_base_fp(1, false, false)),
+            members: vec![EnumMember {
+                name: "X".to_string(),
+                value: 5i32.to_le_bytes().to_vec(), // 4 bytes on a 1-byte base
+            }],
+        };
+        let bytes = dt.serialize();
+        let (parsed, _) = Datatype::parse(&bytes).unwrap();
+        assert_ne!(parsed, dt, "a value wider than the base silently truncates on parse");
+        match parsed {
+            Datatype::Enumeration { members, .. } => assert_eq!(members[0].value, vec![5]),
+            other => panic!("expected Enumeration, got {other:?}"),
+        }
+    }
+
     #[test]
     fn serialize_parse_array_roundtrip() {
         let dt = Datatype::Array {

--- a/tests/enum_datatype.rs
+++ b/tests/enum_datatype.rs
@@ -24,7 +24,8 @@ fn i32_enum_dataset_preserves_members_and_values() {
         .value("BLUE", 2)
         .build();
     let file = write_then_open(|b| {
-        b.create_dataset("color").with_enum_i32_data(dt, &[0, 1, 2, 1]);
+        b.create_dataset("color")
+            .with_enum_i32_data(dt, &[0, 1, 2, 1]);
     });
     let ds = file.dataset("color").unwrap();
     assert_eq!(ds.shape().unwrap(), vec![4]);
@@ -75,7 +76,8 @@ fn i32_enum_dataset_reads_back_through_base_type() {
         .value("BLUE", 2)
         .build();
     let file = write_then_open(|b| {
-        b.create_dataset("color").with_enum_i32_data(dt, &[0, 1, 2, 1]);
+        b.create_dataset("color")
+            .with_enum_i32_data(dt, &[0, 1, 2, 1]);
     });
     let ds = file.dataset("color").unwrap();
 
@@ -113,7 +115,8 @@ fn u8_enum_dataset_roundtrips() {
         .u8_value("ON", 1)
         .build();
     let file = write_then_open(|b| {
-        b.create_dataset("switch").with_enum_u8_data(dt, &[0, 1, 1, 0]);
+        b.create_dataset("switch")
+            .with_enum_u8_data(dt, &[0, 1, 1, 0]);
     });
     let ds = file.dataset("switch").unwrap();
 
@@ -186,7 +189,10 @@ fn non_enum_reads_are_unaffected_by_the_enum_unwrap() {
         b.create_dataset("ints").with_i32_data(&[10, 20, 30]);
         b.create_dataset("text").with_vlen_strings(&["a", "bc"]);
     });
-    assert_eq!(file.dataset("ints").unwrap().read_i32().unwrap(), vec![10, 20, 30]);
+    assert_eq!(
+        file.dataset("ints").unwrap().read_i32().unwrap(),
+        vec![10, 20, 30]
+    );
     let err = file.dataset("text").unwrap().read_i32().unwrap_err();
     assert!(
         matches!(

--- a/tests/enum_datatype.rs
+++ b/tests/enum_datatype.rs
@@ -1,0 +1,198 @@
+//! Round-trip coverage for HDF5 enumeration (H5T class 8) datasets through the
+//! public write/read API.
+//!
+//! This is the hdf5-pure analog of the `hdf5-rs` enum tests: an enum is stored
+//! as values of its integer base type, so a written enum dataset must read back
+//! through the typed integer readers (via the base type) while the datatype
+//! itself preserves the member name/value pairs. See issue #129.
+
+use hdf5_pure::{DType, Datatype, EnumTypeBuilder, File, FileBuilder, FormatError};
+
+/// Build a file holding a single dataset `name`, serialize it, and reopen it.
+fn write_then_open(build: impl FnOnce(&mut FileBuilder)) -> File {
+    let mut builder = FileBuilder::new();
+    build(&mut builder);
+    let bytes = builder.finish().expect("finish");
+    File::from_bytes(bytes).expect("from_bytes")
+}
+
+#[test]
+fn i32_enum_dataset_preserves_members_and_values() {
+    let dt = EnumTypeBuilder::i32_based()
+        .value("RED", 0)
+        .value("GREEN", 1)
+        .value("BLUE", 2)
+        .build();
+    let file = write_then_open(|b| {
+        b.create_dataset("color").with_enum_i32_data(dt, &[0, 1, 2, 1]);
+    });
+    let ds = file.dataset("color").unwrap();
+    assert_eq!(ds.shape().unwrap(), vec![4]);
+
+    // The datatype round-trips as an Enumeration carrying its i32 base and the
+    // full (name, value) member list.
+    match ds.datatype().unwrap() {
+        Datatype::Enumeration {
+            base_type, members, ..
+        } => {
+            assert!(
+                matches!(
+                    *base_type,
+                    Datatype::FixedPoint {
+                        size: 4,
+                        signed: true,
+                        ..
+                    }
+                ),
+                "expected i32 base, got {base_type:?}"
+            );
+            let pairs: Vec<(&str, &[u8])> = members
+                .iter()
+                .map(|m| (m.name.as_str(), m.value.as_slice()))
+                .collect();
+            assert_eq!(
+                pairs,
+                vec![
+                    ("RED", &0i32.to_le_bytes()[..]),
+                    ("GREEN", &1i32.to_le_bytes()[..]),
+                    ("BLUE", &2i32.to_le_bytes()[..]),
+                ]
+            );
+        }
+        other => panic!("expected Enumeration, got {other:?}"),
+    }
+}
+
+#[test]
+fn i32_enum_dataset_reads_back_through_base_type() {
+    // Regression for the read asymmetry (issue #129): before the fix, read_i32
+    // on an enum dataset failed `ensure_numeric` with TypeMismatch. An enum is
+    // now decoded through its integer base, so signed, wider, and float reads
+    // all resolve to the stored codes.
+    let dt = EnumTypeBuilder::i32_based()
+        .value("RED", 0)
+        .value("GREEN", 1)
+        .value("BLUE", 2)
+        .build();
+    let file = write_then_open(|b| {
+        b.create_dataset("color").with_enum_i32_data(dt, &[0, 1, 2, 1]);
+    });
+    let ds = file.dataset("color").unwrap();
+
+    assert_eq!(ds.read_i32().unwrap(), vec![0, 1, 2, 1]);
+    assert_eq!(ds.read_i64().unwrap(), vec![0, 1, 2, 1]);
+    assert_eq!(ds.read_u32().unwrap(), vec![0, 1, 2, 1]);
+    assert_eq!(ds.read_f64().unwrap(), vec![0.0, 1.0, 2.0, 1.0]);
+}
+
+#[test]
+fn enum_dataset_classifies_as_dtype_enum_of_member_names() {
+    let dt = EnumTypeBuilder::i32_based()
+        .value("RED", 0)
+        .value("GREEN", 1)
+        .value("BLUE", 2)
+        .build();
+    let file = write_then_open(|b| {
+        b.create_dataset("color").with_enum_i32_data(dt, &[0, 1, 2]);
+    });
+    let ds = file.dataset("color").unwrap();
+
+    // The simplified DType surfaces the member names (values are dropped here;
+    // recover them via `datatype()` when needed).
+    assert_eq!(
+        ds.dtype().unwrap(),
+        DType::Enum(vec!["RED".into(), "GREEN".into(), "BLUE".into()])
+    );
+    assert_eq!(format!("{}", ds.dtype().unwrap()), "enum[RED, GREEN, BLUE]");
+}
+
+#[test]
+fn u8_enum_dataset_roundtrips() {
+    let dt = EnumTypeBuilder::u8_based()
+        .u8_value("OFF", 0)
+        .u8_value("ON", 1)
+        .build();
+    let file = write_then_open(|b| {
+        b.create_dataset("switch").with_enum_u8_data(dt, &[0, 1, 1, 0]);
+    });
+    let ds = file.dataset("switch").unwrap();
+
+    assert_eq!(
+        ds.dtype().unwrap(),
+        DType::Enum(vec!["OFF".into(), "ON".into()])
+    );
+    // One byte per element on disk.
+    assert_eq!(ds.read_raw().unwrap().len(), 4);
+    // read_u8 already worked (it returns raw bytes); read_i32 works via the base.
+    assert_eq!(ds.read_u8().unwrap(), vec![0, 1, 1, 0]);
+    assert_eq!(ds.read_i32().unwrap(), vec![0, 1, 1, 0]);
+}
+
+#[test]
+fn u8_enum_reads_identically_to_a_plain_u8_dataset() {
+    // "An enum is its base type for value reads": a u8-based enum must decode
+    // exactly as a plain u8 dataset. The unsigned readers recover 255; read_i32
+    // reinterprets the 0xFF byte as signed (-1), identically in both cases — the
+    // enum unwrap changes nothing about the per-reader integer semantics.
+    let dt = EnumTypeBuilder::u8_based()
+        .u8_value("LO", 0)
+        .u8_value("HI", 255)
+        .build();
+    let file = write_then_open(|b| {
+        b.create_dataset("level").with_enum_u8_data(dt, &[0, 255]);
+        b.create_dataset("plain").with_u8_data(&[0, 255]);
+    });
+    let level = file.dataset("level").unwrap();
+    let plain = file.dataset("plain").unwrap();
+
+    assert_eq!(level.read_u8().unwrap(), vec![0, 255]);
+    assert_eq!(level.read_u32().unwrap(), vec![0, 255]);
+    assert_eq!(level.read_i32().unwrap(), plain.read_i32().unwrap());
+    assert_eq!(level.read_u32().unwrap(), plain.read_u32().unwrap());
+}
+
+#[test]
+fn enum_i32_data_into_u8_enum_type_is_rejected() {
+    // `with_enum_i32_data` writes 4 bytes per value, but a u8-based enum declares
+    // 1 byte per element. The writer's shape/data-length invariant catches the
+    // mismatch rather than producing an unreadable file.
+    let u8_enum = EnumTypeBuilder::u8_based()
+        .u8_value("OFF", 0)
+        .u8_value("ON", 1)
+        .build();
+    let mut builder = FileBuilder::new();
+    builder
+        .create_dataset("bad")
+        .with_enum_i32_data(u8_enum, &[0, 1]);
+    match builder.finish() {
+        Err(hdf5_pure::Error::Format(FormatError::ShapeDataMismatch {
+            expected,
+            actual,
+            element_size,
+        })) => {
+            assert_eq!(element_size, 1);
+            assert_eq!(expected, 2); // 2 elements * 1 byte
+            assert_eq!(actual, 8); // 2 values * 4 bytes each
+        }
+        other => panic!("expected ShapeDataMismatch, got {other:?}"),
+    }
+}
+
+#[test]
+fn non_enum_reads_are_unaffected_by_the_enum_unwrap() {
+    // The enum-unwrap on the read path must be a no-op for ordinary datatypes,
+    // and a genuinely non-numeric datatype must still be rejected.
+    let file = write_then_open(|b| {
+        b.create_dataset("ints").with_i32_data(&[10, 20, 30]);
+        b.create_dataset("text").with_vlen_strings(&["a", "bc"]);
+    });
+    assert_eq!(file.dataset("ints").unwrap().read_i32().unwrap(), vec![10, 20, 30]);
+    let err = file.dataset("text").unwrap().read_i32().unwrap_err();
+    assert!(
+        matches!(
+            err,
+            hdf5_pure::Error::Format(FormatError::TypeMismatch { .. })
+        ),
+        "reading a vlen-string dataset as i32 should still be a TypeMismatch, got {err:?}"
+    );
+}

--- a/tests/serde_roundtrip.rs
+++ b/tests/serde_roundtrip.rs
@@ -887,3 +887,128 @@ fn roundtrip_option_complex_inner() {
         none_vec: None,
     });
 }
+
+// ---------------------------------------------------------------------------
+// Enum edge cases (issue #129). The `.mat` serde path encodes a Rust enum only
+// as a unit variant, by variant name, as a MATLAB char string. Non-unit
+// variants and unknown names must be rejected cleanly, renamed variants must
+// honor the serde name, and enums must round-trip inside sequences.
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+enum NewtypeVariant {
+    N(i32),
+}
+#[derive(Serialize)]
+enum TupleVariant {
+    T(i32, i32),
+}
+#[derive(Serialize)]
+enum StructVariant {
+    S { a: i32 },
+}
+#[derive(Serialize)]
+struct HoldsNewtype {
+    v: NewtypeVariant,
+}
+#[derive(Serialize)]
+struct HoldsTuple {
+    v: TupleVariant,
+}
+#[derive(Serialize)]
+struct HoldsStruct {
+    v: StructVariant,
+}
+
+#[test]
+fn non_unit_enum_variants_are_unsupported() {
+    assert!(matches!(
+        mat::to_bytes(&HoldsNewtype {
+            v: NewtypeVariant::N(1)
+        }),
+        Err(mat::MatError::UnsupportedType(_))
+    ));
+    assert!(matches!(
+        mat::to_bytes(&HoldsTuple {
+            v: TupleVariant::T(1, 2)
+        }),
+        Err(mat::MatError::UnsupportedType(_))
+    ));
+    assert!(matches!(
+        mat::to_bytes(&HoldsStruct {
+            v: StructVariant::S { a: 1 }
+        }),
+        Err(mat::MatError::UnsupportedType(_))
+    ));
+}
+
+#[derive(Serialize)]
+struct StateStr {
+    state: String,
+}
+#[derive(Deserialize, Debug)]
+struct StateFlag {
+    #[allow(dead_code)]
+    state: Flag,
+}
+
+#[test]
+fn deserialize_unknown_enum_variant_errors() {
+    // A char dataset whose value isn't a known variant name deserializes to a
+    // clean serde `unknown variant` error, not a silent wrong variant.
+    let bytes = mat::to_bytes(&StateStr {
+        state: "Maybe".into(),
+    })
+    .unwrap();
+    let err = mat::from_bytes::<StateFlag>(&bytes).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("unknown variant") && msg.contains("Maybe"),
+        "expected an unknown-variant error mentioning \"Maybe\", got: {msg}"
+    );
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+enum Color {
+    #[serde(rename = "rouge")]
+    Red,
+    #[serde(rename = "vert")]
+    Green,
+    Blue,
+}
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct Palette {
+    c: Color,
+}
+
+#[test]
+fn renamed_enum_variant_uses_serde_name() {
+    let bytes = mat::to_bytes(&Palette { c: Color::Red }).unwrap();
+    // The on-disk char string is the serde-renamed identifier, not "Red".
+    let file = File::from_bytes(bytes.clone()).unwrap();
+    let ds = file.dataset("c").unwrap();
+    let units = ds.read_u16().unwrap();
+    assert_eq!(String::from_utf16(&units).unwrap(), "rouge");
+    // And it round-trips back to the original variant by that name.
+    let back: Palette = mat::from_bytes(&bytes).unwrap();
+    assert_eq!(back, Palette { c: Color::Red });
+}
+
+#[test]
+fn all_enum_variants_roundtrip() {
+    for c in [Color::Red, Color::Green, Color::Blue] {
+        rt(Palette { c });
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct FlagList {
+    states: Vec<Flag>,
+}
+
+#[test]
+fn vec_of_unit_enums_roundtrips() {
+    rt(FlagList {
+        states: vec![Flag::On, Flag::Off, Flag::On],
+    });
+}


### PR DESCRIPTION
Closes #129.

## Summary

Increases enum test coverage and aligns hdf5-pure's enum round-trip behavior with the intent of [metno/hdf5-rust#184](https://github.com/metno/hdf5-rust/pull/184), interpreted for this crate's architecture.

While mapping the three enum layers (low-level HDF5 enumeration datatype, the serde `.mat` Rust-enum path, and the `MatEnum` MCOS view) I found a genuine round-trip defect: the crate could **write** an HDF5 enum dataset (`EnumTypeBuilder` / `DatasetBuilder::with_enum_i32_data`) but could not **read it back** through the typed readers.

## The fix

`read_i32` and the other typed integer/float readers gate on `ensure_numeric`, which only accepts `FixedPoint`/`FloatingPoint` and rejected `Datatype::Enumeration` with a `TypeMismatch`. This adds an `effective_numeric()` helper in `src/data_read.rs` that unwraps an enum to its integer base type, and routes every `read_as_*` reader through it, so enum data now decodes as its base — the pure-Rust analog of how `hdf5-rs` treats an enum for value reads.

- Non-enum datatypes are returned unchanged, so ordinary reads are unaffected and a genuinely non-numeric datatype (e.g. a vlen string) still returns `TypeMismatch`.
- `DType::Enum` continues to surface member names, so a caller gets both the codes (via the readers) and the names (via the datatype).

## Test coverage added

- **`tests/enum_datatype.rs`** (new): i32/u8 enum write → reopen → read round-trips, member/value preservation, `DType::Enum` + `Display` classification, an enum reading *identically* to its plain base type, the writer's `ShapeDataMismatch` width guard, and a regression pin that non-enum reads are unaffected.
- **`src/data_read.rs`**: a unit test decoding an enum through its base directly.
- **`src/datatype.rs`**: serialize/parse round-trips across u8 / big-endian i16 / i64 bases, the >256-member count-field split, and a characterization of the un-validated value/base width mismatch.
- **`tests/serde_roundtrip.rs`**: non-unit variants error cleanly, unknown-variant deserialize errors, `#[serde(rename)]` name matching, and `Vec<enum>` round-trips.

## Intentionally out of scope

- **Name-based enum-to-enum conversion / reject-missing-member** (PR #184's core rule): that presupposes a typed destination enum supplied at read time, which hdf5-pure's generic read path does not have — it returns raw codes plus names. There is nothing to reject against, so porting the conversion engine would invent API the crate doesn't otherwise expose.
- **bool as a `{FALSE,TRUE}` enum** on read (`decode_attr_value` returns `None` for enums; repack refuses such an attribute) — a distinct optional feature, worth a separate issue.
- A cmake/C-library interop crosscheck of the on-disk enum encoding — worth adding alongside the existing crosscheck suite in a follow-up.

## Verification

- `cargo test --lib` — 500 passed
- `cargo test --features serde` — full integration suite + doctests green
- `cargo clippy --all-targets --features serde` — clean
