### PR TITLE
Document and test the fixed group creation format

### DIFF
--- a/docs/guide/groups-attributes.md
+++ b/docs/guide/groups-attributes.md
@@ -47,6 +47,9 @@ The pattern is uniform at every level: build, finish, attach. A child must be fi
 
 See the [writing guide](writing.md) for the full dataset builder API used inside groups.
 
+!!! note "Group format is fixed, not configurable"
+    There is no group creation property list: every group is written with the same fixed, timestamp-free, new-style layout regardless of settings or child count. See [Limitations](../reference/limitations.md#group-creation-property-list-gcpl) for details.
+
 ## Attributes
 
 Attributes are small named pieces of metadata. Set them on the root via `FileBuilder::set_attr`, on a group via `GroupBuilder::set_attr`, or on a dataset via `DatasetBuilder::set_attr` (the dataset form is chainable and returns `&mut Self`). The value is an `AttrValue`, an enum covering the common scalar, array, and string encodings:

--- a/docs/reference/limitations.md
+++ b/docs/reference/limitations.md
@@ -41,6 +41,10 @@ SWMR append requires a **latest-format** file (v2/v3 superblock) and **no userbl
 
 In-place editing operates on files with **8-byte offsets and lengths** (what the writer emits and what modern files use). Other offset/length widths are not editable in place.
 
+### Group creation property list (GCPL)
+
+There is no property-list API for group creation, and none of its settings are configurable — every group `hdf5-pure` writes (including the root group) has exactly one fixed shape: a new-style (v2 object header) group with compact link storage and no stored timestamps. This is equivalent to always creating every group with `obj_track_times = false`, and never switching to old-style (symbol-table) or dense (fractal-heap) link storage, regardless of file version or child count. Unlike the reference library, whose GCPL defaults vary by version, this shape is fixed on purpose: it keeps output byte-for-byte reproducible, which is exactly what makes `hdf5-pure` a good fit for stable snapshot files. See [#131](https://github.com/stephenberry/hdf5-pure/issues/131).
+
 ## Planned support
 
 Refused today with a `... yet` message, intended to land. Each row links to its tracking issue.

--- a/src/file_writer.rs
+++ b/src/file_writer.rs
@@ -1451,6 +1451,7 @@ impl FileWriter {
 mod tests {
     use super::*;
     use crate::group_v2::resolve_path_any;
+    use crate::link_info::LinkInfoMessage;
     use crate::object_header::ObjectHeader;
     use crate::signature;
 
@@ -1542,6 +1543,85 @@ mod tests {
         fw.add_group(gb.finish());
         let bytes = fw.finish().unwrap();
         assert_eq!(read_dataset_f64(&bytes, "grp/vals"), vec![10.0, 20.0]);
+    }
+
+    // hdf5-pure has no group creation property list: every object header it
+    // writes is fixed to one shape, equivalent to the C library's
+    // `obj_track_times = false` (see issue #131) — never toggleable, so these
+    // lock in the "no timestamps" half of that fixed shape for both the root
+    // group and an ordinary sub-group.
+    #[test]
+    fn root_group_carries_no_timestamps() {
+        let fw = FileWriter::new();
+        let bytes = fw.finish().unwrap();
+        let (_, oh) = parse_file(&bytes);
+        assert_eq!(oh.flags & 0x20, 0, "times-stored flag must be clear");
+        assert!(oh.modification_time.is_none());
+        assert!(oh.access_time.is_none());
+        assert!(oh.change_time.is_none());
+        assert!(oh.birth_time.is_none());
+    }
+
+    #[test]
+    fn sub_group_carries_no_timestamps() {
+        let mut fw = FileWriter::new();
+        let mut gb = fw.create_group("grp");
+        gb.create_dataset("vals").with_f64_data(&[1.0]);
+        fw.add_group(gb.finish());
+        let bytes = fw.finish().unwrap();
+        let sig = signature::find_signature(&bytes).unwrap();
+        let sb = Superblock::parse(&bytes, sig).unwrap();
+        let addr = resolve_path_any(&bytes, &sb, "grp").unwrap();
+        let hdr =
+            ObjectHeader::parse(&bytes, addr as usize, sb.offset_size, sb.length_size).unwrap();
+        assert_eq!(hdr.flags & 0x20, 0, "times-stored flag must be clear");
+        assert!(hdr.modification_time.is_none());
+    }
+
+    // The other half of the fixed shape: every group is "new style" (a Link
+    // Info + Group Info message pair) with links stored inline, regardless of
+    // child count — hdf5-pure never converts a group to dense (fractal-heap)
+    // link storage on write (see issue #131 and the tracked gap in #102).
+    #[test]
+    fn group_links_stay_compact_regardless_of_child_count() {
+        let mut fw = FileWriter::new();
+        let mut gb = fw.create_group("grp");
+        for i in 0..20 {
+            gb.create_dataset(&format!("d{i}"))
+                .with_f64_data(&[i as f64]);
+        }
+        fw.add_group(gb.finish());
+        let bytes = fw.finish().unwrap();
+        let sig = signature::find_signature(&bytes).unwrap();
+        let sb = Superblock::parse(&bytes, sig).unwrap();
+        let addr = resolve_path_any(&bytes, &sb, "grp").unwrap();
+        let hdr =
+            ObjectHeader::parse(&bytes, addr as usize, sb.offset_size, sb.length_size).unwrap();
+
+        let link_info_msg = hdr
+            .messages
+            .iter()
+            .find(|m| m.msg_type == MessageType::LinkInfo)
+            .unwrap();
+        let link_info = LinkInfoMessage::parse(&link_info_msg.data, sb.offset_size).unwrap();
+        assert!(
+            link_info.fractal_heap_address.is_none(),
+            "no dense link storage is ever used"
+        );
+
+        let group_info_msg = hdr
+            .messages
+            .iter()
+            .find(|m| m.msg_type == MessageType::GroupInfo)
+            .unwrap();
+        assert_eq!(group_info_msg.data, vec![0, 0]);
+
+        let link_count = hdr
+            .messages
+            .iter()
+            .filter(|m| m.msg_type == MessageType::Link)
+            .count();
+        assert_eq!(link_count, 20);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `hdf5-pure` has no group creation property list (GCPL) — every group it writes, including the root group, is always a new-style (v2 object header) group with compact-only link storage and no stored timestamps, regardless of settings or child count.
- Unlike the reference library, whose GCPL defaults vary by version, this shape is fixed on purpose: it keeps output byte-for-byte reproducible, which suits stable snapshot files.
- Adds regression tests locking in that fixed shape (no timestamps on root/sub-groups; links stay compact even with 20 children) and documents it in `docs/reference/limitations.md` and `docs/guide/groups-attributes.md`.
- No behavior change — docs and tests only.

Closes #131.

## Test plan
- [x] `cargo test --lib file_writer::tests` — new tests pass
- [x] `cargo test --all-targets` — full suite passes (503 lib tests + integration tests)
- [x] `cargo clippy --all-targets --all-features` — clean
- [x] `cargo fmt --check` — clean