### PR TITLE
Add empty and provenance datasets in EditSession's in-place add path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- `EditSession` now adds, in place, an **empty (zero-element) contiguous dataset** and a **provenance-tagged dataset** (`DatasetBuilder::with_provenance`, behind the `provenance` feature); a chunked/extensible empty dataset stays refused ([#105](https://github.com/stephenberry/hdf5-pure/issues/105)).
+
 ## [0.20.1] - 2026-07-01
 
 HDF5 **enumeration datasets** now read back through the typed integer/float readers via their integer base type, so an enum dataset written with `EnumTypeBuilder` / `DatasetBuilder::with_enum_i32_data` reads its codes instead of failing with a `TypeMismatch`. Non-breaking patch.

--- a/docs/reference/limitations.md
+++ b/docs/reference/limitations.md
@@ -57,7 +57,7 @@ Refused today with a `... yet` message, intended to land. Each row links to its 
 | **Dense** (fractal-heap) link & attribute storage | [#102](https://github.com/stephenberry/hdf5-pure/issues/102) |
 | Editing across **soft / external links** | [#103](https://github.com/stephenberry/hdf5-pure/issues/103) |
 | Userblock files, creation-order tracking, shared/SOHM messages, v0/v1 conversion | [#104](https://github.com/stephenberry/hdf5-pure/issues/104) |
-| Adding **object-reference / provenance / empty / variable-length-attribute** datasets | [#105](https://github.com/stephenberry/hdf5-pure/issues/105) |
+| Adding **object-reference** datasets and **variable-length-attribute** datasets/groups | [#105](https://github.com/stephenberry/hdf5-pure/issues/105) |
 | **Cross-file copy** of variable-length / reference / shared data | [#106](https://github.com/stephenberry/hdf5-pure/issues/106) |
 
 ### Repack

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -3490,11 +3490,14 @@ fn flatten_dataset(db: DatasetBuilder) -> Result<FlatDataset, Error> {
     };
 
     let elem = dt.type_size() as u64;
-    if !is_empty && elem > 0 {
+    if elem > 0 {
         // Multiply with checked arithmetic: an absurd shape whose element count
         // (or byte size) overflows `u64` is refused rather than panicking in a
         // debug build or silently wrapping in release (which could let a wrapped
-        // product spuriously match `raw.len()`).
+        // product spuriously match `raw.len()`). For a zero-element shape this
+        // expected length is always 0 (a `0` dimension makes every checked
+        // multiplication `Some(0)` regardless of the other dimensions), so this
+        // also catches data mistakenly supplied for a shape that holds nothing.
         let expected = shape
             .iter()
             .try_fold(1u64, |acc, &d| acc.checked_mul(d))
@@ -3592,11 +3595,10 @@ fn flatten_dataset(db: DatasetBuilder) -> Result<FlatDataset, Error> {
         // unlimited dimension is `u64::MAX`); a fixed-shape dataset has none.
         max_dimensions: db.maxshape.clone(),
     };
-    let mut attrs: Vec<crate::attribute::AttributeMessage> = db
-        .attrs
-        .iter()
-        .map(|(n, v)| build_attr_message(n, v))
-        .collect();
+    let mut attrs: Vec<crate::attribute::AttributeMessage> = Vec::with_capacity(db.attrs.len());
+    for (n, v) in &db.attrs {
+        attrs.push(build_attr_message(n, v));
+    }
     #[cfg(feature = "provenance")]
     if let Some(ref prov) = db.provenance {
         let p = crate::provenance::Provenance {

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -88,11 +88,14 @@
 //!   dimensions. A chunked dataset's data and index — and any filtered chunks —
 //!   are produced by the same builder the whole-file writer uses and appended at
 //!   end-of-file, so its object header is byte-identical to a freshly written
-//!   one. Every added dataset must have a fixed-size datatype with a non-empty
-//!   shape and carry only fixed-size (non variable-length) attributes, few
-//!   enough to stay in compact storage; object-reference and provenance
-//!   datasets are not added in place. Group attribute edits have the same
-//!   compact, fixed-size attribute restriction.
+//!   one. A contiguous dataset may be empty (zero-element); chunking an empty
+//!   shape is not supported. A provenance dataset (`with_provenance`) is
+//!   supported, its attributes computed the same way the whole-file writer
+//!   computes them. Every added dataset must have a fixed-size datatype and
+//!   carry only fixed-size (non variable-length) attributes, few enough to stay
+//!   in compact storage; object-reference datasets are not added in place.
+//!   Group attribute edits have the same compact, fixed-size attribute
+//!   restriction.
 //! - A new group's parent must already exist or be created in the same session
 //!   (each level created explicitly); intermediate groups are not auto-created.
 //!
@@ -490,9 +493,11 @@ impl EditSession {
     ///
     /// The dataset may be contiguous or chunked, and chunked datasets may be
     /// filtered (`with_deflate`, `with_shuffle`, `with_fletcher32`,
-    /// `with_scale_offset`, `with_zfp`) and/or extensible (`with_maxshape`); see
-    /// the [module docs](self) for what stays unsupported (variable-length or
-    /// dense attributes, object-reference and provenance datasets, empty shapes).
+    /// `with_scale_offset`, `with_zfp`) and/or extensible (`with_maxshape`). An
+    /// empty (zero-element) contiguous dataset is supported (chunking one is
+    /// not), and a provenance dataset (`with_provenance`) is supported; see the
+    /// [module docs](self) for what still stays unsupported (variable-length or
+    /// dense attributes, object-reference datasets).
     pub fn create_dataset(&mut self, path: &str) -> &mut DatasetBuilder {
         let mut comps = split_path(path);
         let leaf = comps.pop().unwrap_or_default();
@@ -1211,11 +1216,20 @@ impl EditSession {
                 let oh = if fd.chunk_options.is_chunked() || fd.maxshape.is_some() {
                     self.build_chunked_dataset(&fd)?
                 } else {
-                    let data_addr = self.alloc_or_append(&fd.raw)?;
+                    // A zero-element dataset has no data block to allocate; its
+                    // layout address is the undefined-address sentinel (never
+                    // base-relative — see `build_dataset_oh`'s empty-data callers
+                    // in the whole-file writer), matching every reader's and the
+                    // reference C library's convention for "no storage allocated".
+                    let data_addr = if fd.raw.is_empty() {
+                        u64::MAX
+                    } else {
+                        self.alloc_or_append(&fd.raw)? - base
+                    };
                     build_dataset_oh(
                         &fd.dt,
                         &fd.ds,
-                        data_addr - base,
+                        data_addr,
                         fd.raw.len() as u64,
                         &fd.attrs,
                         None,
@@ -3436,11 +3450,15 @@ fn retain_disjoint_in_bounds(spans: &mut Vec<(u64, u64)>, eof: u64) {
 /// Validate a staged dataset and reduce it to a [`FlatDataset`]. Contiguous,
 /// unfiltered datasets are emitted as such; chunked, filtered, or extensible
 /// datasets carry their [`ChunkOptions`] and maxshape through to the commit,
-/// where [`build_chunked_data_at_ext`] lays out their chunk data and index.
-/// Rejects any remaining feature this engine cannot reproduce faithfully:
-/// object-reference or provenance datasets, variable-length or dense
-/// attributes, an empty (zero-element) shape, or a filter pipeline the build
-/// cannot construct.
+/// where [`build_chunked_data_at_ext`] lays out their chunk data and index. An
+/// empty (zero-element) shape is allowed for contiguous storage (mirroring the
+/// whole-file writer, its data address is `HADDR_UNDEF` — see the apply loop),
+/// but chunking one stays refused via the geometry validation below. A
+/// `provenance` dataset has its SHA-256/creator/timestamp/source attributes
+/// computed here from `raw`, exactly as the whole-file writer does. Rejects
+/// any remaining feature this engine cannot reproduce faithfully:
+/// object-reference datasets, variable-length or dense attributes, or a filter
+/// pipeline the build cannot construct.
 fn flatten_dataset(db: DatasetBuilder) -> Result<FlatDataset, Error> {
     if db.name.is_empty() {
         return Err(Error::EditUnsupported("dataset path has an empty name"));
@@ -3450,12 +3468,6 @@ fn flatten_dataset(db: DatasetBuilder) -> Result<FlatDataset, Error> {
             "object-reference datasets cannot be added in place yet",
         ));
     }
-    #[cfg(feature = "provenance")]
-    if db.provenance.is_some() {
-        return Err(Error::EditUnsupported(
-            "provenance datasets cannot be added in place yet",
-        ));
-    }
 
     let dt = db
         .datatype
@@ -3463,17 +3475,22 @@ fn flatten_dataset(db: DatasetBuilder) -> Result<FlatDataset, Error> {
     let shape = db
         .shape
         .ok_or(Error::EditUnsupported("dataset has no shape"))?;
-    if shape.contains(&0) {
+    let is_empty = shape.contains(&0);
+    let chunked = db.chunk_options.is_chunked() || db.maxshape.is_some();
+    if is_empty && chunked {
         return Err(Error::EditUnsupported(
-            "empty (zero-element) datasets cannot be added in place yet",
+            "chunked or extensible empty (zero-element) datasets cannot be added in place yet",
         ));
     }
-    let raw = db
-        .data
-        .ok_or(Error::EditUnsupported("dataset has no data"))?;
+    let raw = if is_empty {
+        db.data.unwrap_or_default()
+    } else {
+        db.data
+            .ok_or(Error::EditUnsupported("dataset has no data"))?
+    };
 
     let elem = dt.type_size() as u64;
-    if elem > 0 {
+    if !is_empty && elem > 0 {
         // Multiply with checked arithmetic: an absurd shape whose element count
         // (or byte size) overflows `u64` is refused rather than panicking in a
         // debug build or silently wrapping in release (which could let a wrapped
@@ -3497,7 +3514,6 @@ fn flatten_dataset(db: DatasetBuilder) -> Result<FlatDataset, Error> {
         }
     }
 
-    let chunked = db.chunk_options.is_chunked() || db.maxshape.is_some();
     if chunked {
         // Refuse malformed chunk geometry up front (the same validation the
         // whole-file writer applies), so a bad request — chunk dimensions of the
@@ -3551,11 +3567,6 @@ fn flatten_dataset(db: DatasetBuilder) -> Result<FlatDataset, Error> {
             "variable-length attributes cannot be added in place yet",
         ));
     }
-    if db.attrs.len() > MAX_COMPACT_ATTRS {
-        return Err(Error::EditUnsupported(
-            "datasets with dense (many) attributes cannot be added in place yet",
-        ));
-    }
     // The link message body (whose length is independent of the address) must
     // fit the object-header message's u16 size field; a pathologically long
     // name would otherwise overflow it into silent corruption.
@@ -3581,11 +3592,25 @@ fn flatten_dataset(db: DatasetBuilder) -> Result<FlatDataset, Error> {
         // unlimited dimension is `u64::MAX`); a fixed-shape dataset has none.
         max_dimensions: db.maxshape.clone(),
     };
-    let attrs = db
+    let mut attrs: Vec<crate::attribute::AttributeMessage> = db
         .attrs
         .iter()
         .map(|(n, v)| build_attr_message(n, v))
         .collect();
+    #[cfg(feature = "provenance")]
+    if let Some(ref prov) = db.provenance {
+        let p = crate::provenance::Provenance {
+            creator: prov.creator.clone(),
+            timestamp: prov.timestamp.clone(),
+            source: prov.source.clone(),
+        };
+        attrs.extend(p.build_attrs(&raw));
+    }
+    if attrs.len() > MAX_COMPACT_ATTRS {
+        return Err(Error::EditUnsupported(
+            "datasets with dense (many) attributes cannot be added in place yet",
+        ));
+    }
 
     Ok(FlatDataset {
         name: db.name,

--- a/tests/edit_in_place.rs
+++ b/tests/edit_in_place.rs
@@ -2268,9 +2268,34 @@ fn add_chunked_empty_dataset_is_rejected_without_writing() {
     std::fs::remove_file(&path).ok();
 }
 
+/// An empty dataset whose supplied data does not match its (zero-element)
+/// shape is rejected rather than silently written as unreachable, orphaned
+/// storage: `flatten_dataset` must validate `raw` against the shape even when
+/// the shape contains a `0` dimension, not just for non-empty shapes.
+#[test]
+fn add_empty_dataset_with_mismatched_data_is_rejected_without_writing() {
+    let path = std::env::temp_dir().join("hdf5_pure_edit_add_empty_mismatched.h5");
+    write_starter(&path);
+    let before = std::fs::read(&path).unwrap();
+
+    {
+        let mut session = EditSession::open(&path).unwrap();
+        session
+            .create_dataset("bogus")
+            .with_f64_data(&[9.0, 9.0, 9.0])
+            .with_shape(&[0, 3]);
+        let err = session.commit().unwrap_err();
+        assert!(err.to_string().contains("shape"), "got: {err}");
+    }
+
+    assert_eq!(std::fs::read(&path).unwrap(), before);
+    std::fs::remove_file(&path).ok();
+}
+
 /// A provenance-tagged dataset (issue #105) can be added in place; the
-/// SHA-256/creator/timestamp attributes are computed and stored exactly as
-/// the whole-file writer does, and `verify_provenance` confirms them.
+/// SHA-256/creator/timestamp/source attributes are computed and stored
+/// exactly as the whole-file writer does, and `verify_provenance` confirms
+/// the hash while the attribute values themselves are checked directly.
 #[cfg(feature = "provenance")]
 #[test]
 fn add_provenance_dataset_via_edit_session() {
@@ -2292,5 +2317,125 @@ fn add_provenance_dataset_via_edit_session() {
     let ds = file.dataset("sensor").unwrap();
     assert_eq!(ds.read_f64().unwrap(), vec![1.0, 2.0, 3.0]);
     assert_eq!(ds.verify_provenance().unwrap(), VerifyResult::Ok);
+    let attrs = ds.attrs().unwrap();
+    assert_eq!(
+        attrs.get("_provenance_creator"),
+        Some(&AttrValue::String("test-suite".into()))
+    );
+    assert_eq!(
+        attrs.get("_provenance_timestamp"),
+        Some(&AttrValue::String("2026-02-19T12:00:00Z".into()))
+    );
+    assert_eq!(
+        attrs.get("_provenance_source"),
+        Some(&AttrValue::String("bench".into()))
+    );
+    std::fs::remove_file(&path).ok();
+}
+
+/// A provenance-tagged dataset can also be chunked/compressed in the same
+/// commit: provenance attributes and chunked storage flow through the same
+/// `attrs` vec and apply-loop path independently, so this combination should
+/// just work — this test is the regression guard for that claim.
+#[cfg(all(feature = "provenance", feature = "deflate"))]
+#[test]
+fn add_provenance_chunked_dataset_via_edit_session() {
+    use hdf5_pure::VerifyResult;
+
+    let path = std::env::temp_dir().join("hdf5_pure_edit_add_provenance_chunked.h5");
+    write_starter(&path);
+
+    {
+        let mut session = EditSession::open(&path).unwrap();
+        session
+            .create_dataset("sensor_chunked")
+            .with_f64_data(&[1.0, 2.0, 3.0, 4.0])
+            .with_shape(&[4])
+            .with_chunks(&[2])
+            .with_deflate(6)
+            .with_provenance("test-suite", "2026-02-19T12:00:00Z", None);
+        session.commit().unwrap();
+    }
+
+    let file = File::open(&path).unwrap();
+    let ds = file.dataset("sensor_chunked").unwrap();
+    assert_eq!(ds.read_f64().unwrap(), vec![1.0, 2.0, 3.0, 4.0]);
+    assert_eq!(ds.verify_provenance().unwrap(), VerifyResult::Ok);
+    let attrs = ds.attrs().unwrap();
+    assert_eq!(
+        attrs.get("_provenance_creator"),
+        Some(&AttrValue::String("test-suite".into()))
+    );
+    assert!(
+        !attrs.contains_key("_provenance_source"),
+        "no source was given, so no source attribute should be written"
+    );
+    std::fs::remove_file(&path).ok();
+}
+
+/// Provenance attributes (up to 4) are appended to `attrs` before the
+/// dense-attribute (`MAX_COMPACT_ATTRS` = 8) budget check runs, so a dataset
+/// that would otherwise fit can be pushed over the limit by its own
+/// provenance metadata. Exactly at the boundary (8 total) must succeed with
+/// every value intact.
+#[cfg(feature = "provenance")]
+#[test]
+fn add_provenance_dataset_at_attr_budget_boundary_via_edit_session() {
+    let path = std::env::temp_dir().join("hdf5_pure_edit_add_provenance_at_budget.h5");
+    write_starter(&path);
+
+    {
+        let mut session = EditSession::open(&path).unwrap();
+        let ds = session.create_dataset("sensor_at_budget");
+        ds.with_f64_data(&[1.0, 2.0]);
+        // 4 plain attributes + 4 provenance attributes (source included) = 8.
+        for i in 0..4i64 {
+            ds.set_attr(&format!("plain_{i}"), AttrValue::I64(i));
+        }
+        ds.with_provenance("test-suite", "2026-02-19T12:00:00Z", Some("bench"));
+        session.commit().unwrap();
+    }
+
+    let file = File::open(&path).unwrap();
+    let ds = file.dataset("sensor_at_budget").unwrap();
+    assert_eq!(ds.read_f64().unwrap(), vec![1.0, 2.0]);
+    let attrs = ds.attrs().unwrap();
+    for i in 0..4i64 {
+        assert_eq!(
+            attrs.get(&format!("plain_{i}")),
+            Some(&AttrValue::I64(i)),
+            "plain_{i} attribute value mismatch"
+        );
+    }
+    assert_eq!(
+        attrs.get("_provenance_creator"),
+        Some(&AttrValue::String("test-suite".into()))
+    );
+    std::fs::remove_file(&path).ok();
+}
+
+/// One attribute past the boundary above (9 total, once provenance is
+/// appended) is refused, and the refusal must not write anything.
+#[cfg(feature = "provenance")]
+#[test]
+fn add_provenance_dataset_over_attr_budget_is_rejected_without_writing() {
+    let path = std::env::temp_dir().join("hdf5_pure_edit_add_provenance_over_budget.h5");
+    write_starter(&path);
+    let before = std::fs::read(&path).unwrap();
+
+    {
+        let mut session = EditSession::open(&path).unwrap();
+        let ds = session.create_dataset("sensor_over_budget");
+        ds.with_f64_data(&[1.0, 2.0]);
+        // 5 plain attributes + 4 provenance attributes (source included) = 9.
+        for i in 0..5 {
+            ds.set_attr(&format!("plain_{i}"), AttrValue::I32(i));
+        }
+        ds.with_provenance("test-suite", "2026-02-19T12:00:00Z", Some("bench"));
+        let err = session.commit().unwrap_err();
+        assert!(err.to_string().contains("dense"), "got: {err}");
+    }
+
+    assert_eq!(std::fs::read(&path).unwrap(), before);
     std::fs::remove_file(&path).ok();
 }

--- a/tests/edit_in_place.rs
+++ b/tests/edit_in_place.rs
@@ -2204,3 +2204,93 @@ fn write_dataset_with_no_other_edits_takes_inplace_fast_path() {
     );
     std::fs::remove_file(&path).ok();
 }
+
+/// A zero-element (empty) contiguous dataset — the on-disk equivalent of the
+/// whole-file writer's `HADDR_UNDEF` data address for "no storage allocated"
+/// (issue #105) — can be added in place, alongside an ordinary dataset in the
+/// same commit.
+#[test]
+fn add_empty_dataset_via_edit_session() {
+    let path = std::env::temp_dir().join("hdf5_pure_edit_add_empty.h5");
+    write_starter(&path);
+
+    {
+        let mut session = EditSession::open(&path).unwrap();
+        session
+            .create_dataset("empty")
+            .with_f64_data(&[])
+            .with_shape(&[0, 3]);
+        session.create_dataset("added").with_i32_data(&[7, 8]);
+        session.commit().unwrap();
+    }
+
+    let file = File::open(&path).unwrap();
+    let empty = file.dataset("empty").unwrap();
+    assert_eq!(empty.shape().unwrap(), vec![0, 3]);
+    assert_eq!(empty.dtype().unwrap(), DType::F64);
+    assert_eq!(empty.read_f64().unwrap(), Vec::<f64>::new());
+    assert_eq!(
+        file.dataset("added").unwrap().read_i32().unwrap(),
+        vec![7, 8]
+    );
+    // The original, pre-existing dataset is untouched.
+    assert_eq!(
+        file.dataset("original").unwrap().read_f64().unwrap(),
+        vec![1.0, 2.0, 3.0, 4.0]
+    );
+    std::fs::remove_file(&path).ok();
+}
+
+/// Chunking a zero-element shape stays refused in place (it's a distinct,
+/// separately-tracked capability from the plain contiguous empty dataset
+/// above): `malformed_chunked_requests_are_rejected_without_writing` already
+/// covers the whole-file-writer-equivalent geometry refusal; this confirms
+/// `EditSession` refuses it too, cleanly, without writing anything.
+#[test]
+fn add_chunked_empty_dataset_is_rejected_without_writing() {
+    let path = std::env::temp_dir().join("hdf5_pure_edit_add_chunked_empty.h5");
+    write_starter(&path);
+    let before = std::fs::read(&path).unwrap();
+
+    {
+        let mut session = EditSession::open(&path).unwrap();
+        session
+            .create_dataset("stream")
+            .with_i32_data(&[])
+            .with_shape(&[0])
+            .with_maxshape(&[u64::MAX])
+            .with_chunks(&[16]);
+        let err = session.commit().unwrap_err();
+        assert!(err.to_string().contains("empty"), "got: {err}");
+    }
+
+    assert_eq!(std::fs::read(&path).unwrap(), before);
+    std::fs::remove_file(&path).ok();
+}
+
+/// A provenance-tagged dataset (issue #105) can be added in place; the
+/// SHA-256/creator/timestamp attributes are computed and stored exactly as
+/// the whole-file writer does, and `verify_provenance` confirms them.
+#[cfg(feature = "provenance")]
+#[test]
+fn add_provenance_dataset_via_edit_session() {
+    use hdf5_pure::VerifyResult;
+
+    let path = std::env::temp_dir().join("hdf5_pure_edit_add_provenance.h5");
+    write_starter(&path);
+
+    {
+        let mut session = EditSession::open(&path).unwrap();
+        session
+            .create_dataset("sensor")
+            .with_f64_data(&[1.0, 2.0, 3.0])
+            .with_provenance("test-suite", "2026-02-19T12:00:00Z", Some("bench"));
+        session.commit().unwrap();
+    }
+
+    let file = File::open(&path).unwrap();
+    let ds = file.dataset("sensor").unwrap();
+    assert_eq!(ds.read_f64().unwrap(), vec![1.0, 2.0, 3.0]);
+    assert_eq!(ds.verify_provenance().unwrap(), VerifyResult::Ok);
+    std::fs::remove_file(&path).ok();
+}

--- a/tests/edit_userblock.rs
+++ b/tests/edit_userblock.rs
@@ -169,6 +169,72 @@ fn userblock_cross_file_copy_from_userblock_source_is_refused() {
     std::fs::remove_file(&dst_path).ok();
 }
 
+/// An empty (zero-element) dataset added on a userblock file must round-trip
+/// correctly. This is the one test in the suite that can actually
+/// discriminate correct behavior from a broken `u64::MAX - base` regression:
+/// at `base_address == 0` the empty-dataset sentinel (`u64::MAX`, written
+/// with no subtraction) and a wrongly-adjusted sentinel are numerically
+/// identical, so only a non-zero base can catch a mistake here.
+#[test]
+fn userblock_add_empty_dataset_roundtrip() {
+    let path = std::env::temp_dir().join("hdf5_pure_ub_add_empty.h5");
+    let userblock = build_userblock_file(&path);
+
+    {
+        let mut s = EditSession::open(&path).unwrap();
+        s.create_dataset("empty")
+            .with_f64_data(&[])
+            .with_shape(&[0, 3]);
+        s.commit().unwrap();
+    }
+
+    let file = File::open(&path).unwrap();
+    let empty = file.dataset("empty").unwrap();
+    assert_eq!(empty.shape().unwrap(), vec![0, 3]);
+    assert_eq!(empty.read_f64().unwrap(), Vec::<f64>::new());
+    // Untouched original still reads correctly.
+    assert_eq!(
+        file.dataset("alpha").unwrap().read_f64().unwrap(),
+        vec![1.0, 2.0, 3.0, 4.0]
+    );
+    assert_eq!(&std::fs::read(&path).unwrap()[..UB], &userblock[..]);
+
+    std::fs::remove_file(&path).ok();
+}
+
+/// A provenance-tagged dataset added on a userblock file must round-trip
+/// correctly, exercising the same base-relative address arithmetic as the
+/// non-userblock case above but where a `- base` bug would actually be
+/// observable.
+#[cfg(feature = "provenance")]
+#[test]
+fn userblock_add_provenance_dataset_roundtrip() {
+    use hdf5_pure::VerifyResult;
+
+    let path = std::env::temp_dir().join("hdf5_pure_ub_add_provenance.h5");
+    let userblock = build_userblock_file(&path);
+
+    {
+        let mut s = EditSession::open(&path).unwrap();
+        s.create_dataset("sensor")
+            .with_f64_data(&[1.0, 2.0, 3.0])
+            .with_provenance("test-suite", "2026-02-19T12:00:00Z", Some("bench"));
+        s.commit().unwrap();
+    }
+
+    let file = File::open(&path).unwrap();
+    let ds = file.dataset("sensor").unwrap();
+    assert_eq!(ds.read_f64().unwrap(), vec![1.0, 2.0, 3.0]);
+    assert_eq!(ds.verify_provenance().unwrap(), VerifyResult::Ok);
+    assert_eq!(
+        ds.attrs().unwrap().get("_provenance_creator"),
+        Some(&AttrValue::String("test-suite".into()))
+    );
+    assert_eq!(&std::fs::read(&path).unwrap()[..UB], &userblock[..]);
+
+    std::fs::remove_file(&path).ok();
+}
+
 #[test]
 fn real_mat_add_dataset_preserves_userblock_and_data() {
     // Copy the fixture so the test never mutates the checked-in file.


### PR DESCRIPTION
## Summary
- Part of the #105 catalog (in-place add of object-reference, provenance, empty, and variable-length-attribute datasets). This PR closes the empty-dataset and provenance-dataset slices; object-reference datasets and variable-length attributes are still refused and tracked separately under #105.
- `EditSession`'s add path now supports a contiguous **empty (zero-element) dataset** (its data address is written as `HADDR_UNDEF`, mirroring the whole-file writer) — chunking one stays refused, since that's a distinct, separately-tracked capability.
- It also now supports a **provenance-tagged dataset** (`DatasetBuilder::with_provenance`, behind the `provenance` feature): the SHA-256/creator/timestamp/source attributes are computed from the dataset's raw bytes exactly as the whole-file writer computes them.
- Updated `docs/reference/limitations.md` and `CHANGELOG.md` to reflect the narrowed remaining scope of #105.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features`
- [x] `cargo test --all-targets` (all feature combinations except `matio-crosscheck`, which needs a local `libmatio` install)
- [x] New regression tests in `tests/edit_in_place.rs`: `add_empty_dataset_via_edit_session`, `add_chunked_empty_dataset_is_rejected_without_writing` (confirms the remaining scope boundary), `add_provenance_dataset_via_edit_session`