### PR TITLE
mat: serialize Rust unit / serde_json Null as an omitted field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
-- `mat::to_bytes` no longer aborts the whole encode when a struct field serializes as a Rust unit `()` — most commonly a `serde_json::Value::Null` field: the field is now dropped like `Option::None` (read it back with `#[serde(default)]`) instead of failing with `UnsupportedType("() / unit")` ([#PR](https://github.com/stephenberry/hdf5-pure/pull/PR)).
+- `mat::to_bytes` no longer aborts the whole encode when a struct field serializes as a Rust unit `()` — most commonly a `serde_json::Value::Null` field: the field is now dropped like `Option::None` (read it back with `#[serde(default)]`) instead of failing with `UnsupportedType("() / unit")` ([#141](https://github.com/stephenberry/hdf5-pure/pull/141)).
 - The buffered and streaming readers now agree on a malformed v1 object header: the buffered path stops at the declared object-header size instead of reading (and following) a chunk-0 message that overruns it ([#140](https://github.com/stephenberry/hdf5-pure/pull/140)).
 - Parsing a crafted file now returns a format error instead of panicking on an arithmetic overflow, hardening address and size computations across the metadata parsers (local heap, symbol table, datatype sizing, and the chunk/fixed-array/extensible-array indexes) ([#140](https://github.com/stephenberry/hdf5-pure/pull/140)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- `mat::to_bytes` no longer aborts the whole encode when a struct field serializes as a Rust unit `()` — most commonly a `serde_json::Value::Null` field: the field is now dropped like `Option::None` (read it back with `#[serde(default)]`) instead of failing with `UnsupportedType("() / unit")` ([#PR](https://github.com/stephenberry/hdf5-pure/pull/PR)).
 - The buffered and streaming readers now agree on a malformed v1 object header: the buffered path stops at the declared object-header size instead of reading (and following) a chunk-0 message that overruns it ([#140](https://github.com/stephenberry/hdf5-pure/pull/140)).
 - Parsing a crafted file now returns a format error instead of panicking on an arithmetic overflow, hardening address and size computations across the metadata parsers (local heap, symbol table, datatype sizing, and the chunk/fixed-array/extensible-array indexes) ([#140](https://github.com/stephenberry/hdf5-pure/pull/140)).
 

--- a/docs/interop/matlab.md
+++ b/docs/interop/matlab.md
@@ -69,8 +69,12 @@ The serializer maps Rust types to HDF5 datasets and the MATLAB classes MATLAB ex
 | `Complex32` / `Complex64` | compound `{real, imag}` dataset |
 | nested struct | HDF5 group with `MATLAB_class = "struct"`, `MATLAB_fields` |
 | `Option<T>` (struct field) | omitted if `None` |
+| unit `()` / unit struct / `serde_json::Value::Null` (struct field) | omitted, same as `None` (see caveat below) |
 | unit enum variant | UTF-16 char dataset holding the variant name |
 | `Vec<Struct>` / `Vec<Option<T>>` / ragged `Vec<Vec<T>>` | cell array (`MATLAB_class = "cell"`, object references into `#refs#`); `None` slots become `struct([])` |
+
+!!! note "Unit and `null` fields round-trip with `#[serde(default)]`"
+    A struct field that serializes as a Rust unit `()` is dropped from the output, exactly like `Option::None`. The most common case is a `serde_json::Value::Null` field, since `serde_json` serializes `Value::Null` via `serialize_unit`. Because the field is absent on disk, reading it back needs `#[serde(default)]` on the field (or an `Option<T>` field, which serde defaults automatically); with a default, a `serde_json::Value` field reconstructs as `Value::Null`. A field that serializes as unit and has no serde default fails to deserialize the dropped field, which is the same contract as a non-defaulted `Option` field.
 
 ### Matrices and the column-major convention
 

--- a/docs/interop/matlab.md
+++ b/docs/interop/matlab.md
@@ -74,7 +74,7 @@ The serializer maps Rust types to HDF5 datasets and the MATLAB classes MATLAB ex
 | `Vec<Struct>` / `Vec<Option<T>>` / ragged `Vec<Vec<T>>` | cell array (`MATLAB_class = "cell"`, object references into `#refs#`); `None` slots become `struct([])` |
 
 !!! note "Unit and `null` fields round-trip with `#[serde(default)]`"
-    A struct field that serializes as a Rust unit `()` is dropped from the output, exactly like `Option::None`. The most common case is a `serde_json::Value::Null` field, since `serde_json` serializes `Value::Null` via `serialize_unit`. Because the field is absent on disk, reading it back needs `#[serde(default)]` on the field (or an `Option<T>` field, which serde defaults automatically); with a default, a `serde_json::Value` field reconstructs as `Value::Null`. A field that serializes as unit and has no serde default fails to deserialize the dropped field, which is the same contract as a non-defaulted `Option` field.
+    A struct field that serializes as a Rust unit `()` is dropped from the output, exactly like `Option::None`. The most common case is a `serde_json::Value::Null` field, since `serde_json` serializes `Value::Null` via `serialize_unit`. Because the field is absent on disk, reading it back needs `#[serde(default)]` on the field (or an `Option<T>` field, which serde defaults to `None` automatically); with a default, a `serde_json::Value` field reconstructs as `Value::Null`. A non-`Option` field that has no serde default fails to deserialize the dropped field with a missing-field error, so add `#[serde(default)]` (or use `Option<T>`) if the field can be absent.
 
 ### Matrices and the column-major convention
 

--- a/src/mat/de/value_de.rs
+++ b/src/mat/de/value_de.rs
@@ -174,7 +174,12 @@ impl<'de> Deserializer<'de> for MatValueDeserializer {
 
     fn deserialize_unit<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, MatError> {
         match self.value {
-            MatValue::Omit => visitor.visit_unit(),
+            // `Omit` is the in-memory placeholder for a missing value;
+            // `EmptyStructArray` is its on-disk encoding (`struct([])`) inside a
+            // cell array. Accept both, mirroring `deserialize_option` above, so a
+            // unit that lowered to `struct([])` in a sequence round-trips back to
+            // `()` instead of failing on read.
+            MatValue::Omit | MatValue::EmptyStructArray => visitor.visit_unit(),
             other => mismatch("unit", other),
         }
     }

--- a/src/mat/ser/value_ser.rs
+++ b/src/mat/ser/value_ser.rs
@@ -110,11 +110,18 @@ impl Serializer for ValueSerializer {
     }
 
     fn serialize_unit(self) -> Result<MatValue, MatError> {
-        Err(MatError::UnsupportedType("() / unit"))
+        // Unit maps to `Omit`, exactly like `serialize_none` above. This drops
+        // the field from its parent struct (see `emit::build_struct_group`) and
+        // keeps the nested serializer consistent with `RootSerializer`, which
+        // already treats a root-level `()`/`None`/unit-struct as an empty
+        // workspace. The common way to hit this is `serde_json::Value::Null`,
+        // which serializes via `serialize_unit`; without this it aborted the
+        // whole encode even though the equivalent `Option::None` encoded fine.
+        Ok(MatValue::Omit)
     }
 
     fn serialize_unit_struct(self, _name: &'static str) -> Result<MatValue, MatError> {
-        Err(MatError::UnsupportedType("unit struct"))
+        Ok(MatValue::Omit)
     }
 
     fn serialize_unit_variant(

--- a/tests/serde_roundtrip.rs
+++ b/tests/serde_roundtrip.rs
@@ -230,10 +230,43 @@ fn null_field_is_omitted_like_none() {
     // Must not abort the encode the way it used to with
     // `UnsupportedType("() / unit")`.
     let bytes = mat::to_bytes(&v).expect("Null field must not abort the encode");
-    let file = File::from_bytes(bytes).unwrap();
+    let file = File::from_bytes(bytes.clone()).unwrap();
     // `id` survives; the Null `meta` field is dropped, just like `None`.
     assert!(file.dataset("id").is_ok());
     assert!(file.dataset("meta").is_err());
+    // The dropped field reads back to its serde default: `Value`'s default is
+    // `Value::Null`, so the whole record round-trips.
+    let back: WithNullMeta = mat::from_bytes(&bytes).unwrap();
+    assert_eq!(back, v);
+}
+
+#[test]
+fn dropped_unit_field_without_default_fails_to_deserialize() {
+    // Documents the read-back contract the docs describe: a non-`Option` field
+    // that serialized away must carry `#[serde(default)]` to reconstruct. The
+    // encode still succeeds; only the deserialize of the absent field fails.
+    #[derive(Serialize)]
+    struct Writer {
+        id: u32,
+        meta: serde_json::Value, // Null -> dropped
+    }
+    #[derive(Deserialize, Debug)]
+    struct ReaderNoDefault {
+        #[allow(dead_code)]
+        id: u32,
+        #[allow(dead_code)]
+        meta: serde_json::Value, // no #[serde(default)]
+    }
+    let bytes = mat::to_bytes(&Writer {
+        id: 1,
+        meta: serde_json::Value::Null,
+    })
+    .unwrap();
+    let err = mat::from_bytes::<ReaderNoDefault>(&bytes).unwrap_err();
+    assert!(
+        err.to_string().contains("meta"),
+        "expected a missing-field error naming `meta`, got: {err}"
+    );
 }
 
 #[test]
@@ -253,6 +286,64 @@ fn some_null_is_omitted_like_none() {
     let file = File::from_bytes(mat::to_bytes(&v).unwrap()).unwrap();
     assert!(file.dataset("id").is_ok());
     assert!(file.dataset("meta").is_err());
+}
+
+#[test]
+fn unit_struct_field_is_omitted() {
+    #[derive(Serialize)]
+    struct Marker;
+    #[derive(Serialize)]
+    struct S {
+        id: u32,
+        marker: Marker,
+    }
+    let file = File::from_bytes(
+        mat::to_bytes(&S {
+            id: 5,
+            marker: Marker,
+        })
+        .unwrap(),
+    )
+    .unwrap();
+    assert!(file.dataset("id").is_ok());
+    assert!(file.dataset("marker").is_err());
+}
+
+#[test]
+fn vec_of_unit_roundtrips() {
+    // A unit inside a sequence lowers to a `struct([])` cell slot on write; the
+    // reader accepts `struct([])` back as `()` so the degenerate `Vec<()>` still
+    // round-trips rather than failing on read.
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    struct S {
+        units: Vec<()>,
+    }
+    let v = S {
+        units: vec![(), (), ()],
+    };
+    let bytes = mat::to_bytes(&v).unwrap();
+    let back: S = mat::from_bytes(&bytes).unwrap();
+    assert_eq!(back, v);
+}
+
+#[test]
+fn vec_of_values_with_null_roundtrips() {
+    // The realistic sequence case: a `serde_json::Value` array carrying a `Null`
+    // among numbers round-trips element-for-element.
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    struct S {
+        items: Vec<serde_json::Value>,
+    }
+    let v = S {
+        items: vec![
+            serde_json::Value::from(1),
+            serde_json::Value::Null,
+            serde_json::Value::from(3),
+        ],
+    };
+    let bytes = mat::to_bytes(&v).unwrap();
+    let back: S = mat::from_bytes(&bytes).unwrap();
+    assert_eq!(back, v);
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]

--- a/tests/serde_roundtrip.rs
+++ b/tests/serde_roundtrip.rs
@@ -210,6 +210,51 @@ fn option_some_serializes_underlying() {
     assert_eq!(ds.shape().unwrap(), vec![5, 1]);
 }
 
+// A Rust unit `()` — the shape `serde_json::Value::Null` serializes as — is
+// dropped from its parent struct exactly like `Option::None`, instead of
+// aborting the whole encode. See the `serialize_unit` handler in
+// `mat/ser/value_ser.rs`.
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct WithNullMeta {
+    id: u32,
+    #[serde(default)]
+    meta: serde_json::Value,
+}
+
+#[test]
+fn null_field_is_omitted_like_none() {
+    let v = WithNullMeta {
+        id: 7,
+        meta: serde_json::Value::Null,
+    };
+    // Must not abort the encode the way it used to with
+    // `UnsupportedType("() / unit")`.
+    let bytes = mat::to_bytes(&v).expect("Null field must not abort the encode");
+    let file = File::from_bytes(bytes).unwrap();
+    // `id` survives; the Null `meta` field is dropped, just like `None`.
+    assert!(file.dataset("id").is_ok());
+    assert!(file.dataset("meta").is_err());
+}
+
+#[test]
+fn some_null_is_omitted_like_none() {
+    // `Some(Value::Null)` forwards through `serialize_some` to the inner
+    // `serialize_unit`, so it drops the field too — the pre-fix behavior made
+    // wrapping in `Option` an unreliable workaround.
+    #[derive(Serialize)]
+    struct S {
+        id: u32,
+        meta: Option<serde_json::Value>,
+    }
+    let v = S {
+        id: 3,
+        meta: Some(serde_json::Value::Null),
+    };
+    let file = File::from_bytes(mat::to_bytes(&v).unwrap()).unwrap();
+    assert!(file.dataset("id").is_ok());
+    assert!(file.dataset("meta").is_err());
+}
+
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 struct WithComplex {
     z: Complex64,


### PR DESCRIPTION
## Summary

`mat::to_bytes` (and the `to_file` / `*_with_options` variants) failed with `UnsupportedType("() / unit")` whenever the serialized value contained a Rust unit `()` anywhere in its tree. The most common way to hit this is a `serde_json::Value::Null` field: `serde_json` serializes `Value::Null` via `serialize_unit`, which the nested `ValueSerializer` hard-errored on.

This was inconsistent with `Option::None`, which the same serializer already maps to `MatValue::Omit` (the field is dropped and the rest of the struct encodes fine). So `None` was graceful but the semantically-equivalent `Null` was fatal, and a struct carrying a loosely-typed `serde_json::Value` field encoded fine right up until one of those values happened to be `Null`. `Some(Value::Null)` failed too (`serialize_some` forwards to the inner `serialize_unit`), so wrapping in `Option` was not a reliable workaround.

## Fix

Map both `serialize_unit` and `serialize_unit_struct` to `MatValue::Omit`, exactly like `serialize_none`. Beyond matching `serialize_none`, this aligns the nested `ValueSerializer` with `RootSerializer`, which **already** collapses a root-level `()` / `None` / unit-struct to an empty workspace (`src/mat/ser/root.rs`) — so the nested path was contradicting a convention the crate had already settled at the root.

## Round-trip note

A dropped field reads back cleanly with `#[serde(default)]`: `serde_json::Value`'s `Default` is `Value::Null`, so `Null -> dropped -> Null`. A field that serializes as unit and has no serde default fails to deserialize the absent field, which is the same contract as a non-defaulted `Option` field. Documented in `docs/interop/matlab.md`.

Considered but rejected: emitting a MATLAB empty `[]` for the field instead of dropping it. That keeps the field present but reads back as an empty *array*, not `Null`, so it's actually less faithful for the `Value::Null` case.

## Tests

- `null_field_is_omitted_like_none` — a `serde_json::Value::Null` field no longer aborts the encode; `id` survives, `meta` is dropped.
- `some_null_is_omitted_like_none` — `Some(Value::Null)` drops the field too.

Full `--features serde` suite, `cargo fmt --check`, and `clippy` all pass.