### PR TITLE
Fix panic on dataspace element-count overflow (#142)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Reading an attribute or dataset whose dataspace declares dimensions whose product overflows `u64` no longer panics: the element count now saturates so the size and limit checks reject the file as a format error ([#142](https://github.com/stephenberry/hdf5-pure/issues/142)).
+
 ## [0.21.2] - 2026-07-14
 
 The `.mat` serializer now drops a struct field that serializes as a Rust unit `()` — most commonly a `serde_json::Value::Null` — like `Option::None` instead of aborting the encode. Parser hardening: the buffered and streaming readers agree on a malformed v1 object header, and crafted files return a format error instead of panicking on an arithmetic overflow across the metadata parsers. Non-breaking patch.

--- a/src/chunked_read.rs
+++ b/src/chunked_read.rs
@@ -697,7 +697,15 @@ pub fn read_chunked_data(
     let ctx = ChunkContext::from_datatype(&chunk_dims_u64, datatype);
     let decompressed_chunks = decompress_all_chunks(file_data, &chunks, pipeline, ctx)?;
 
-    let total_bytes = dataspace.num_elements().to_usize()? * elem_size;
+    let num_elements = dataspace.num_elements();
+    let total_bytes =
+        num_elements
+            .to_usize()?
+            .checked_mul(elem_size)
+            .ok_or(FormatError::OffsetOverflow {
+                offset: num_elements,
+                length: elem_size as u64,
+            })?;
     Ok(assemble_chunks(
         &chunks,
         &decompressed_chunks,
@@ -801,7 +809,15 @@ pub fn read_chunked_data_from_source<S: FileSource + ?Sized>(
     let chunk_dims_u64: Vec<u64> = chunk_dims.iter().map(|&d| d as u64).collect();
     let ctx = ChunkContext::from_datatype(&chunk_dims_u64, datatype);
     let decompressed_chunks = decompress_all_chunks_from_source(source, &chunks, pipeline, ctx)?;
-    let total_bytes = dataspace.num_elements().to_usize()? * elem_size;
+    let num_elements = dataspace.num_elements();
+    let total_bytes =
+        num_elements
+            .to_usize()?
+            .checked_mul(elem_size)
+            .ok_or(FormatError::OffsetOverflow {
+                offset: num_elements,
+                length: elem_size as u64,
+            })?;
     Ok(assemble_chunks(
         &chunks,
         &decompressed_chunks,

--- a/src/dataspace.rs
+++ b/src/dataspace.rs
@@ -172,6 +172,11 @@ impl Dataspace {
     }
 
     /// Total number of elements. Scalar = 1, Null = 0.
+    ///
+    /// The count saturates at `u64::MAX` rather than panicking when a malformed
+    /// dataspace declares dimensions whose product overflows `u64`. Every caller
+    /// treats the saturated value as an impossibly large element count, so the
+    /// downstream size and limit checks reject it as an error instead.
     pub fn num_elements(&self) -> u64 {
         match self.space_type {
             DataspaceType::Null => 0,
@@ -180,7 +185,9 @@ impl Dataspace {
                 if self.dimensions.is_empty() {
                     0
                 } else {
-                    self.dimensions.iter().product()
+                    self.dimensions
+                        .iter()
+                        .fold(1u64, |acc, &dim| acc.saturating_mul(dim))
                 }
             }
         }
@@ -282,6 +289,16 @@ mod tests {
         let md = ds.max_dimensions.clone().unwrap();
         assert_eq!(md, vec![10, u64::MAX, 100]);
         assert_eq!(ds.num_elements(), 24);
+    }
+
+    #[test]
+    fn num_elements_saturates_on_overflow() {
+        // A malformed dataspace can declare dimensions whose product exceeds
+        // u64::MAX. num_elements() must saturate instead of panicking, so the
+        // callers can reject the impossibly large count as an error.
+        let data = build_v1_dataspace(3, 0, &[1 << 40, 1 << 40, 1 << 40], None);
+        let ds = Dataspace::parse(&data, 8).unwrap();
+        assert_eq!(ds.num_elements(), u64::MAX);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #142 (weekly fuzzing crash in the `streaming_differential` target).

## Root cause

The symbolized backtrace pointed at `attribute::compute_raw_data`, but the panic (`attempt to multiply with overflow`) was in the inlined `Dataspace::num_elements()`. It computed the element count with an unchecked `dimensions.iter().product()` over `u64` dims, which panics under overflow-checks when a malformed dataspace declares dimensions whose product exceeds `u64::MAX`. `compute_raw_data` already guarded with `checked_mul`, but the overflow happened inside `num_elements()` before it could return.

## Fix

- `src/dataspace.rs` — `num_elements()` now folds with `saturating_mul`, capping at `u64::MAX` instead of panicking. Every caller already treats an impossibly large count as an error (via `checked_mul`, `to_usize()?`, or `> limit` checks), so the file is cleanly rejected as a format error.
- `src/chunked_read.rs` — the two `num_elements().to_usize()? * elem_size` multiplies were the only downstream consumers that would still panic on the saturated sentinel, so they now use `checked_mul(...).ok_or(OffsetOverflow)`, matching the existing pattern in the same file.
- Added a `num_elements_saturates_on_overflow` regression test.

## Verification

- `cargo +nightly fuzz run streaming_differential <crash-file>` runs clean (previously reproduced the panic locally).
- 90s fuzz smoke run: 315,369 runs, no crash.
- Full lib suite: 511 passed. `clippy --all-targets --all-features` clean, `fmt --check` clean, `check --no-default-features` (no_std) clean.