### PR TITLE
Add EditSession::append_dataset for filtered unlimited datasets (#144)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- `EditSession::append_dataset` grows an existing **chunked, unlimited dataset** in place along its first dimension — **filtered** (deflate/shuffle/fletcher32/scale-offset, and ZFP with the `zfp` feature) or not, and of any length (a trailing partial chunk is rewritten) — without requiring SWMR; existing chunk data stays put while the appended chunks and a rebuilt Extensible-Array index are added, and the result reads back in the reference C library and h5py. Datasets that are not Extensible-Array-indexed (a version-1 B-tree, fixed-array, or single-chunk index), higher than rank 1, use a filter this engine cannot re-encode, or have more than one hard link are refused ([#144](https://github.com/stephenberry/hdf5-pure/issues/144)).
+- `Dataset` gains read-only introspection — `is_chunked`, `maxshape`, `chunk_shape`, and `filters` — so callers can check a dataset's storage, extensibility, and filter pipeline (for example append eligibility) without decoding any data ([#144](https://github.com/stephenberry/hdf5-pure/issues/144)).
+
 ### Fixed
 
 - Reading an attribute or dataset whose dataspace declares dimensions whose product overflows `u64` no longer panics: the element count now saturates so the size and limit checks reject the file as a format error ([#142](https://github.com/stephenberry/hdf5-pure/issues/142)).

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ lossless read. For N-dimensional arrays see the `ndarray` feature below.
 
 ### Editing in place
 
-`EditSession` opens an existing file and adds, deletes, or copies objects, or edits compact group attributes without reading it all in and rewriting it. New data and the rebuilt object headers are appended at the end of the file and the superblock is repointed last, so the cost is proportional to what changes and a failed commit leaves the file valid.
+`EditSession` opens an existing file and adds, deletes, or copies objects, appends to chunked unlimited datasets in place (including filtered/compressed ones, via `append_dataset`), or edits compact group attributes without reading it all in and rewriting it. New data and the rebuilt object headers are appended at the end of the file and the superblock is repointed last, so the cost is proportional to what changes and a failed commit leaves the file valid.
 
 ```rust,no_run
 use hdf5_pure::{AttrValue, EditSession};

--- a/docs/guide/editing.md
+++ b/docs/guide/editing.md
@@ -36,6 +36,7 @@ After a successful `commit()`, the staged set is cleared and the session can be 
 | `EditSession::open(path)` | Open an existing file for editing | — |
 | `create_group(path)` | Stage a new empty group; its parent must exist or be created in the same session | — |
 | `create_dataset(path)` | Stage a new dataset and return a `DatasetBuilder` to configure data, shape, and attributes | — |
+| `append_dataset(path)` | Stage appending elements along axis 0 of an existing chunked, unlimited dataset; returns an `AppendBuilder` | `H5Dset_extent` + write |
 | `set_group_attr(path, name, value)` | Stage adding or replacing a compact group attribute | — |
 | `remove_group_attr(path, name)` | Stage removing a compact group attribute | — |
 | `copy(src, dst)` | Stage a deep copy of a dataset or whole group subtree within this file | `H5Ocopy` |
@@ -65,6 +66,31 @@ session.commit().unwrap();
 ```
 
 Unlike `copy`, the source subtree is read and validated **eagerly** (the `File` borrow need not outlive the call), so `copy_from` returns a `Result`; the destination still changes only on `commit()`. Because the copy is byte-for-byte verbatim, anything whose stored bytes embed a *source-file* absolute address — which would dangle in another file — is refused up front: variable-length and reference datasets and attributes (whether compact or dense), and any shared header message (a committed datatype, or an SOHM-shared dataspace, fill value, or filter pipeline). The same-file `copy` keeps these forms valid instead, by sharing the source file's global heaps and objects. The `source` must be a buffered file (`File::open` or `File::from_bytes`, not `File::open_streaming`) using 8-byte offsets and no userblock.
+
+## Appending to an unlimited dataset
+
+`append_dataset` grows an existing **chunked, unlimited** dataset in place along its first (axis-0) dimension, **including filtered** datasets (deflate, shuffle, fletcher32, scale-offset, and ZFP with the `zfp` feature). It is the general, non-SWMR counterpart to the [SWMR writer](swmr.md), which appends only to *unfiltered*, chunk-aligned datasets. It returns an `AppendBuilder` whose typed and generic methods mirror the writer's; repeated calls concatenate in call order.
+
+```rust
+use hdf5_pure::EditSession;
+
+let mut session = EditSession::open("log.h5").unwrap();
+session.append_dataset("samples").append_i32(&[8, 9, 10, 11]);
+session.commit().unwrap();
+```
+
+Existing chunks stay exactly where they are. Only the newly appended chunks — plus the single trailing partial chunk, when the dataset's current length is not a whole multiple of the chunk length — are compressed and written; every other chunk is carried into the rebuilt index by metadata alone. So an append does not rewrite existing data and the file does not grow by the whole dataset each time. Appends of any length are allowed, and the datatype, fill value, filter pipeline, and attributes are preserved.
+
+Like every `EditSession` edit, an append commits by writing the new chunks and a rebuilt index at end-of-file and repointing the superblock last (under the session's exclusive lock), so a crash leaves either the original dataset or the fully grown one, never a torn state. It sets no SWMR flag.
+
+### Eligibility
+
+The first release supports the Extensible-Array chunk index — the index the reference C library and h5py select for a single unlimited dimension under the latest format, and the one this crate writes for every unlimited dataset — with rank-1 datasets that have a single hard link. A dataset that is not chunked, not unlimited along axis 0, not Extensible-Array indexed, higher than rank 1, uses a filter this engine cannot re-encode, or has a sparse chunk grid is refused with `Error::AppendUnsupported` before any file bytes change. Check eligibility up front with the read-side accessors [`is_chunked`, `maxshape`, `chunk_shape`, and `filters`](reading.md#chunking-filters-and-append-eligibility) rather than relying on the refusal error.
+
+Element types are checked, never coerced: each typed `append_*` call records the datatype it implies, and `commit` refuses a mismatch against the dataset's on-disk datatype — including a mix of element types in one builder. `append_raw` appends already-little-endian element bytes verbatim; its length must be a whole multiple of the element size and the dataset's datatype must be little-endian.
+
+!!! tip "Runnable example"
+    This section mirrors [`examples/append_dataset.rs`](https://github.com/stephenberry/hdf5-pure/blob/main/examples/append_dataset.rs). Run it with `cargo run --example append_dataset`.
 
 ## How it works
 

--- a/docs/guide/reading.md
+++ b/docs/guide/reading.md
@@ -75,6 +75,29 @@ println!("shape: {:?}", ds.shape().unwrap());
 println!("dtype: {:?}", ds.dtype().unwrap());
 ```
 
+### Chunking, filters, and append eligibility
+
+Four accessors describe a dataset's storage layout without reading any data. They also tell you whether a dataset can be grown in place with [`EditSession::append_dataset`](editing.md#appending-to-an-unlimited-dataset) before you attempt the append:
+
+| Method | Returns |
+|---|---|
+| `Dataset::is_chunked()` | `bool` — `true` for chunked storage; filtered datasets are always chunked |
+| `Dataset::maxshape()` | `Option<Vec<u64>>` — maximum dimensions, an unlimited axis reported as `u64::MAX`; `None` for a fixed-shape dataset |
+| `Dataset::chunk_shape()` | `Option<Vec<u64>>` — chunk dimensions, one per rank; `None` when not chunked |
+| `Dataset::filters()` | `Vec<u16>` — HDF5 filter IDs in pipeline order (1 = deflate, 2 = shuffle, 3 = fletcher32, 6 = scale-offset); empty when unfiltered |
+
+```rust
+use hdf5_pure::File;
+
+let file = File::open("log.h5").unwrap();
+let ds = file.dataset("samples").unwrap();
+
+// Broadly appendable: chunked and unlimited along axis 0. The full rules
+// (rank 1, Extensible-Array index, single hard link) are in the editing guide.
+let appendable = ds.is_chunked()
+    && matches!(ds.maxshape().unwrap().as_deref(), Some([u64::MAX, ..]));
+```
+
 ## Reading dataset data
 
 ### Typed reads

--- a/docs/guide/swmr.md
+++ b/docs/guide/swmr.md
@@ -109,3 +109,6 @@ SWMR append supports the following subset, distinct from the general [editing](e
 | Build | requires `std` (the default); the in-memory/WASM path cannot refresh |
 
 `SwmrWriter::open` rejects files that fall outside this subset, returning `Error::SwmrAppendUnsupported` for a non-latest-format superblock or a userblock file before performing any mutating write.
+
+!!! tip "Appending without SWMR"
+    If you don't need concurrent readers, [`EditSession::append_dataset`](editing.md#appending-to-an-unlimited-dataset) appends to an unlimited dataset in place with fewer restrictions — it handles **filtered** (compressed) datasets and **any-length**, non-chunk-aligned appends, neither of which the SWMR writer supports. Reach for SWMR only when a separate process must read the dataset while it grows.

--- a/examples/append_dataset.rs
+++ b/examples/append_dataset.rs
@@ -1,0 +1,88 @@
+//! Appending to a filtered, unlimited dataset in place with
+//! `EditSession::append_dataset` — no SWMR, and without rewriting existing
+//! chunks.
+//!
+//! A rank-1 dataset created with an unlimited dimension and a filter pipeline
+//! (here shuffle + deflate) is grown along axis 0 by appending new elements.
+//! Existing chunks are kept where they are; only the new chunks — plus the
+//! single trailing partial chunk when the current length is not chunk-aligned —
+//! are compressed and written, and the chunk index is rebuilt over the whole
+//! set. The superblock is repointed last, so a failed commit leaves the
+//! original dataset intact.
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo run --example append_dataset
+//! ```
+
+use hdf5_pure::{EditSession, File, FileBuilder};
+
+fn main() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = dir.path().join("log.h5");
+
+    // ---- Create a filtered, unlimited, chunked dataset ------------------
+    // One unlimited dimension (`with_maxshape(&[u64::MAX])`) plus `with_chunks`
+    // makes this an Extensible-Array-indexed dataset, which is the append
+    // target. The filter pipeline is preserved across every append.
+    let initial: Vec<i32> = (0..8).collect();
+    let mut builder = FileBuilder::new();
+    builder
+        .create_dataset("samples")
+        .with_i32_data(&initial)
+        .with_shape(&[initial.len() as u64])
+        .with_maxshape(&[u64::MAX])
+        .with_chunks(&[4])
+        .with_shuffle()
+        .with_deflate(6);
+    builder.write(&path).expect("write initial file");
+
+    // ---- Check eligibility up front (optional) --------------------------
+    // These read-side accessors let a caller decide whether a dataset can be
+    // appended to without relying on the append's refusal error.
+    {
+        let file = File::open(&path).expect("reopen for introspection");
+        let ds = file.dataset("samples").expect("open dataset");
+        assert!(ds.is_chunked());
+        assert_eq!(ds.maxshape().unwrap(), Some(vec![u64::MAX])); // axis 0 unlimited
+        assert_eq!(ds.chunk_shape().unwrap(), Some(vec![4]));
+        assert_eq!(ds.filters(), vec![2, 1]); // shuffle (2) then deflate (1)
+        println!(
+            "eligible: chunked={}, maxshape={:?}, chunks={:?}, filters={:?}",
+            ds.is_chunked(),
+            ds.maxshape().unwrap(),
+            ds.chunk_shape().unwrap(),
+            ds.filters(),
+        );
+    } // the buffered reader holds no lock, but drop it before editing anyway
+
+    // ---- Append in place ------------------------------------------------
+    // Aligned append: 8 -> 16 (two whole chunks of 4).
+    {
+        let mut session = EditSession::open(&path).expect("open for editing");
+        session
+            .append_dataset("samples")
+            .append_i32(&[8, 9, 10, 11, 12, 13, 14, 15]);
+        session.commit().expect("commit aligned append");
+    } // drop the session to release its exclusive lock before reopening
+
+    // Unaligned append: 16 -> 21. Since 21 is not a multiple of the chunk
+    // length, the trailing partial chunk is read, extended, and re-encoded;
+    // every earlier chunk is carried by metadata alone, so existing data is not
+    // rewritten and the file does not grow by the whole dataset per append.
+    {
+        let mut session = EditSession::open(&path).expect("open for editing");
+        session
+            .append_dataset("samples")
+            .append_i32(&[16, 17, 18, 19, 20]);
+        session.commit().expect("commit unaligned append");
+    }
+
+    // ---- Verify ---------------------------------------------------------
+    let file = File::open(&path).expect("reopen");
+    let all = file.dataset("samples").unwrap().read_i32().unwrap();
+    println!("dataset now holds {} samples: {all:?}", all.len());
+    assert_eq!(all, (0..21).collect::<Vec<_>>());
+    println!("in-place append verified");
+}

--- a/src/chunked_write.rs
+++ b/src/chunked_write.rs
@@ -726,7 +726,7 @@ pub fn build_fixed_array_at(
 }
 
 /// Serialize a v4 Extensible Array layout message.
-fn serialize_v4_extensible_array(
+pub(crate) fn serialize_v4_extensible_array(
     chunk_dims: &[u32],
     ea_address: u64,
     offset_size: u8,

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -152,14 +152,17 @@ use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::Path;
 
 use crate::checksum::jenkins_lookup3;
-use crate::chunked_read::{enumerate_chunks_buffered, plan_dense_grid};
+use crate::chunked_read::{chunk_index_spans_buffered, enumerate_chunks_buffered, plan_dense_grid};
 use crate::chunked_write::{
-    ChunkMeta, ChunkOptions, ChunkProvider, build_chunked_data_at_ext, emit_chunked_data_verbatim,
-    plan_chunked_data_verbatim, split_into_chunks,
+    ChunkMeta, ChunkOptions, ChunkProvider, WrittenChunk, build_chunked_data_at_ext,
+    build_extensible_array_at, emit_chunked_data_verbatim, plan_chunked_data_verbatim,
+    serialize_v4_extensible_array, split_into_chunks,
 };
 use crate::data_layout::DataLayout;
 use crate::dataspace::{Dataspace, DataspaceType};
+use crate::datatype::{Datatype, DatatypeByteOrder};
 use crate::error::{Error, FormatError};
+use crate::extensible_array::ExtensibleArrayHeader;
 use crate::file_lock::{self, FileLocking};
 use crate::file_space_info::{FileSpaceInfo, FileSpaceStrategy};
 use crate::file_writer::{
@@ -168,7 +171,7 @@ use crate::file_writer::{
 use crate::filter_pipeline::{
     FILTER_DEFLATE, FILTER_FLETCHER32, FILTER_SCALEOFFSET, FILTER_SHUFFLE, FilterPipeline,
 };
-use crate::filters::{ChunkContext, compress_chunk};
+use crate::filters::{ChunkContext, compress_chunk, decompress_chunk};
 use crate::free_space::FreeList;
 use crate::free_space_manager::{self, FreeSection, FsmHeader, fshd_len, serialize_file_fsm};
 use crate::group_v2::resolve_group_entries;
@@ -179,7 +182,9 @@ use crate::signature;
 use crate::superblock::Superblock;
 use crate::type_builders::{
     AttrValue, DatasetBuilder, ObjectRefTarget, VlStringStaging, build_attr_message,
-    build_global_heap_collection, patch_vl_refs, patch_vl_refs_masked,
+    build_global_heap_collection, make_f32_type, make_f64_type, make_i8_type, make_i16_type,
+    make_i32_type, make_i64_type, make_u8_type, make_u16_type, make_u32_type, make_u64_type,
+    patch_vl_refs, patch_vl_refs_masked,
 };
 
 /// An undefined on-disk address (all bits set), HDF5's "no address" sentinel.
@@ -214,6 +219,97 @@ type PathKey = Vec<String>;
 /// each an (attribute message still carrying a placeholder heap address, its
 /// global heap collection bytes) pair, resolved in the apply loop.
 type PendingVlAttrs = Vec<(crate::attribute::AttributeMessage, Vec<u8>)>;
+
+/// Accumulates elements to append to an existing chunked, unlimited dataset via
+/// [`EditSession::append_dataset`], in call order along the dataset's first
+/// (axis-0) dimension.
+///
+/// It mirrors [`DatasetBuilder`]'s typed/generic vocabulary. Repeated typed or
+/// [`append_raw`](Self::append_raw) calls concatenate; each typed method also
+/// records the element datatype it implies, which `commit` checks against the
+/// dataset's on-disk datatype (a mismatch — including a mix of element types in
+/// one builder — is refused with [`Error::AppendUnsupported`], never written as
+/// garbage).
+pub struct AppendBuilder {
+    /// Accumulated little-endian element bytes to append, in call order.
+    raw: Vec<u8>,
+    /// The element datatype implied by the typed `append_*` calls, if any were
+    /// used. `None` when only [`append_raw`](Self::append_raw) was called (a raw
+    /// append is checked structurally — element-size alignment and little-endian
+    /// on-disk order — rather than by datatype equality).
+    elem_dt: Option<Datatype>,
+    /// Set when two typed calls implied different element datatypes; `commit`
+    /// refuses such a builder rather than write a mix of encodings.
+    dt_conflict: bool,
+}
+
+impl AppendBuilder {
+    fn new() -> Self {
+        Self {
+            raw: Vec::new(),
+            elem_dt: None,
+            dt_conflict: false,
+        }
+    }
+
+    /// Record the datatype a typed append implies, flagging a conflict if an
+    /// earlier typed call implied a different one.
+    fn set_dt(&mut self, dt: Datatype) {
+        match &self.elem_dt {
+            Some(prev) if *prev != dt => self.dt_conflict = true,
+            Some(_) => {}
+            None => self.elem_dt = Some(dt),
+        }
+    }
+
+    /// Append already-little-endian element bytes verbatim. The concatenated
+    /// length must be a whole multiple of the dataset's on-disk element size, and
+    /// the dataset's element datatype must be little-endian; no datatype is
+    /// otherwise inferred. Prefer the typed methods when the element type is known.
+    pub fn append_raw(&mut self, bytes: &[u8]) -> &mut Self {
+        self.raw.extend_from_slice(bytes);
+        self
+    }
+
+    /// Generic append of a flat slice of any supported scalar type — the
+    /// counterpart of [`DatasetBuilder::with_data`](crate::DatasetBuilder::with_data).
+    pub fn append<T: crate::element::H5Element>(&mut self, data: &[T]) -> &mut Self {
+        T::append_into(self, data);
+        self
+    }
+}
+
+/// Generate the typed `append_*` methods: serialize each value little-endian and
+/// record the implied element datatype.
+macro_rules! append_typed {
+    ($($method:ident, $ty:ty, $make:ident;)*) => {
+        impl AppendBuilder {
+            $(
+                #[doc = concat!("Append `", stringify!($ty), "` values to the dataset.")]
+                pub fn $method(&mut self, data: &[$ty]) -> &mut Self {
+                    self.set_dt($make());
+                    for &v in data {
+                        self.raw.extend_from_slice(&v.to_le_bytes());
+                    }
+                    self
+                }
+            )*
+        }
+    };
+}
+
+append_typed! {
+    append_f64, f64, make_f64_type;
+    append_f32, f32, make_f32_type;
+    append_i8, i8, make_i8_type;
+    append_i16, i16, make_i16_type;
+    append_i32, i32, make_i32_type;
+    append_i64, i64, make_i64_type;
+    append_u8, u8, make_u8_type;
+    append_u16, u16, make_u16_type;
+    append_u32, u32, make_u32_type;
+    append_u64, u64, make_u64_type;
+}
 
 /// An open HDF5 file being edited in place.
 ///
@@ -258,6 +354,12 @@ pub struct EditSession {
     /// datatype and shape must match the on-disk ones byte-exactly (this is a
     /// value overwrite, not a reshape/retype). Applied on the next `commit`.
     pending_writes: Vec<(PathKey, DatasetBuilder)>,
+    /// Appends staged by `append_dataset`, as (full dataset path, builder). Each
+    /// grows an existing chunked, unlimited, Extensible-Array-indexed dataset
+    /// along axis 0 by keeping its existing chunk data in place and rebuilding the
+    /// index over the kept plus newly-appended (and any rewritten trailing) chunks.
+    /// Applied on the next `commit`.
+    pending_appends: Vec<(PathKey, AppendBuilder)>,
     /// New groups staged by `create_group`, as full paths.
     pending_groups: Vec<PathKey>,
     /// Group attribute edits staged as (group path, operation). The path may be
@@ -378,6 +480,7 @@ impl EditSession {
             superblock,
             pending_datasets: Vec::new(),
             pending_writes: Vec::new(),
+            pending_appends: Vec::new(),
             pending_groups: Vec::new(),
             pending_group_attrs: Vec::new(),
             pending_deletes: Vec::new(),
@@ -575,6 +678,46 @@ impl EditSession {
         &mut self.pending_writes.last_mut().unwrap().1
     }
 
+    /// Stage an append of new elements to an **existing** chunked, unlimited
+    /// dataset, applied on the next [`commit`](Self::commit). `path` names a
+    /// dataset that must already exist; the returned [`AppendBuilder`] supplies
+    /// the elements to add via its typed / generic / raw `append_*` methods.
+    ///
+    /// Unlike [`write_dataset`](Self::write_dataset) (a value overwrite that
+    /// forbids any shape change) this **grows** the dataset along its first
+    /// (axis-0) dimension. It works on **filtered** datasets: the appended chunks
+    /// are compressed through the dataset's own on-disk filter pipeline
+    /// (deflate / shuffle / fletcher32 / scale-offset, and ZFP with the `zfp`
+    /// feature), and the pipeline, datatype, fill value, and attributes are
+    /// preserved verbatim. Appends of any length are supported — when the
+    /// dataset's current length is not a whole multiple of the chunk length, the
+    /// single trailing partial chunk is read, extended, and re-encoded; every
+    /// other existing chunk is carried by metadata alone, so the existing data is
+    /// not rewritten and the file does not grow by the whole dataset per append.
+    ///
+    /// This does **not** use SWMR and sets no consistency flag. Like every other
+    /// [`EditSession`] edit it commits by appending the new chunks and a rebuilt
+    /// index at end-of-file and repointing the superblock last (under the
+    /// session's exclusive lock), so a crash leaves either the original dataset or
+    /// the fully-grown one, never a torn state.
+    ///
+    /// The first release supports the Extensible-Array chunk index (the index the
+    /// reference C library and h5py select for a single unlimited dimension under
+    /// the latest format, and the one this crate writes for every unlimited
+    /// dataset), rank-1 datasets, and datasets with a single hard link. A dataset
+    /// that is not chunked, not unlimited along axis 0, not Extensible-Array
+    /// indexed, higher than rank 1, uses a filter this engine cannot re-encode,
+    /// has a sparse chunk grid, or (for [`append_raw`](AppendBuilder::append_raw))
+    /// has a big-endian element datatype is refused with
+    /// [`Error::AppendUnsupported`]. Use [`Dataset::is_chunked`](crate::Dataset::is_chunked),
+    /// [`maxshape`](crate::Dataset::maxshape), and [`filters`](crate::Dataset::filters)
+    /// to check eligibility up front.
+    pub fn append_dataset(&mut self, path: &str) -> &mut AppendBuilder {
+        self.pending_appends
+            .push((split_path(path), AppendBuilder::new()));
+        &mut self.pending_appends.last_mut().unwrap().1
+    }
+
     /// Stage a new (empty) group at `path`, created on the next
     /// [`commit`](Self::commit). The parent must already exist or be created in
     /// the same session; populate the group with datasets via
@@ -762,6 +905,7 @@ impl EditSession {
     pub fn commit(&mut self) -> Result<(), Error> {
         if self.pending_datasets.is_empty()
             && self.pending_writes.is_empty()
+            && self.pending_appends.is_empty()
             && self.pending_groups.is_empty()
             && self.pending_group_attrs.is_empty()
             && self.pending_deletes.is_empty()
@@ -852,6 +996,58 @@ impl EditSession {
                     moving_writes.push((parent, leaf, mw));
                 }
             }
+            write_targets.push(full);
+        }
+
+        // --- Preflight appends (`append_dataset`) under the same all-or-nothing,
+        // single-hard-link contract. Each plans a relocating append — existing
+        // chunk data stays in place; the appended (and any rewritten trailing)
+        // chunks and a rebuilt Extensible-Array index are staged, and the whole is
+        // treated like a relocating overwrite of the dataset's header (staged
+        // against its parent group so the commit patches the link). A zero-length
+        // append is a no-op and is dropped here. ---
+        let appends = std::mem::take(&mut self.pending_appends);
+        for (full, ab) in appends {
+            if full.is_empty() {
+                return Err(Error::AppendUnsupported("cannot append to the root group"));
+            }
+            if ab.raw.is_empty() {
+                continue; // nothing to append
+            }
+            // A dataset overwritten or appended earlier in this commit would be
+            // planned against a stale header and its old storage double-freed;
+            // require separate commits.
+            if write_targets.contains(&full) {
+                return Err(Error::AppendUnsupported(
+                    "the same dataset is edited more than once in one commit; use separate commits",
+                ));
+            }
+            let path_str = full.join("/");
+            let addr = crate::group_v2::resolve_path_any(&self.data, &self.superblock, &path_str)
+                .map_err(|_| {
+                Error::AppendUnsupported("nothing to append to at the given path")
+            })?;
+            let addr = usize::try_from(addr)
+                .map_err(|_| Error::AppendUnsupported("dataset address exceeds this platform"))?;
+            let mw = Self::prepare_append(&self.data, addr, &ab, base)?;
+            // A relocating append moves the dataset's object header and patches only
+            // the one parent link that names it, so it is safe only when this is the
+            // dataset's sole hard link (same rule as a relocating overwrite).
+            let counts = incoming_links
+                .get_or_insert_with(|| self.count_incoming_hard_links())
+                .as_ref();
+            match counts.and_then(|c| c.get(&(addr as u64))) {
+                Some(&1) => {}
+                _ => {
+                    return Err(Error::AppendUnsupported(
+                        "appending relocates the dataset header; only supported when it \
+                         has a single hard link",
+                    ));
+                }
+            }
+            let leaf = full.last().unwrap().clone();
+            let parent = full[..full.len() - 1].to_vec();
+            moving_writes.push((parent, leaf, mw));
             write_targets.push(full);
         }
 
@@ -1203,6 +1399,24 @@ impl EditSession {
                             if let Some(spans) = self.chunked_storage_spans(a) {
                                 to_free.extend(spans);
                             }
+                        }
+                    }
+                    // A relocating append keeps the existing chunk *data* in place
+                    // (shared by both indexes during the commit), so only the old
+                    // index structure and the relocated old trailing chunk are dead.
+                    // The old header chunks are freed by the generic path below.
+                    MovingWrite::AppendedChunks {
+                        old_addr,
+                        old_tail_extent,
+                        ..
+                    } => {
+                        if let Ok(a) = usize::try_from(*old_addr) {
+                            if let Some(spans) = self.chunked_index_spans(a) {
+                                to_free.extend(spans);
+                            }
+                        }
+                        if let Some(ext) = old_tail_extent {
+                            to_free.push(*ext);
                         }
                     }
                     _ => {}
@@ -2235,6 +2449,316 @@ impl EditSession {
         }
     }
 
+    /// Plan a relocating append to an existing chunked, unlimited,
+    /// Extensible-Array-indexed dataset at `addr`. Validates the target, splits
+    /// the appended elements into new (and one rewritten trailing) chunks —
+    /// compressed through the on-disk pipeline when filtered — and gathers the
+    /// existing complete chunks by metadata alone. Returns the
+    /// [`MovingWrite::AppendedChunks`] plan; the commit machinery appends the new
+    /// chunks and a rebuilt index and repoints the header (see
+    /// [`write_appended_chunks`](Self::write_appended_chunks)).
+    ///
+    /// Reads only `d` (the file mirror); no bytes are written here. `d` is the
+    /// whole file image and `base` its userblock base; the dataset's stored
+    /// (base-relative) structures are read through a `base`-shifted view.
+    fn prepare_append(
+        d: &[u8],
+        addr: usize,
+        ab: &AppendBuilder,
+        base: u64,
+    ) -> Result<MovingWrite, Error> {
+        if ab.dt_conflict {
+            return Err(Error::AppendUnsupported(
+                "append mixes element types in one builder; use one element type per \
+                 append_dataset call",
+            ));
+        }
+
+        let region = Self::gather_oh_messages(d, addr, base)?;
+
+        // Locate the datatype, dataspace, data-layout, and filter-pipeline
+        // messages, and detect a group (link) header.
+        let mut datatype: Option<(usize, usize)> = None;
+        let mut dataspace: Option<(usize, usize)> = None;
+        let mut layout: Option<(usize, usize)> = None;
+        let mut filter: Option<(usize, usize)> = None;
+        let mut has_link = false;
+        let mut p = 0;
+        while let Some((msg_type, body, body_end)) = next_message(&region, p)? {
+            match msg_type {
+                MessageType::Datatype => datatype = Some((body, body_end)),
+                MessageType::Dataspace => dataspace = Some((body, body_end)),
+                MessageType::DataLayout => layout = Some((body, body_end)),
+                MessageType::FilterPipeline => filter = Some((body, body_end)),
+                MessageType::Link | MessageType::LinkInfo | MessageType::SymbolTable => {
+                    has_link = true;
+                }
+                _ => {}
+            }
+            p = body_end;
+        }
+        if has_link {
+            return Err(Error::AppendUnsupported(
+                "append target is a group, not a dataset",
+            ));
+        }
+        let (dt_b, dt_e) =
+            datatype.ok_or(Error::AppendUnsupported("dataset header has no datatype"))?;
+        let (ds_b, ds_e) =
+            dataspace.ok_or(Error::AppendUnsupported("dataset header has no dataspace"))?;
+        let (lb, le) = layout.ok_or(Error::AppendUnsupported(
+            "dataset header has no data layout",
+        ))?;
+
+        let (disk_dt, _) = Datatype::parse(&region[dt_b..dt_e])
+            .map_err(|_| Error::AppendUnsupported("dataset header datatype could not be parsed"))?;
+        let disk_ds = Dataspace::parse(&region[ds_b..ds_e], LENGTH_SIZE).map_err(|_| {
+            Error::AppendUnsupported("dataset header dataspace could not be parsed")
+        })?;
+        let dl = DataLayout::parse(&region[lb..le], OFFSET_SIZE, LENGTH_SIZE).map_err(|_| {
+            Error::AppendUnsupported("dataset header data layout could not be parsed")
+        })?;
+
+        // Require chunked, data-layout version 4, Extensible-Array index (type 4).
+        let DataLayout::Chunked {
+            version: lversion,
+            chunk_index_type,
+            btree_address,
+            ..
+        } = &dl
+        else {
+            return Err(Error::AppendUnsupported(
+                "append requires a chunked dataset",
+            ));
+        };
+        if *lversion != 4 || *chunk_index_type != Some(4) {
+            return Err(Error::AppendUnsupported(
+                "append requires an Extensible-Array-indexed chunked dataset (a single \
+                 unlimited dimension under the latest format)",
+            ));
+        }
+
+        // Require rank 1, unlimited along axis 0.
+        if disk_ds.space_type != DataspaceType::Simple || disk_ds.dimensions.len() != 1 {
+            return Err(Error::AppendUnsupported(
+                "append requires a rank-1 dataset in this release",
+            ));
+        }
+        match &disk_ds.max_dimensions {
+            Some(md) if md.first() == Some(&u64::MAX) => {}
+            _ => {
+                return Err(Error::AppendUnsupported(
+                    "append requires a dataset that is unlimited along its first dimension",
+                ));
+            }
+        }
+
+        let ChunkedGeometry {
+            spatial,
+            element_size,
+            raw_size,
+            ..
+        } = chunked_geometry(&disk_dt, &disk_ds, &dl)?;
+        let chunk_elems = spatial[0];
+        if chunk_elems == 0 {
+            return Err(Error::AppendUnsupported(
+                "append requires a nonzero chunk length",
+            ));
+        }
+
+        // Validate the appended bytes against the on-disk element type.
+        if ab.raw.len() % element_size != 0 {
+            return Err(Error::AppendUnsupported(
+                "appended byte length is not a whole number of elements",
+            ));
+        }
+        match &ab.elem_dt {
+            // A typed append must match the on-disk datatype exactly (class, size,
+            // and byte order) — this is a value append, not a retype.
+            Some(expected) if *expected != disk_dt => {
+                return Err(Error::AppendUnsupported(
+                    "append datatype does not match the on-disk dataset (wrong element \
+                     type or byte order)",
+                ));
+            }
+            Some(_) => {}
+            // A raw append trusts the caller's bytes but still refuses any datatype
+            // whose flat little-endian bytes cannot be written verbatim: a
+            // big-endian numeric leaf would silently misencode, and a
+            // variable-length or reference leaf embeds heap/object addresses a byte
+            // append cannot reproduce. A typed append is byte-order- and
+            // class-checked by the datatype-equality arm above.
+            None => {
+                if !datatype_is_raw_appendable(&disk_dt) {
+                    return Err(Error::AppendUnsupported(
+                        "append_raw onto this dataset's datatype (non-little-endian, \
+                         variable-length, or reference) could misencode the bytes; use a \
+                         typed append",
+                    ));
+                }
+            }
+        }
+
+        let new_elems = (ab.raw.len() / element_size) as u64;
+        let current_dim0 = disk_ds.dimensions[0];
+        let new_dim0 = current_dim0
+            .checked_add(new_elems)
+            .ok_or(Error::AppendUnsupported(
+                "append would overflow the dataset dimension",
+            ))?;
+
+        // The filter pipeline is preserved verbatim in the rebuilt header; parse it
+        // to re-encode the new chunks. An engine-unencodable filter is refused.
+        let pipeline_message: Option<Vec<u8>> = filter.map(|(fb, fe)| region[fb..fe].to_vec());
+        let has_filters = pipeline_message.is_some();
+        let pipeline = match &pipeline_message {
+            Some(pm) => {
+                let parsed = FilterPipeline::parse(pm).map_err(|_| {
+                    Error::AppendUnsupported("dataset filter pipeline could not be parsed")
+                })?;
+                if !pipeline_reencodable(&parsed) {
+                    return Err(Error::AppendUnsupported(
+                        "dataset uses a filter this engine cannot re-encode",
+                    ));
+                }
+                Some(parsed)
+            }
+            None => None,
+        };
+
+        let base_off = usize::try_from(base).map_err(|_| {
+            Error::AppendUnsupported("userblock base address exceeds this platform")
+        })?;
+        let view = d.get(base_off..).ok_or(Error::AppendUnsupported(
+            "userblock base address past end-of-file",
+        ))?;
+
+        // The rebuilt index's element format (bare address vs address+size+mask) is
+        // chosen by `has_filters`; it must agree with the source index's client id,
+        // or the kept chunks — carried by metadata into the new index — would be
+        // re-encoded in the wrong element width.
+        if let Some(idx_addr) = *btree_address {
+            let src = crate::source::BytesSource::new(view);
+            let hdr =
+                ExtensibleArrayHeader::parse_from_source(&src, idx_addr, OFFSET_SIZE, LENGTH_SIZE)
+                    .map_err(|_| {
+                        Error::AppendUnsupported(
+                            "dataset extensible-array header could not be parsed",
+                        )
+                    })?;
+            if (hdr.client_id == 1) != has_filters {
+                return Err(Error::AppendUnsupported(
+                    "dataset filter metadata is inconsistent (chunk-index client id \
+                     disagrees with the filter pipeline)",
+                ));
+            }
+        }
+
+        // Enumerate the existing chunks (base-relative addresses) and require a
+        // dense grid: `plan_dense_grid` returns the chunks in index order and
+        // `None` on any hole, duplicate, or count mismatch against the dimension.
+        let infos = enumerate_chunks_buffered(view, &dl, &disk_ds, OFFSET_SIZE, LENGTH_SIZE)
+            .map_err(|_| Error::AppendUnsupported("dataset chunk index could not be enumerated"))?;
+        let grid = plan_dense_grid(infos, &disk_ds.dimensions, &spatial).ok_or(
+            Error::AppendUnsupported(
+                "dataset has a sparse or inconsistent chunk grid; cannot append",
+            ),
+        )?;
+        let grid_order = grid.grid_order;
+
+        // Complete chunks are kept by metadata; a trailing partial chunk (when the
+        // current length is not chunk-aligned) is rewritten.
+        let n_full = usize::try_from(current_dim0 / chunk_elems)
+            .map_err(|_| Error::AppendUnsupported("chunk count exceeds this platform"))?;
+        let has_partial = current_dim0 % chunk_elems != 0;
+
+        let mut kept_chunks: Vec<WrittenChunk> = Vec::with_capacity(n_full);
+        for ci in grid_order.iter().take(n_full) {
+            kept_chunks.push(WrittenChunk {
+                address: ci.address,
+                compressed_size: u64::from(ci.chunk_size),
+                raw_size,
+                // Preserve the source mask verbatim: a C/h5py file records a nonzero
+                // mask for a chunk whose filter was skipped (e.g. deflate on
+                // incompressible data), and forcing it to 0 would corrupt that chunk.
+                filter_mask: ci.filter_mask,
+            });
+        }
+
+        // Build the raw byte region for the tail (from the last chunk boundary to
+        // the new end): the live prefix of any rewritten partial chunk, then the
+        // appended bytes.
+        let mut tail_raw: Vec<u8> = Vec::new();
+        let mut old_tail_extent: Option<(u64, u64)> = None;
+        if has_partial {
+            let partial = &grid_order[n_full];
+            let start = usize::try_from(partial.address)
+                .map_err(|_| Error::AppendUnsupported("chunk address exceeds this platform"))?;
+            let len = partial.chunk_size as usize;
+            let end = start.checked_add(len).filter(|&e| e <= view.len()).ok_or(
+                Error::AppendUnsupported("trailing chunk extends past end-of-file"),
+            )?;
+            let stored = &view[start..end];
+            let full = if let Some(pl) = &pipeline {
+                let ctx = ChunkContext::from_datatype(&spatial, &disk_dt);
+                decompress_chunk(stored, pl, ctx, partial.filter_mask).map_err(Error::Format)?
+            } else {
+                stored.to_vec()
+            };
+            let live_elems = usize::try_from(current_dim0 % chunk_elems)
+                .map_err(|_| Error::AppendUnsupported("chunk length exceeds this platform"))?;
+            let live_bytes = live_elems * element_size;
+            if full.len() < live_bytes {
+                return Err(Error::AppendUnsupported(
+                    "trailing chunk decoded shorter than its live element count",
+                ));
+            }
+            tail_raw.extend_from_slice(&full[..live_bytes]);
+            // The old partial chunk's data block is dead once the new index lands.
+            old_tail_extent = Some((partial.address + base, u64::from(partial.chunk_size)));
+        }
+        tail_raw.extend_from_slice(&ab.raw);
+
+        // Split the tail into full chunk buffers (edge overhang zero-filled) and
+        // compress each through the pipeline when filtered.
+        let tail_len_elems = new_dim0 - (n_full as u64) * chunk_elems;
+        let split = split_into_chunks(&tail_raw, &[tail_len_elems], &spatial, element_size);
+        let new_chunk_bytes: Vec<Vec<u8>> = if let Some(pl) = &pipeline {
+            let ctx = ChunkContext::from_datatype(&spatial, &disk_dt);
+            let mut out = Vec::with_capacity(split.len());
+            for (_, buf) in &split {
+                out.push(compress_chunk(buf, pl, ctx).map_err(Error::Format)?);
+            }
+            out
+        } else {
+            split.into_iter().map(|(_, buf)| buf).collect()
+        };
+
+        // Grow the dataspace along axis 0, preserving the (unlimited) max-dims.
+        let mut grown = disk_ds.clone();
+        grown.dimensions[0] = new_dim0;
+        let new_dataspace_body = grown.serialize(LENGTH_SIZE);
+
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "spatial chunk dims come from the on-disk u32 chunk_dimensions, so they fit u32"
+        )]
+        let chunk_dims_u32: Vec<u32> = spatial.iter().map(|&dm| dm as u32).collect();
+
+        Ok(MovingWrite::AppendedChunks {
+            region,
+            new_dataspace_body,
+            chunk_dims_u32,
+            element_size,
+            raw_size,
+            has_filters,
+            kept_chunks,
+            new_chunk_bytes,
+            old_addr: addr as u64,
+            old_tail_extent,
+        })
+    }
+
     /// Parse the object header at `addr` into a copyable model, validating that
     /// every message can be reproduced faithfully (verbatim message bytes, with
     /// only the contiguous data address and child link targets repointed).
@@ -2901,7 +3425,103 @@ impl EditSession {
                 chunk_bytes,
                 &[],
             ),
+            MovingWrite::AppendedChunks {
+                region,
+                new_dataspace_body,
+                chunk_dims_u32,
+                element_size,
+                raw_size,
+                has_filters,
+                kept_chunks,
+                new_chunk_bytes,
+                ..
+            } => self.write_appended_chunks(
+                region,
+                new_dataspace_body,
+                chunk_dims_u32,
+                *element_size,
+                *raw_size,
+                *has_filters,
+                kept_chunks,
+                new_chunk_bytes,
+            ),
         }
+    }
+
+    /// Apply a relocating append ([`MovingWrite::AppendedChunks`]): append the new
+    /// (and any rewritten trailing) chunk bytes at end-of-file, rebuild a fresh
+    /// Extensible Array over the kept plus appended chunks, grow the dataspace and
+    /// repoint the data layout in the verbatim header `region`, and write the
+    /// relocated header. Returns the new header address; the caller patches the
+    /// parent link. The kept chunk data is untouched (referenced by both the old
+    /// and new index during the commit); the old index/header/trailing chunk are
+    /// freed only after the superblock repoint.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "the append rebuild needs the header region, grown dataspace, chunk \
+        geometry, and both chunk sets; bundling them into a struct would only move the list"
+    )]
+    fn write_appended_chunks(
+        &mut self,
+        region: &[u8],
+        new_dataspace_body: &[u8],
+        chunk_dims_u32: &[u32],
+        element_size: usize,
+        raw_size: u64,
+        has_filters: bool,
+        kept_chunks: &[WrittenChunk],
+        new_chunk_bytes: &[Vec<u8>],
+    ) -> Result<u64, Error> {
+        let base = self.superblock.base_address;
+        // Append each new chunk at true end-of-file (never `alloc_or_append`: the
+        // rebuilt index below records base-relative addresses computed from the
+        // end-of-file the appends land at). Existing chunks keep their in-place
+        // addresses and are carried by metadata alone.
+        let mut combined: Vec<WrittenChunk> = kept_chunks.to_vec();
+        for cb in new_chunk_bytes {
+            let abs = self.append(cb)?;
+            combined.push(WrittenChunk {
+                address: abs - base,
+                compressed_size: cb.len() as u64,
+                raw_size,
+                // This engine applies every filter to a new chunk (no per-chunk
+                // skipping), so an appended chunk's mask is always 0. Kept chunks
+                // carry their own (possibly nonzero) mask in `combined` already.
+                filter_mask: 0,
+            });
+        }
+
+        // Build the fresh Extensible Array at the current end-of-file. Its embedded
+        // block addresses are computed from `ea_base` (base-relative), so appending
+        // the blob at the matching file offset makes them resolve correctly, on a
+        // userblock (`base != 0`) file too.
+        let ea_base = self.data.len() as u64 - base;
+        let ea_bytes =
+            build_extensible_array_at(&combined, OFFSET_SIZE, LENGTH_SIZE, has_filters, ea_base)
+                .map_err(Error::Format)?;
+        let written = self.append(&ea_bytes)?;
+        debug_assert_eq!(
+            written,
+            ea_base + base,
+            "extensible-array index must land at end-of-file",
+        );
+
+        // Swap the dataspace (grown) and data-layout (repointed at the new index)
+        // messages; every other header message is preserved verbatim.
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "element size is a datatype byte width that fits u32"
+        )]
+        let layout_body = serialize_v4_extensible_array(
+            chunk_dims_u32,
+            ea_base,
+            OFFSET_SIZE,
+            element_size as u32,
+        );
+        let region = replace_dataspace_message(region, new_dataspace_body)?;
+        let region = replace_layout_message(&region, &layout_body)?;
+        let oh = build_v2_object_header(&region);
+        self.alloc_or_append(&oh)
     }
 
     /// Append `bytes` at end-of-file, updating both the mirror and the file.
@@ -3461,6 +4081,50 @@ impl EditSession {
         }
         Some(spans)
     }
+
+    /// Every on-disk byte span of a chunked dataset's *index structure only* (not
+    /// its chunk data), for reclaiming the old index after a relocating append
+    /// ([`MovingWrite::AppendedChunks`]) that keeps the chunk data in place. Mirror
+    /// of [`chunked_storage_spans`](Self::chunked_storage_spans) but delegating to
+    /// [`chunk_index_spans_buffered`], which enumerates only the EA header/index/
+    /// data/super blocks and never a chunk-data address, so the shared kept chunk
+    /// data is never freed. Base-aware and validated disjoint/in-bounds; returns
+    /// `None` (leave unreclaimed) on any error or violation.
+    fn chunked_index_spans(&self, addr: usize) -> Option<Vec<(u64, u64)>> {
+        let region =
+            Self::gather_oh_messages(&self.data, addr, self.superblock.base_address).ok()?;
+        let mut layout_msg: Option<(usize, usize)> = None;
+        let mut p = 0;
+        loop {
+            match next_message(&region, p) {
+                Ok(Some((msg_type, body, body_end))) => {
+                    if msg_type == MessageType::DataLayout {
+                        layout_msg = Some((body, body_end));
+                    }
+                    p = body_end;
+                }
+                Ok(None) => break,
+                Err(_) => return None,
+            }
+        }
+        let (lb, le) = layout_msg?;
+        let layout = DataLayout::parse(&region[lb..le], OFFSET_SIZE, LENGTH_SIZE).ok()?;
+        if !matches!(layout, DataLayout::Chunked { .. }) {
+            return None;
+        }
+        let base = self.superblock.base_address;
+        let base_off = usize::try_from(base).ok()?;
+        let mut spans =
+            chunk_index_spans_buffered(&self.data[base_off..], &layout, OFFSET_SIZE, LENGTH_SIZE)
+                .ok()?;
+        for (a, _) in &mut spans {
+            *a = a.checked_add(base)?;
+        }
+        if !spans_disjoint_in_bounds(&mut spans, self.data.len() as u64) {
+            return None;
+        }
+        Some(spans)
+    }
 }
 
 /// A dirty group in the edit plan: its base object-header message region and the
@@ -3665,6 +4329,44 @@ enum MovingWrite {
         meta: Vec<ChunkMeta>,
         chunk_bytes: Vec<Vec<u8>>,
         old_addr: u64,
+    },
+    /// A relocating **append** to a chunked, unlimited, Extensible-Array-indexed
+    /// dataset (`append_dataset`). The dataset's existing chunk *data* stays in
+    /// place; only the newly-appended chunks and any rewritten trailing partial
+    /// chunk (`new_chunk_bytes`, already compressed through the on-disk pipeline)
+    /// are appended at end-of-file, a fresh Extensible Array is rebuilt over
+    /// `kept_chunks ++ new_chunk_bytes`, the verbatim header `region`'s dataspace
+    /// message is grown (`new_dataspace_body`) and its data-layout message
+    /// repointed at the new index (every other message — datatype, filter
+    /// pipeline, fill value, attributes — preserved verbatim), and the header is
+    /// relocated. After the commit lands, only the old index structure at
+    /// `old_addr`, the old header, and the relocated old trailing chunk
+    /// (`old_tail_extent`) are freed — never the kept chunk data, which both the
+    /// old and new index share during the commit.
+    AppendedChunks {
+        region: Vec<u8>,
+        /// The grown dataspace message body (v2-serialized), current axis-0
+        /// dimension increased, maximum dimensions (unlimited) preserved.
+        new_dataspace_body: Vec<u8>,
+        /// Rank-only spatial chunk dimensions, for the rebuilt v4 layout message.
+        chunk_dims_u32: Vec<u32>,
+        element_size: usize,
+        /// Full (uncompressed) chunk byte size = product(spatial) * element_size.
+        raw_size: u64,
+        has_filters: bool,
+        /// Existing complete chunks, in index order, carried by metadata alone —
+        /// their base-relative addresses, on-disk stored sizes, and filter masks
+        /// preserved exactly (a nonzero mask from a C/h5py-skipped filter is kept).
+        kept_chunks: Vec<WrittenChunk>,
+        /// The appended chunks in index order: the recompressed trailing partial
+        /// chunk first (when present), then the remaining new full chunks.
+        new_chunk_bytes: Vec<Vec<u8>>,
+        /// The dataset header address, for old-index and old-header reclaim.
+        old_addr: u64,
+        /// The absolute `(addr, len)` of the old trailing partial chunk's data
+        /// block when it was rewritten, freed after the commit lands. `None` when
+        /// the append was chunk-aligned (no partial chunk to rewrite).
+        old_tail_extent: Option<(u64, u64)>,
     },
 }
 
@@ -4039,6 +4741,66 @@ fn replace_layout_message(region: &[u8], new_layout_body: &[u8]) -> Result<Vec<u
         ));
     }
     Ok(out)
+}
+
+/// Rebuild a header message `region`, replacing the single Dataspace message's
+/// record with one carrying `new_dataspace_body` (the grown current dimensions,
+/// v2-serialized, maximum dimensions preserved) and leaving every other message
+/// byte-for-byte. Used by the append path to grow a dataset's axis-0 dimension.
+/// The replacement may differ in length from the original (a v1 on-disk
+/// dataspace is normalized to v2 in the rebuilt header), so the record is rebuilt
+/// via [`region_message`] rather than patched in place.
+fn replace_dataspace_message(region: &[u8], new_dataspace_body: &[u8]) -> Result<Vec<u8>, Error> {
+    let mut out = Vec::with_capacity(region.len());
+    let mut p = 0;
+    let mut replaced = false;
+    while let Some((msg_type, _body, body_end)) = next_message(region, p)? {
+        if msg_type == MessageType::Dataspace && !replaced {
+            out.extend_from_slice(&region_message(MessageType::Dataspace, new_dataspace_body));
+            replaced = true;
+        } else {
+            out.extend_from_slice(&region[p..body_end]);
+        }
+        p = body_end;
+    }
+    if !replaced {
+        return Err(Error::AppendUnsupported(
+            "dataset header has no dataspace message to grow",
+        ));
+    }
+    Ok(out)
+}
+
+/// Whether a datatype's raw on-disk bytes can be appended verbatim from a caller
+/// via [`AppendBuilder::append_raw`]. True only when every scalar leaf is safe to
+/// write as flat little-endian bytes:
+///
+/// - numeric leaves (fixed-point, floating-point, time, bit field) must be
+///   little-endian, or the caller's little-endian bytes would silently misencode
+///   into a big-endian (or VAX) field;
+/// - string and opaque leaves are byte arrays with no numeric byte order, so they
+///   are order-agnostic and safe;
+/// - aggregates (enumeration, array, compound) are appendable iff every leaf is;
+/// - variable-length and reference leaves embed global-heap or object addresses
+///   that a flat byte append cannot reproduce, so they are never raw-appendable.
+///
+/// A typed `append_*` bypasses this: it checks full datatype equality instead, so
+/// it already refuses every non-little-endian and non-scalar dataset.
+fn datatype_is_raw_appendable(dt: &Datatype) -> bool {
+    match dt {
+        Datatype::FixedPoint { byte_order, .. }
+        | Datatype::FloatingPoint { byte_order, .. }
+        | Datatype::Time { byte_order, .. }
+        | Datatype::BitField { byte_order, .. } => *byte_order == DatatypeByteOrder::LittleEndian,
+        Datatype::String { .. } | Datatype::Opaque { .. } => true,
+        Datatype::Enumeration { base_type, .. } | Datatype::Array { base_type, .. } => {
+            datatype_is_raw_appendable(base_type)
+        }
+        Datatype::Compound { members, .. } => members
+            .iter()
+            .all(|m| datatype_is_raw_appendable(&m.datatype)),
+        Datatype::VariableLength { .. } | Datatype::Reference { .. } => false,
+    }
 }
 
 /// The datatype, dataspace, parsed chunked data layout, and verbatim filter-
@@ -4904,6 +5666,66 @@ mod tests {
             p = end;
         }
         out
+    }
+
+    #[test]
+    fn raw_appendable_recurses_into_aggregates() {
+        use crate::datatype::{CompoundMember, DatatypeByteOrder};
+
+        let f64_with = |byte_order| Datatype::FloatingPoint {
+            size: 8,
+            byte_order,
+            bit_offset: 0,
+            bit_precision: 64,
+            exponent_location: 52,
+            exponent_size: 11,
+            mantissa_location: 0,
+            mantissa_size: 52,
+            exponent_bias: 1023,
+        };
+        let le_f64 = f64_with(DatatypeByteOrder::LittleEndian);
+        let be_f64 = f64_with(DatatypeByteOrder::BigEndian);
+
+        // Little-endian scalar: appendable. Big-endian scalar: not.
+        assert!(datatype_is_raw_appendable(&le_f64));
+        assert!(!datatype_is_raw_appendable(&be_f64));
+
+        // The confirmed bug: a compound / array whose leaf is big-endian must be
+        // refused (it was wrongly accepted before recursion was added).
+        let be_member = Datatype::Compound {
+            size: 8,
+            members: vec![CompoundMember {
+                name: "x".into(),
+                byte_offset: 0,
+                datatype: be_f64.clone(),
+            }],
+        };
+        assert!(!datatype_is_raw_appendable(&be_member));
+        let le_member = Datatype::Compound {
+            size: 8,
+            members: vec![CompoundMember {
+                name: "x".into(),
+                byte_offset: 0,
+                datatype: le_f64.clone(),
+            }],
+        };
+        assert!(datatype_is_raw_appendable(&le_member));
+        assert!(!datatype_is_raw_appendable(&Datatype::Array {
+            base_type: Box::new(be_f64.clone()),
+            dimensions: vec![4],
+        }));
+
+        // Variable-length / reference leaves are never raw-appendable, even LE.
+        assert!(!datatype_is_raw_appendable(&Datatype::VariableLength {
+            is_string: false,
+            padding: None,
+            charset: None,
+            base_type: Box::new(le_f64.clone()),
+        }));
+        assert!(!datatype_is_raw_appendable(&Datatype::Reference {
+            size: 8,
+            ref_type: crate::datatype::ReferenceType::Object,
+        }));
     }
 
     #[test]

--- a/src/element.rs
+++ b/src/element.rs
@@ -35,6 +35,7 @@
 //! round_trip("floats", &[1.0f32, 2.5, -3.0]);
 //! ```
 
+use crate::edit::AppendBuilder;
 use crate::error::Error;
 use crate::reader::Dataset;
 use crate::type_builders::DatasetBuilder;
@@ -65,10 +66,15 @@ pub trait H5Element: sealed::Sealed + Copy {
     /// Set `builder`'s data and datatype from a flat row-major slice.
     #[doc(hidden)]
     fn write_into(builder: &mut DatasetBuilder, data: &[Self]);
+
+    /// Append a flat row-major slice to `builder`, recording the implied
+    /// element datatype for the commit-time datatype-match check.
+    #[doc(hidden)]
+    fn append_into(builder: &mut AppendBuilder, data: &[Self]);
 }
 
 macro_rules! impl_h5_element {
-    ($ty:ty, $read:ident, $write:ident) => {
+    ($ty:ty, $read:ident, $write:ident, $append:ident) => {
         impl sealed::Sealed for $ty {}
         impl H5Element for $ty {
             fn read_from(ds: &Dataset<'_>) -> Result<Vec<Self>, Error> {
@@ -77,20 +83,23 @@ macro_rules! impl_h5_element {
             fn write_into(builder: &mut DatasetBuilder, data: &[Self]) {
                 builder.$write(data);
             }
+            fn append_into(builder: &mut AppendBuilder, data: &[Self]) {
+                builder.$append(data);
+            }
         }
     };
 }
 
-impl_h5_element!(f32, read_f32, with_f32_data);
-impl_h5_element!(f64, read_f64, with_f64_data);
-impl_h5_element!(i8, read_i8, with_i8_data);
-impl_h5_element!(i16, read_i16, with_i16_data);
-impl_h5_element!(i32, read_i32, with_i32_data);
-impl_h5_element!(i64, read_i64, with_i64_data);
-impl_h5_element!(u8, read_u8, with_u8_data);
-impl_h5_element!(u16, read_u16, with_u16_data);
-impl_h5_element!(u32, read_u32, with_u32_data);
-impl_h5_element!(u64, read_u64, with_u64_data);
+impl_h5_element!(f32, read_f32, with_f32_data, append_f32);
+impl_h5_element!(f64, read_f64, with_f64_data, append_f64);
+impl_h5_element!(i8, read_i8, with_i8_data, append_i8);
+impl_h5_element!(i16, read_i16, with_i16_data, append_i16);
+impl_h5_element!(i32, read_i32, with_i32_data, append_i32);
+impl_h5_element!(i64, read_i64, with_i64_data, append_i64);
+impl_h5_element!(u8, read_u8, with_u8_data, append_u8);
+impl_h5_element!(u16, read_u16, with_u16_data, append_u16);
+impl_h5_element!(u32, read_u32, with_u32_data, append_u32);
+impl_h5_element!(u64, read_u64, with_u64_data, append_u64);
 
 impl DatasetBuilder {
     /// Set the dataset's data and datatype from a flat slice of any supported

--- a/src/error.rs
+++ b/src/error.rs
@@ -656,6 +656,14 @@ pub enum Error {
     /// filtered, not rank-1 with an unlimited dimension, or not
     /// Extensible-Array indexed). The payload is a human-readable reason.
     SwmrAppendUnsupported(&'static str),
+    /// The dataset is not a supported target for
+    /// [`EditSession::append_dataset`](crate::EditSession::append_dataset) — for
+    /// example a dataset that is not chunked, not extensible along its first
+    /// dimension, not indexed by an Extensible Array, higher than rank 1, uses a
+    /// filter this engine cannot re-encode, has a big-endian on-disk element
+    /// datatype (for a raw append), or has more than one hard link. The payload
+    /// is a human-readable reason.
+    AppendUnsupported(&'static str),
     /// The file or the requested object is not a supported target for the
     /// in-place editor ([`crate::EditSession`]) — for example a userblock or
     /// non-latest-format file, a group whose links are densely stored, or a
@@ -695,6 +703,9 @@ impl fmt::Display for Error {
             ),
             Error::SwmrAppendUnsupported(reason) => {
                 write!(f, "unsupported SWMR append target: {reason}")
+            }
+            Error::AppendUnsupported(reason) => {
+                write!(f, "unsupported append target: {reason}")
             }
             Error::EditUnsupported(reason) => {
                 write!(f, "unsupported in-place edit target: {reason}")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,7 +253,7 @@ pub use writer::FileBuilder;
 pub use swmr_writer::SwmrWriter;
 
 #[cfg(feature = "std")]
-pub use edit::EditSession;
+pub use edit::{AppendBuilder, EditSession};
 
 #[cfg(feature = "std")]
 pub use repack::{RepackOptions, repack};

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1082,6 +1082,65 @@ impl<'f> Dataset<'f> {
         Ok(ds.dimensions.clone())
     }
 
+    /// The dataset's maximum dimensions, when it is extensible. An unlimited
+    /// dimension is reported as `u64::MAX`. Returns `Ok(None)` for a fixed-shape
+    /// dataset (no maximum-dimensions record, or one equal to the current shape).
+    ///
+    /// Together with [`is_chunked`](Self::is_chunked) and
+    /// [`chunk_shape`](Self::chunk_shape), this lets a caller check up front
+    /// whether a dataset is eligible for
+    /// [`EditSession::append_dataset`](crate::EditSession::append_dataset)
+    /// (which requires a chunked dataset whose first maximum dimension is
+    /// `u64::MAX`) instead of relying on the append's refusal error.
+    pub fn maxshape(&self) -> Result<Option<Vec<u64>>, Error> {
+        let ds = self.dataspace()?;
+        match &ds.max_dimensions {
+            Some(md) if *md != ds.dimensions => Ok(Some(md.clone())),
+            _ => Ok(None),
+        }
+    }
+
+    /// Whether the dataset uses chunked storage (as opposed to contiguous or
+    /// compact). Filtered datasets are always chunked. Returns `false` for a
+    /// dataset with no data-layout message or a non-chunked layout.
+    pub fn is_chunked(&self) -> bool {
+        matches!(self.data_layout(), Ok(DataLayout::Chunked { .. }))
+    }
+
+    /// The dataset's chunk dimensions (one per dataset rank), or `Ok(None)` when
+    /// the dataset is not chunked. The element-size dimension the on-disk layout
+    /// appends is stripped, so the result lines up with
+    /// [`shape`](Self::shape) / [`maxshape`](Self::maxshape).
+    pub fn chunk_shape(&self) -> Result<Option<Vec<u64>>, Error> {
+        let DataLayout::Chunked {
+            chunk_dimensions, ..
+        } = self.data_layout()?
+        else {
+            return Ok(None);
+        };
+        let rank = self.dataspace()?.dimensions.len();
+        if chunk_dimensions.len() <= rank {
+            return Ok(None);
+        }
+        Ok(Some(
+            chunk_dimensions[..rank]
+                .iter()
+                .map(|&c| u64::from(c))
+                .collect(),
+        ))
+    }
+
+    /// The HDF5 filter IDs applied to this dataset's chunks, in pipeline
+    /// (application) order, or an empty vector when the dataset is unfiltered.
+    /// The IDs are the registered HDF5 filter numbers — e.g. 1 = deflate,
+    /// 2 = shuffle, 3 = fletcher32, 6 = scale-offset — so a caller can inspect
+    /// the pipeline without decoding a chunk.
+    pub fn filters(&self) -> Vec<u16> {
+        self.filter_pipeline()
+            .map(|p| p.filters.iter().map(|f| f.filter_id).collect())
+            .unwrap_or_default()
+    }
+
     /// Returns the simplified datatype of the dataset.
     pub fn dtype(&self) -> Result<DType, Error> {
         let dt = self.datatype()?;

--- a/tests/append.rs
+++ b/tests/append.rs
@@ -3,7 +3,7 @@
 //! filtered and unfiltered, chunk-aligned and not — and read the result back
 //! with this crate. C-library interop lives in `append_crosscheck.rs`.
 
-use hdf5_pure::{EditSession, Error, File, FileBuilder, ScaleOffset};
+use hdf5_pure::{AppendBuilder, EditSession, Error, File, FileBuilder, ScaleOffset};
 use tempfile::tempdir;
 
 /// Create a rank-1, unlimited i32 dataset with the given chunk length and
@@ -272,6 +272,22 @@ fn introspection_on_contiguous_dataset() {
 // --- Refusal matrix: every case leaves the file unchanged and returns
 // Error::AppendUnsupported. ---
 
+/// Stage an append on `dataset` via `build`, commit, and return the result —
+/// dropping the session (and its exclusive file lock) before returning so a
+/// subsequent readback can reopen the file. On Windows the write lock is
+/// mandatory, so a still-open session makes `File::open` fail with a lock
+/// violation; keeping the session scoped here is what lets each case verify the
+/// file is unchanged after a refused commit.
+fn commit_append(
+    path: &std::path::Path,
+    dataset: &str,
+    build: impl FnOnce(&mut AppendBuilder),
+) -> Result<(), Error> {
+    let mut s = EditSession::open(path).unwrap();
+    build(s.append_dataset(dataset));
+    s.commit()
+}
+
 fn assert_append_unsupported(res: Result<(), Error>) {
     match res {
         Err(Error::AppendUnsupported(_)) => {}
@@ -288,9 +304,9 @@ fn refuse_contiguous() {
         .with_i32_data(&[1, 2, 3])
         .with_shape(&[3]);
     b.write(&path).unwrap();
-    let mut s = EditSession::open(&path).unwrap();
-    s.append_dataset("d").append_i32(&[4, 5]);
-    assert_append_unsupported(s.commit());
+    assert_append_unsupported(commit_append(&path, "d", |a| {
+        a.append_i32(&[4, 5]);
+    }));
     assert_eq!(read_i32(&path), vec![1, 2, 3]);
 }
 
@@ -306,9 +322,9 @@ fn refuse_fixed_chunked_not_unlimited() {
         .with_maxshape(&[100])
         .with_chunks(&[3]);
     b.write(&path).unwrap();
-    let mut s = EditSession::open(&path).unwrap();
-    s.append_dataset("d").append_i32(&[6, 7, 8]);
-    assert_append_unsupported(s.commit());
+    assert_append_unsupported(commit_append(&path, "d", |a| {
+        a.append_i32(&[6, 7, 8]);
+    }));
     assert_eq!(read_i32(&path), (0..6).collect::<Vec<_>>());
 }
 
@@ -324,9 +340,9 @@ fn refuse_rank2() {
         .with_maxshape(&[u64::MAX, 4])
         .with_chunks(&[1, 4]);
     b.write(&path).unwrap();
-    let mut s = EditSession::open(&path).unwrap();
-    s.append_dataset("d").append_i32(&[0, 0, 0, 0]);
-    assert_append_unsupported(s.commit());
+    assert_append_unsupported(commit_append(&path, "d", |a| {
+        a.append_i32(&[0, 0, 0, 0]);
+    }));
 }
 
 #[test]
@@ -334,9 +350,9 @@ fn refuse_datatype_mismatch() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("d.h5");
     create_i32(&path, 4, 4, true, false, false);
-    let mut s = EditSession::open(&path).unwrap();
-    s.append_dataset("d").append_f64(&[1.0, 2.0]); // f64 onto i32
-    assert_append_unsupported(s.commit());
+    assert_append_unsupported(commit_append(&path, "d", |a| {
+        a.append_f64(&[1.0, 2.0]); // f64 onto i32
+    }));
     assert_eq!(read_i32(&path), (0..4).collect::<Vec<_>>());
 }
 
@@ -345,9 +361,9 @@ fn refuse_raw_wrong_length() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("d.h5");
     create_i32(&path, 4, 4, true, false, false);
-    let mut s = EditSession::open(&path).unwrap();
-    s.append_dataset("d").append_raw(&[1, 2, 3]); // 3 bytes, elem size 4
-    assert_append_unsupported(s.commit());
+    assert_append_unsupported(commit_append(&path, "d", |a| {
+        a.append_raw(&[1, 2, 3]); // 3 bytes, elem size 4
+    }));
     assert_eq!(read_i32(&path), (0..4).collect::<Vec<_>>());
 }
 
@@ -356,9 +372,9 @@ fn refuse_mixed_element_types() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("d.h5");
     create_i32(&path, 4, 4, true, false, false);
-    let mut s = EditSession::open(&path).unwrap();
-    s.append_dataset("d").append_i32(&[4, 5]).append_i64(&[6]);
-    assert_append_unsupported(s.commit());
+    assert_append_unsupported(commit_append(&path, "d", |a| {
+        a.append_i32(&[4, 5]).append_i64(&[6]);
+    }));
     assert_eq!(read_i32(&path), (0..4).collect::<Vec<_>>());
 }
 
@@ -367,7 +383,7 @@ fn refuse_nonexistent_dataset() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("d.h5");
     create_i32(&path, 4, 4, true, false, false);
-    let mut s = EditSession::open(&path).unwrap();
-    s.append_dataset("missing").append_i32(&[1]);
-    assert_append_unsupported(s.commit());
+    assert_append_unsupported(commit_append(&path, "missing", |a| {
+        a.append_i32(&[1]);
+    }));
 }

--- a/tests/append.rs
+++ b/tests/append.rs
@@ -1,0 +1,373 @@
+//! Pure-Rust tests for `EditSession::append_dataset`: append new elements to an
+//! existing chunked, unlimited, Extensible-Array-indexed dataset in place —
+//! filtered and unfiltered, chunk-aligned and not — and read the result back
+//! with this crate. C-library interop lives in `append_crosscheck.rs`.
+
+use hdf5_pure::{EditSession, Error, File, FileBuilder, ScaleOffset};
+use tempfile::tempdir;
+
+/// Create a rank-1, unlimited i32 dataset with the given chunk length and
+/// (optional) filters, seeded with `0..n`.
+fn create_i32(
+    path: &std::path::Path,
+    n: i32,
+    chunk: u64,
+    deflate: bool,
+    shuffle: bool,
+    fletcher32: bool,
+) {
+    let data: Vec<i32> = (0..n).collect();
+    let mut b = FileBuilder::new();
+    let ds = b
+        .create_dataset("d")
+        .with_i32_data(&data)
+        .with_shape(&[n as u64])
+        .with_maxshape(&[u64::MAX])
+        .with_chunks(&[chunk]);
+    if shuffle {
+        ds.with_shuffle();
+    }
+    if deflate {
+        ds.with_deflate(6);
+    }
+    if fletcher32 {
+        ds.with_fletcher32();
+    }
+    b.write(path).unwrap();
+}
+
+fn read_i32(path: &std::path::Path) -> Vec<i32> {
+    let f = File::open(path).unwrap();
+    f.dataset("d").unwrap().read_i32().unwrap()
+}
+
+fn append_i32(path: &std::path::Path, values: &[i32]) {
+    let mut s = EditSession::open(path).unwrap();
+    s.append_dataset("d").append_i32(values);
+    s.commit().unwrap();
+}
+
+#[test]
+fn append_deflate_shuffle_chunk_aligned() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("d.h5");
+    // 8 elements, chunk 4 => 2 full chunks. Append 8 more (2 chunks): aligned.
+    create_i32(&path, 8, 4, true, true, false);
+    append_i32(&path, &(8..16).collect::<Vec<_>>());
+    assert_eq!(read_i32(&path), (0..16).collect::<Vec<_>>());
+}
+
+#[test]
+fn append_unaligned_crosses_chunk_boundary() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("d.h5");
+    // 6 elements, chunk 4 => 1 full chunk + a partial (2 of 4). Append 5 => 11:
+    // the partial chunk is rewritten and the tail grows to 3 chunks.
+    create_i32(&path, 6, 4, true, true, false);
+    append_i32(&path, &(6..11).collect::<Vec<_>>());
+    assert_eq!(read_i32(&path), (0..11).collect::<Vec<_>>());
+}
+
+#[test]
+fn append_repeated_partial_then_partial() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("d.h5");
+    create_i32(&path, 3, 4, true, false, false); // 1 partial chunk (3 of 4)
+    append_i32(&path, &[3, 4]); // -> 5 (crosses into chunk 1, partial)
+    append_i32(&path, &[5, 6, 7]); // -> 8 (fills chunk 1)
+    append_i32(&path, &[8]); // -> 9 (new partial chunk 2)
+    assert_eq!(read_i32(&path), (0..9).collect::<Vec<_>>());
+}
+
+#[test]
+fn append_unfiltered() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("d.h5");
+    create_i32(&path, 6, 3, false, false, false);
+    append_i32(&path, &(6..13).collect::<Vec<_>>()); // unaligned (6->13)
+    assert_eq!(read_i32(&path), (0..13).collect::<Vec<_>>());
+}
+
+#[test]
+fn append_fletcher32() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("d.h5");
+    create_i32(&path, 5, 4, true, false, true);
+    append_i32(&path, &(5..12).collect::<Vec<_>>());
+    assert_eq!(read_i32(&path), (0..12).collect::<Vec<_>>());
+}
+
+#[test]
+fn append_scale_offset_f64() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("d.h5");
+    let init: Vec<f64> = (0..6).map(|i| i as f64 * 0.25).collect();
+    let mut b = FileBuilder::new();
+    b.create_dataset("d")
+        .with_f64_data(&init)
+        .with_shape(&[6])
+        .with_maxshape(&[u64::MAX])
+        .with_chunks(&[4])
+        .with_scale_offset(ScaleOffset::FloatDScale(2));
+    b.write(&path).unwrap();
+
+    let more: Vec<f64> = (6..14).map(|i| i as f64 * 0.25).collect();
+    {
+        let mut s = EditSession::open(&path).unwrap();
+        s.append_dataset("d").append_f64(&more);
+        s.commit().unwrap();
+    }
+    let back = File::open(&path)
+        .unwrap()
+        .dataset("d")
+        .unwrap()
+        .read_f64()
+        .unwrap();
+    let expected: Vec<f64> = (0..14).map(|i| i as f64 * 0.25).collect();
+    assert_eq!(back.len(), expected.len());
+    for (a, b) in back.iter().zip(expected.iter()) {
+        assert!((a - b).abs() < 1e-9, "{a} != {b}");
+    }
+}
+
+#[test]
+fn append_generic_and_raw() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("d.h5");
+    create_i32(&path, 4, 4, true, false, false);
+    // Generic append<T>.
+    {
+        let mut s = EditSession::open(&path).unwrap();
+        s.append_dataset("d").append(&[4i32, 5, 6, 7]);
+        s.commit().unwrap();
+    }
+    // Raw append (little-endian i32 bytes).
+    {
+        let mut s = EditSession::open(&path).unwrap();
+        let mut bytes = Vec::new();
+        for v in [8i32, 9, 10] {
+            bytes.extend_from_slice(&v.to_le_bytes());
+        }
+        s.append_dataset("d").append_raw(&bytes);
+        s.commit().unwrap();
+    }
+    assert_eq!(read_i32(&path), (0..11).collect::<Vec<_>>());
+}
+
+#[test]
+fn append_to_userblock_file() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("ub.h5");
+    // A 512-byte userblock (as a .mat file has) makes the superblock base nonzero,
+    // so every stored address is base-relative. The append must place and index
+    // its new chunks base-relative too.
+    let mut b = FileBuilder::new();
+    b.with_userblock(512);
+    b.create_dataset("d")
+        .with_i32_data(&(0..8).collect::<Vec<_>>())
+        .with_shape(&[8])
+        .with_maxshape(&[u64::MAX])
+        .with_chunks(&[4])
+        .with_shuffle()
+        .with_deflate(6);
+    b.write(&path).unwrap();
+    append_i32(&path, &(8..17).collect::<Vec<_>>()); // unaligned 8 -> 17
+    assert_eq!(read_i32(&path), (0..17).collect::<Vec<_>>());
+}
+
+#[test]
+fn zero_length_append_is_noop() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("d.h5");
+    create_i32(&path, 5, 4, true, false, false);
+    {
+        let mut s = EditSession::open(&path).unwrap();
+        s.append_dataset("d").append_i32(&[]);
+        s.commit().unwrap();
+    }
+    assert_eq!(read_i32(&path), (0..5).collect::<Vec<_>>());
+}
+
+#[test]
+fn many_appends_do_not_rewrite_existing_data() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("d.h5");
+    // Incompressible base data so its on-disk size dominates the per-append index
+    // overhead: if each append rewrote the whole dataset the file would grow by
+    // ~one base per append (10x+); keeping existing chunk data in place bounds it.
+    let lcg = |mut x: u32| {
+        move || {
+            x = x.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+            x as i32
+        }
+    };
+    let base_n = 20_000usize;
+    let mut rng = lcg(0x1234_5678);
+    let base: Vec<i32> = (0..base_n).map(|_| rng()).collect();
+    {
+        let mut b = FileBuilder::new();
+        b.create_dataset("d")
+            .with_i32_data(&base)
+            .with_shape(&[base_n as u64])
+            .with_maxshape(&[u64::MAX])
+            .with_chunks(&[200])
+            .with_deflate(6);
+        b.write(&path).unwrap();
+    }
+    let size_after_create = std::fs::metadata(&path).unwrap().len();
+
+    let mut expected = base;
+    {
+        let mut s = EditSession::open(&path).unwrap();
+        for _ in 0..10 {
+            let batch: Vec<i32> = (0..200).map(|_| rng()).collect();
+            expected.extend_from_slice(&batch);
+            s.append_dataset("d").append_i32(&batch);
+            s.commit().unwrap();
+        }
+    }
+    assert_eq!(read_i32(&path), expected);
+
+    let final_size = std::fs::metadata(&path).unwrap().len();
+    // 10 appends of 200 to a 20 000-element incompressible base. Rewriting the
+    // dataset each append would roughly multiply the file size; keeping data in
+    // place keeps growth to index/header churn, well under a single extra base.
+    assert!(
+        final_size < size_after_create * 2,
+        "file grew from {size_after_create} to {final_size}; appends must not rewrite existing data"
+    );
+}
+
+#[test]
+fn introspection_reports_eligibility() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("d.h5");
+    create_i32(&path, 8, 4, true, true, false);
+    let f = File::open(&path).unwrap();
+    let ds = f.dataset("d").unwrap();
+    assert!(ds.is_chunked());
+    assert_eq!(ds.maxshape().unwrap(), Some(vec![u64::MAX]));
+    assert_eq!(ds.chunk_shape().unwrap(), Some(vec![4]));
+    // shuffle (2) then deflate (1), in pipeline order.
+    assert_eq!(ds.filters(), vec![2, 1]);
+}
+
+#[test]
+fn introspection_on_contiguous_dataset() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("d.h5");
+    let mut b = FileBuilder::new();
+    b.create_dataset("d")
+        .with_i32_data(&[1, 2, 3])
+        .with_shape(&[3]);
+    b.write(&path).unwrap();
+    let f = File::open(&path).unwrap();
+    let ds = f.dataset("d").unwrap();
+    assert!(!ds.is_chunked());
+    assert_eq!(ds.maxshape().unwrap(), None);
+    assert_eq!(ds.chunk_shape().unwrap(), None);
+    assert!(ds.filters().is_empty());
+}
+
+// --- Refusal matrix: every case leaves the file unchanged and returns
+// Error::AppendUnsupported. ---
+
+fn assert_append_unsupported(res: Result<(), Error>) {
+    match res {
+        Err(Error::AppendUnsupported(_)) => {}
+        other => panic!("expected AppendUnsupported, got {other:?}"),
+    }
+}
+
+#[test]
+fn refuse_contiguous() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("d.h5");
+    let mut b = FileBuilder::new();
+    b.create_dataset("d")
+        .with_i32_data(&[1, 2, 3])
+        .with_shape(&[3]);
+    b.write(&path).unwrap();
+    let mut s = EditSession::open(&path).unwrap();
+    s.append_dataset("d").append_i32(&[4, 5]);
+    assert_append_unsupported(s.commit());
+    assert_eq!(read_i32(&path), vec![1, 2, 3]);
+}
+
+#[test]
+fn refuse_fixed_chunked_not_unlimited() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("d.h5");
+    // Chunked but a finite maximum (not unlimited) => fixed-array index, refused.
+    let mut b = FileBuilder::new();
+    b.create_dataset("d")
+        .with_i32_data(&(0..6).collect::<Vec<_>>())
+        .with_shape(&[6])
+        .with_maxshape(&[100])
+        .with_chunks(&[3]);
+    b.write(&path).unwrap();
+    let mut s = EditSession::open(&path).unwrap();
+    s.append_dataset("d").append_i32(&[6, 7, 8]);
+    assert_append_unsupported(s.commit());
+    assert_eq!(read_i32(&path), (0..6).collect::<Vec<_>>());
+}
+
+#[test]
+fn refuse_rank2() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("d.h5");
+    // 2-D dataset with one unlimited axis (EA index) — refused as rank > 1.
+    let mut b = FileBuilder::new();
+    b.create_dataset("d")
+        .with_i32_data(&(0..12).collect::<Vec<_>>())
+        .with_shape(&[3, 4])
+        .with_maxshape(&[u64::MAX, 4])
+        .with_chunks(&[1, 4]);
+    b.write(&path).unwrap();
+    let mut s = EditSession::open(&path).unwrap();
+    s.append_dataset("d").append_i32(&[0, 0, 0, 0]);
+    assert_append_unsupported(s.commit());
+}
+
+#[test]
+fn refuse_datatype_mismatch() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("d.h5");
+    create_i32(&path, 4, 4, true, false, false);
+    let mut s = EditSession::open(&path).unwrap();
+    s.append_dataset("d").append_f64(&[1.0, 2.0]); // f64 onto i32
+    assert_append_unsupported(s.commit());
+    assert_eq!(read_i32(&path), (0..4).collect::<Vec<_>>());
+}
+
+#[test]
+fn refuse_raw_wrong_length() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("d.h5");
+    create_i32(&path, 4, 4, true, false, false);
+    let mut s = EditSession::open(&path).unwrap();
+    s.append_dataset("d").append_raw(&[1, 2, 3]); // 3 bytes, elem size 4
+    assert_append_unsupported(s.commit());
+    assert_eq!(read_i32(&path), (0..4).collect::<Vec<_>>());
+}
+
+#[test]
+fn refuse_mixed_element_types() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("d.h5");
+    create_i32(&path, 4, 4, true, false, false);
+    let mut s = EditSession::open(&path).unwrap();
+    s.append_dataset("d").append_i32(&[4, 5]).append_i64(&[6]);
+    assert_append_unsupported(s.commit());
+    assert_eq!(read_i32(&path), (0..4).collect::<Vec<_>>());
+}
+
+#[test]
+fn refuse_nonexistent_dataset() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("d.h5");
+    create_i32(&path, 4, 4, true, false, false);
+    let mut s = EditSession::open(&path).unwrap();
+    s.append_dataset("missing").append_i32(&[1]);
+    assert_append_unsupported(s.commit());
+}

--- a/tests/append_crosscheck.rs
+++ b/tests/append_crosscheck.rs
@@ -1,0 +1,197 @@
+// Crosschecks link the reference HDF5 C library (the `hdf5-metno` dev-dependency),
+// gated to 64-bit-pointer targets; skip on 32-bit so the pure-Rust suite still
+// runs under `cross test --target i686-...`.
+#![cfg(not(target_pointer_width = "32"))]
+//! Interop tests for `EditSession::append_dataset`: append to a filtered,
+//! unlimited, Extensible-Array-indexed dataset and confirm the reference C
+//! library (`hdf5-metno`) reads the grown dataset back exactly — including
+//! datasets the C library itself created, whose incompressible chunks carry a
+//! nonzero per-chunk filter mask that the append must preserve.
+
+use hdf5::Extent;
+use hdf5::file::LibraryVersion;
+use hdf5_pure::{EditSession, File, FileBuilder};
+use tempfile::tempdir;
+
+/// A deterministic incompressible i32 stream (LCG), so deflate stores chunks
+/// uncompressed and the C library records a nonzero per-chunk filter mask.
+fn incompressible(seed: u32, n: usize) -> Vec<i32> {
+    let mut x = seed;
+    (0..n)
+        .map(|_| {
+            x = x.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+            x as i32
+        })
+        .collect()
+}
+
+fn read_pure(path: &std::path::Path) -> Vec<i32> {
+    File::open(path)
+        .unwrap()
+        .dataset("d")
+        .unwrap()
+        .read_i32()
+        .unwrap()
+}
+
+fn read_c(path: &std::path::Path) -> Vec<i32> {
+    let f = hdf5::File::open(path).unwrap();
+    f.dataset("d").unwrap().read_raw::<i32>().unwrap()
+}
+
+/// Create a filtered (deflate+shuffle) rank-1 unlimited i32 dataset with the C
+/// library under the latest format (so it gets an Extensible-Array index).
+fn c_create_filtered(path: &std::path::Path, data: &[i32], chunk: usize) {
+    let file = hdf5::File::with_options()
+        .with_fapl(|p| p.libver_bounds(LibraryVersion::V110, LibraryVersion::latest()))
+        .create(path)
+        .unwrap();
+    let ds = file
+        .new_dataset::<i32>()
+        .shuffle()
+        .deflate(6)
+        .chunk((chunk,))
+        .shape((Extent::resizable(data.len()),))
+        .create("d")
+        .unwrap();
+    ds.write(data).unwrap();
+    file.close().unwrap();
+}
+
+/// Create a filtered rank-1 unlimited i32 dataset with this crate.
+fn pure_create_filtered(path: &std::path::Path, data: &[i32], chunk: u64) {
+    let mut b = FileBuilder::new();
+    b.create_dataset("d")
+        .with_i32_data(data)
+        .with_shape(&[data.len() as u64])
+        .with_maxshape(&[u64::MAX])
+        .with_chunks(&[chunk])
+        .with_shuffle()
+        .with_deflate(6);
+    b.write(path).unwrap();
+}
+
+fn pure_append(path: &std::path::Path, values: &[i32]) {
+    let mut s = EditSession::open(path).unwrap();
+    s.append_dataset("d").append_i32(values);
+    s.commit().unwrap();
+}
+
+#[test]
+fn pure_creates_pure_appends_c_reads() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("d.h5");
+    let base: Vec<i32> = (0..12).collect();
+    pure_create_filtered(&path, &base, 4);
+    // Aligned append (12 -> 20) then unaligned (20 -> 27).
+    pure_append(&path, &(12..20).collect::<Vec<_>>());
+    pure_append(&path, &(20..27).collect::<Vec<_>>());
+    let expected: Vec<i32> = (0..27).collect();
+    assert_eq!(read_pure(&path), expected);
+    assert_eq!(read_c(&path), expected);
+}
+
+#[test]
+fn c_creates_pure_appends_both_read() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("d.h5");
+    let base: Vec<i32> = (0..20).collect();
+    c_create_filtered(&path, &base, 5);
+    pure_append(&path, &(20..33).collect::<Vec<_>>()); // unaligned 20 -> 33
+    let expected: Vec<i32> = (0..33).collect();
+    assert_eq!(read_pure(&path), expected);
+    assert_eq!(read_c(&path), expected);
+}
+
+#[test]
+fn c_incompressible_kept_chunks_filter_mask_preserved() {
+    // The load-bearing interop case: the C library stores incompressible chunks
+    // uncompressed and records a nonzero per-chunk filter mask. The append must
+    // carry each kept chunk's original mask (not force 0) into the rebuilt index,
+    // or the C library would try to inflate stored-uncompressed bytes and read
+    // garbage.
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("d.h5");
+    let base = incompressible(0xABCD_1234, 40); // 8 chunks of 5, all incompressible
+    c_create_filtered(&path, &base, 5);
+
+    let extra = incompressible(0x5555_AAAA, 17); // unaligned append (40 -> 57)
+    pure_append(&path, &extra);
+
+    let mut expected = base.clone();
+    expected.extend_from_slice(&extra);
+    assert_eq!(
+        read_c(&path),
+        expected,
+        "C must read the kept incompressible chunks intact"
+    );
+    assert_eq!(read_pure(&path), expected);
+}
+
+#[test]
+fn append_to_c_empty_extensible() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("d.h5");
+    // C creates an empty (0-length) resizable filtered dataset.
+    c_create_filtered(&path, &[], 4);
+    pure_append(&path, &(0..10).collect::<Vec<_>>());
+    let expected: Vec<i32> = (0..10).collect();
+    assert_eq!(read_pure(&path), expected);
+    assert_eq!(read_c(&path), expected);
+}
+
+#[test]
+fn pure_unfiltered_append_c_reads() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("d.h5");
+    let mut b = FileBuilder::new();
+    b.create_dataset("d")
+        .with_i32_data(&(0..10).collect::<Vec<_>>())
+        .with_shape(&[10])
+        .with_maxshape(&[u64::MAX])
+        .with_chunks(&[4]);
+    b.write(&path).unwrap();
+    pure_append(&path, &(10..23).collect::<Vec<_>>());
+    let expected: Vec<i32> = (0..23).collect();
+    assert_eq!(read_pure(&path), expected);
+    assert_eq!(read_c(&path), expected);
+}
+
+#[test]
+fn userblock_append_c_reads() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("ub.h5");
+    let mut b = FileBuilder::new();
+    b.with_userblock(512);
+    b.create_dataset("d")
+        .with_i32_data(&(0..10).collect::<Vec<_>>())
+        .with_shape(&[10])
+        .with_maxshape(&[u64::MAX])
+        .with_chunks(&[4])
+        .with_shuffle()
+        .with_deflate(6);
+    b.write(&path).unwrap();
+    pure_append(&path, &(10..21).collect::<Vec<_>>()); // unaligned
+    let expected: Vec<i32> = (0..21).collect();
+    assert_eq!(read_pure(&path), expected);
+    assert_eq!(read_c(&path), expected);
+}
+
+#[test]
+fn large_paged_ea_append_c_reads() {
+    // Append enough chunks (chunk length 1) that the rebuilt Extensible Array uses
+    // super blocks / paged data blocks, then confirm the C library reads it back.
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("d.h5");
+    let base: Vec<i32> = (0..64).collect();
+    pure_create_filtered(&path, &base, 1);
+    {
+        let mut s = EditSession::open(&path).unwrap();
+        s.append_dataset("d")
+            .append_i32(&(64..4096).collect::<Vec<_>>());
+        s.commit().unwrap();
+    }
+    let expected: Vec<i32> = (0..4096).collect();
+    assert_eq!(read_pure(&path), expected);
+    assert_eq!(read_c(&path), expected);
+}


### PR DESCRIPTION
Closes #144.

## What

Adds a general-purpose, non-SWMR in-place **append** to chunked, unlimited datasets — including **filtered** ones — via `EditSession::append_dataset`. Previously the only incremental append was part of the optional SWMR writer and was limited to unfiltered datasets; this brings appending into the ordinary `EditSession` edit path so it no longer requires SWMR.

## API

```rust
let mut session = EditSession::open("data.h5")?;
session.append_dataset("signal").append_f64(&[1.0, 2.0, 3.0]);
session.commit()?;
```

`AppendBuilder` mirrors the writer's vocabulary: typed (`append_f64`/`append_i32`/…), generic (`append::<T>`), and `append_raw`. New read-only `Dataset` introspection — `is_chunked`, `maxshape`, `chunk_shape`, `filters` — lets callers check append eligibility without decoding data.

## How it works

Index-relocate: the dataset's existing chunk **data stays in place**; only the new chunks (and, for an unaligned append, the single rewritten trailing partial chunk) are compressed through the dataset's own filter pipeline and appended, the Extensible-Array index is rebuilt over the kept plus new chunks, the dataspace grows, the header relocates, and the superblock is repointed last under the session's exclusive lock. A crash therefore leaves either the original dataset or the fully-grown one. The file does not grow by the whole dataset per append.

Load-bearing correctness details: kept chunks carry their original per-chunk filter mask and stored size verbatim (so a C/h5py file's incompressible chunks — which carry a nonzero mask — read back correctly), all addressing is base-relative so userblock/`.mat` files work, `max_dimensions` stays unlimited, and reclaim frees only the old index, old header, and relocated old tail — never the shared kept chunk data.

## Scope

First release supports the Extensible-Array chunk index (rank-1, single unlimited dimension — the index this crate writes for every unlimited dataset and the one the C library and h5py select under the latest format), filtered (deflate/shuffle/fletcher32/scale-offset, and ZFP with the `zfp` feature) and unfiltered, and appends of any length. Datasets that are not Extensible-Array-indexed (a version-1 B-tree, fixed-array, or single-chunk index), higher than rank 1, use a filter this engine cannot re-encode, have a sparse chunk grid, or have more than one hard link are refused with `Error::AppendUnsupported`.

Deferred (documented): a version-1 B-tree chunk-index writer (for non-latest-format files), rank > 1, and true O(1)-per-append in-place index growth. Because each append rebuilds the index, superseded indexes from separate non-persisting sessions become holes that `repack` reclaims.

## Testing

- `tests/append.rs` (19, pure-Rust): aligned / unaligned / partial-then-partial / unfiltered / fletcher32 / scale-offset / generic / raw / userblock / zero-length appends, the full refusal matrix, introspection, and a no-rewrite space check.
- `tests/append_crosscheck.rs` (7, reference C library): pure→C, C→pure, C-created incompressible chunks with a nonzero filter mask read back intact, append to an empty extensible dataset, a paged Extensible Array (4096 chunks), and a userblock file.

Full suite green (512 lib + all integration); `cargo fmt --check`, `clippy --all-targets --all-features -D warnings`, and the `no_std` check are all clean.