### PR TITLE
Fix broken rustdoc links and publish the full API on docs.rs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,10 @@ jobs:
         run: cargo fmt --all -- --check
       - name: Clippy
         run: cargo clippy --locked --features "serde ndarray" --all-targets -- -D warnings
+      - name: Rustdoc (deny warnings)
+        env:
+          RUSTDOCFLAGS: -D warnings
+        run: cargo doc --locked --no-deps --features "provenance parallel zfp ndarray serde"
 
   shear:
     name: Unused dependencies (cargo-shear)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - Reading an attribute or dataset whose dataspace declares dimensions whose product overflows `u64` no longer panics: the element count now saturates so the size and limit checks reject the file as a format error ([#142](https://github.com/stephenberry/hdf5-pure/issues/142)).
+- docs.rs now documents the full public API — the `ndarray`, `serde` (`mat`), `zfp`, `provenance`, and `parallel` surfaces, previously hidden by a default-features-only build — and repairs the broken rustdoc intra-doc links across the public API ([#154](https://github.com/stephenberry/hdf5-pure/pull/154)).
 
 ## [0.21.2] - 2026-07-14
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,13 @@ build = "build.rs"
 # are needed only for maintainer CI and stay in the git repo for that purpose.
 exclude = ["tests/fixtures/**", "fuzz/**"]
 
+# Publish the full public API on docs.rs. The default feature set hides the
+# `ndarray`, `serde` (`mat`), `zfp`, `provenance`, and `parallel` surfaces (and
+# leaves their cross-references as dead links); `matio-crosscheck` is a
+# test-only feature and is deliberately excluded.
+[package.metadata.docs.rs]
+features = ["provenance", "parallel", "zfp", "ndarray", "serde"]
+
 [features]
 default = ["std", "checksum", "deflate"]
 std = []

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -413,8 +413,8 @@ impl EditSession {
     /// another writer or reader; the lock is released automatically when the
     /// session is dropped or the process exits (including on a crash). Fails with
     /// [`Error::FileLocked`] if the file is already locked, or
-    /// [`Error::EditUnsupported`] if the file is not a supported target (see the
-    /// [module docs](self) for the exact requirements). To control or disable
+    /// [`Error::EditUnsupported`] if the file is not a supported target; its
+    /// documentation enumerates the exact requirements. To control or disable
     /// locking, use [`open_with_locking`](Self::open_with_locking) or set
     /// `HDF5_USE_FILE_LOCKING=FALSE`.
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
@@ -627,9 +627,7 @@ impl EditSession {
     /// contiguous dataset may carry variable-length attributes, a
     /// variable-length-string payload (`with_vlen_strings`), or path-resolved
     /// object-reference elements (`with_path_references`; chunking any of
-    /// these is not supported — see the [module docs](self) for the
-    /// path-resolution rule and what still stays unsupported (dense
-    /// attributes)).
+    /// these is not supported, and dense attributes remain unsupported).
     pub fn create_dataset(&mut self, path: &str) -> &mut DatasetBuilder {
         let mut comps = split_path(path);
         let leaf = comps.pop().unwrap_or_default();
@@ -776,7 +774,7 @@ impl EditSession {
     /// bytes rather than risk freeing a region that is still in use. Freed space is
     /// reused within the open session; for a file created with
     /// `H5Pset_file_space_strategy(persist = true)` it is also recorded on disk so
-    /// it survives reopen (see the [module docs](self)), otherwise it is forgotten
+    /// it survives reopen (see [`EditSession`]), otherwise it is forgotten
     /// on close. After reuse, an object reference to a deleted object may resolve
     /// to an unrelated object (deleting a referenced object is undefined in HDF5).
     ///

--- a/src/error.rs
+++ b/src/error.rs
@@ -273,7 +273,7 @@ pub enum FormatError {
         /// Second operand (typically the length/size).
         length: u64,
     },
-    /// A random-access byte source (see [`crate::source::FileSource`]) failed to
+    /// A random-access byte source failed to
     /// supply the requested bytes. The string carries a backend-specific reason
     /// (e.g. an underlying `std::io::Error` rendered to text), so this stays
     /// `no_std`/`alloc`-friendly and free of an `std::io` dependency.

--- a/src/mat/builder.rs
+++ b/src/mat/builder.rs
@@ -505,7 +505,7 @@ impl MatBuilder {
         Ok(self)
     }
 
-    /// Write a complex `f32` array. See [`write_complex_f64`] for empty-input
+    /// Write a complex `f32` array. See [`write_complex_f64`](Self::write_complex_f64) for empty-input
     /// and compression semantics.
     pub fn write_complex_f32(
         &mut self,
@@ -1320,7 +1320,7 @@ impl<'a> StructWriter<'a> {
     pub fn options(&self) -> &Options {
         self.mb.options()
     }
-    /// Convenience: configured [`StringClass`].
+    /// Convenience: configured [`StringClass`](crate::mat::options::StringClass).
     #[inline]
     pub fn string_class(&self) -> crate::mat::options::StringClass {
         self.options().string_class

--- a/src/mat/identifier.rs
+++ b/src/mat/identifier.rs
@@ -112,7 +112,7 @@ const MAX_DEDUPE_ATTEMPTS: usize = 1_000_000;
 /// Append a numeric suffix to `candidate` until it is not present in `used`.
 /// The suffix is `_1`, `_2`, ...; the base is truncated as needed to keep the
 /// total length under [`MATLAB_NAME_MAX`]. Panics after
-/// [`MAX_DEDUPE_ATTEMPTS`] collisions.
+/// `MAX_DEDUPE_ATTEMPTS` collisions.
 pub fn dedupe_name(mut candidate: String, used: &HashSet<String>) -> String {
     if !used.contains(&candidate) {
         return candidate;

--- a/src/mat/matrix.rs
+++ b/src/mat/matrix.rs
@@ -14,8 +14,8 @@
 //!
 //! # Why three sentinel constants
 //!
-//! [`MATRIX_SENTINEL`], [`MATRIX_COMPLEX64_SENTINEL`], and
-//! [`MATRIX_COMPLEX32_SENTINEL`] are not redundant. The element class for a
+//! `MATRIX_SENTINEL`, `MATRIX_COMPLEX64_SENTINEL`, and
+//! `MATRIX_COMPLEX32_SENTINEL` are not redundant. The element class for a
 //! non-empty `Matrix<T>` can always be recovered from the serialized data
 //! (the inner `Vec<T>` carries enough type information through the seq
 //! unification path), so a single sentinel would suffice for the common

--- a/src/ndarray_support.rs
+++ b/src/ndarray_support.rs
@@ -47,7 +47,7 @@ use crate::type_builders::DatasetBuilder;
 impl Dataset<'_> {
     /// Read the dataset into a statically-ranked [`ndarray::Array`].
     ///
-    /// The dimensionality `D` (e.g. [`ndarray::Ix2`]) is usually inferred from
+    /// The dimensionality `D` (e.g. [`ndarray::Ix2`](tyalias@ndarray::Ix2)) is usually inferred from
     /// the binding, so a call site reads as `let m: Array2<f64> =
     /// ds.read_array()?;`.
     ///

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -285,7 +285,7 @@ impl File {
     ///
     /// This lets a host read a file larger than its address space — the original
     /// motivation being 32-bit targets reading multi-gigabyte files (issue #27).
-    /// Metadata and dataset chunks are read through a [`ReadSeekSource`], so peak
+    /// Metadata and dataset chunks are read through a `ReadSeekSource`, so peak
     /// memory stays close to one chunk plus the metadata being parsed.
     ///
     /// Current limits (the buffered [`File::open`] has none of these): only
@@ -675,7 +675,7 @@ impl File {
     /// file the length reported by its source, for an in-memory file the length
     /// of its buffer. It includes any userblock prefix and trailing bytes, so it
     /// may exceed the superblock's logical end-of-file address; compare against
-    /// [`Superblock::eof_address`](crate::superblock::Superblock) (reachable via
+    /// `Superblock::eof_address` (reachable via
     /// [`File::superblock`]) to detect appended or unaccounted tail bytes.
     pub fn file_size(&self) -> u64 {
         self.source().len()

--- a/src/repack.rs
+++ b/src/repack.rs
@@ -135,7 +135,8 @@ impl RepackOptions {
 /// reading the source or writing the destination partway through can leave a
 /// partial `dst` (remove it and retry).
 ///
-/// See the [module documentation](self) for the exact fidelity contract.
+/// See [`Error::RepackUnsupported`] for the objects that cannot be reproduced
+/// faithfully.
 pub fn repack<P: AsRef<Path>, Q: AsRef<Path>>(
     src: P,
     dst: Q,

--- a/src/source.rs
+++ b/src/source.rs
@@ -91,7 +91,7 @@ pub const DEFAULT_METADATA_CACHE_MAX_ENTRY_BYTES: usize = 64 * 1024;
 /// This is the `hdf5-pure` counterpart to the memory-budget portion of HDF5's
 /// `H5Pset_mdc_config`: it bounds the bytes retained for parsed metadata reads
 /// while a file is opened through [`crate::File::open_streaming_with_options`].
-/// Raw dataset payload reads use [`FileSource::read_exact_at`] and are not
+/// Raw dataset payload reads use `FileSource::read_exact_at` and are not
 /// admitted to this cache.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MetadataCacheConfig {
@@ -103,8 +103,8 @@ impl MetadataCacheConfig {
     /// Create a metadata cache with the given total byte budget.
     ///
     /// Individual cached reads are capped at
-    /// [`DEFAULT_METADATA_CACHE_MAX_ENTRY_BYTES`] by default so one large heap
-    /// or index block cannot monopolize the cache. Use
+    /// `DEFAULT_METADATA_CACHE_MAX_ENTRY_BYTES` (64 KiB) by default so one large
+    /// heap or index block cannot monopolize the cache. Use
     /// [`with_max_entry_bytes`](Self::with_max_entry_bytes) to change that.
     pub const fn new(max_bytes: usize) -> Self {
         let max_entry_bytes = if max_bytes < DEFAULT_METADATA_CACHE_MAX_ENTRY_BYTES {

--- a/src/swmr_writer.rs
+++ b/src/swmr_writer.rs
@@ -141,7 +141,7 @@ impl SwmrWriter {
     /// on Windows, where locks are mandatory, it would block readers outright.
     /// The writer instead marks the file with the superblock SWMR flag while
     /// active; recover a file left flagged by a crashed writer with
-    /// [`clear_swmr_flag`](Self::clear_swmr_flag). See the [module docs](self).
+    /// [`clear_swmr_flag`](Self::clear_swmr_flag).
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
         let mut handle = OpenOptions::new()
             .read(true)

--- a/src/type_builders.rs
+++ b/src/type_builders.rs
@@ -1301,9 +1301,9 @@ impl DatasetBuilder {
     /// passing `values` in row-major order).
     ///
     /// Empty strings become zero-length heap objects (reading back as `""`).
-    /// For full fidelity over null-vs-empty elements, embedded NULs, non-UTF-8
-    /// payloads, or a specific charset/padding, use
-    /// [`with_vlen_string_elements`](Self::with_vlen_string_elements).
+    /// This convenience method cannot distinguish a null element from an empty
+    /// one, nor carry embedded NULs, non-UTF-8 payloads, or a specific
+    /// charset/padding.
     pub fn with_vlen_strings(&mut self, values: &[&str]) -> &mut Self {
         let datatype = make_vlen_string_type(CharacterSet::Utf8);
         let elements: Vec<VlStringElement> = values


### PR DESCRIPTION
## Summary

Fixes the crate's pre-existing rustdoc `-D warnings` debt and the underlying reason docs.rs wasn't showing the whole API. Independent of the AppendWriter work in #153.

Running `RUSTDOCFLAGS="-D warnings" cargo doc` surfaced 17 broken/private intra-doc links across the public API. The root cause is structural: nearly every module in `src/lib.rs` is `pub(crate)`, so `pub` items and the module-level `//!` docs inside them are *private for documentation purposes*. Any public method that linked to `[module docs](self)` or to one of those items produced a broken link.

## Link fixes

- **Re-point to a public item** where one exists: the in-place-edit "requirements" pointer now targets [`Error::EditUnsupported`] (which actually enumerates the unsupported targets) and the repack "fidelity contract" pointer targets [`Error::RepackUnsupported`].
- **Un-link to inline code** where there is no public target: `FileSource::read_exact_at`, `ReadSeekSource`, `Superblock::eof_address` (`Superblock` has no public path — `pub struct` in a `pub(crate)` module), `DEFAULT_METADATA_CACHE_MAX_ENTRY_BYTES`, `MAX_DEDUPE_ATTEMPTS`, and the `mat::matrix` sentinel constants.
- **Fix genuinely broken links**: `write_complex_f64` → `Self::write_complex_f64`, `StringClass` → its full path, and disambiguate `ndarray::Ix2` (a function *and* a type alias) with `tyalias@`.

## Doc-accuracy fix

`with_vlen_strings` told readers to use `with_vlen_string_elements` for full-fidelity variable-length strings, but that method **and** `VlStringElement` are `pub(crate)` and cannot be called from outside the crate. The doc now states the limitation honestly. (Making those two public would restore the advertised capability — happy to do that separately if wanted.)

## docs.rs now publishes the full API

There was no `[package.metadata.docs.rs]`, so docs.rs built with **default features only** — the `ndarray`, `serde` (`mat`), `zfp`, `provenance`, and `parallel` public API was invisible on docs.rs, and its cross-references rendered as dead links. Added metadata documenting the full public surface (the test-only `matio-crosscheck` feature is deliberately excluded).

## Regression gate

There was no doc gate in CI. Added a `Rustdoc (deny warnings)` step to the `lint` job using the same feature set docs.rs publishes, so this debt cannot silently return.

## Scope note

`no_std` / default-feature doc builds cannot be made link-clean: the crate-root overview links the std-gated high-level API (`File`, `EditSession`, `DatasetBuilder`, `H5Element`, ...) by design. The gate therefore targets the full public-feature build, which matches what actually publishes.

## Verification

- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` clean under both `--all-features` and the exact CI-gate feature set.
- Doc-tests pass; `cargo fmt --check` clean.
