### PR TITLE
Add owned, cacheable object handles (#148, phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Breaking
+
+- **Breaking:** `Dataset`, `Group`, and `Object` are now owned handles with no `<'f>` lifetime — `File::dataset`/`group`/`root` hand back handles that share ownership of the open file (internally `Arc`), so a handle can be stored in a struct, cached, sent across threads, and outlive the `File` value it came from, and `File` is now cheaply cloneable. Code that never named the handle lifetime is unaffected; code that wrote `Dataset<'_>` should drop the lifetime, and `File::refresh` now returns `Error::HandlesOutstanding` when a handle or `File` clone is still alive instead of enforcing it at compile time ([#148](https://github.com/stephenberry/hdf5-pure/issues/148)).
+
 ### Added
 
 - `EditSession::append_inplace` grows an existing **chunked, unlimited, Extensible-Array dataset** in place at amortized `O(1)` cost — immediate and crash-atomic, needing no `commit` — and can be interleaved with the session's staged group/dataset/attribute/delete edits on one open file, with no reopening between the fast appends and the tree edits. Unfiltered datasets accept any-length appends, filtered datasets whole chunks only; a userblock or pre-v2 file, an unallocated or non-Extensible-Array index, or a multi-hard-link dataset is refused with `Error::AppendInPlaceUnsupported` (use `append_dataset` instead) ([#146](https://github.com/stephenberry/hdf5-pure/issues/146)).

--- a/docs/guide/swmr.md
+++ b/docs/guide/swmr.md
@@ -77,7 +77,7 @@ let ds = file.dataset("log").unwrap();
 println!("now {} rows", ds.shape().unwrap()[0]);
 ```
 
-`refresh()` is the SWMR reader's refresh primitive, analogous to the C library's `H5Drefresh` and h5py's `Dataset.refresh()`. After it returns, newly fetched `Dataset` and `Group` handles observe the appended chunks and extended dimensions. Existing handles borrow `&self`, so they must be dropped before calling `refresh()`; re-fetch them afterward, as shown above. See [reading](reading.md) for the dataset access APIs used here.
+`refresh()` is the SWMR reader's refresh primitive, analogous to the C library's `H5Drefresh` and h5py's `Dataset.refresh()`. After it returns, newly fetched `Dataset` and `Group` handles observe the appended chunks and extended dimensions. Handles are owned and keep the file open, so `refresh()` needs exclusive access: drop any outstanding `Dataset`/`Group` handle (and any `File` clone) before calling it — otherwise it returns `Error::HandlesOutstanding` — then re-fetch the handles afterward, as shown above. See [reading](reading.md) for the dataset access APIs used here.
 
 !!! note "Refresh cost"
     Each `refresh()` re-reads the entire file from disk (`O(file size)`) and re-validates the superblock checksum; a transient parse failure from catching a writer mid-flush is retried a bounded number of times. When following a large, steadily growing log, budget refresh frequency accordingly. `refresh()` returns an error if the file was not opened with `File::open_swmr` (the in-memory `File::from_bytes` path cannot refresh).

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "hdf5-pure"
-version = "0.21.0"
+version = "0.21.2"
 dependencies = [
  "byteorder",
  "flate2",

--- a/fuzz/fuzz_targets/parse_file.rs
+++ b/fuzz/fuzz_targets/parse_file.rs
@@ -14,7 +14,7 @@ fuzz_target!(|data: &[u8]| {
     }
 });
 
-fn exercise_group(file: &File, group: &Group<'_>, path: &str, depth: usize) {
+fn exercise_group(file: &File, group: &Group, path: &str, depth: usize) {
     let _ = group.attrs();
 
     if let Ok(datasets) = group.datasets() {
@@ -44,7 +44,7 @@ fn exercise_group(file: &File, group: &Group<'_>, path: &str, depth: usize) {
     }
 }
 
-fn exercise_dataset(dataset: &Dataset<'_>) {
+fn exercise_dataset(dataset: &Dataset) {
     let shape = dataset.shape();
     let dtype = dataset.dtype();
     let _ = dataset.attrs();

--- a/fuzz/fuzz_targets/roundtrip_simple.rs
+++ b/fuzz/fuzz_targets/roundtrip_simple.rs
@@ -76,7 +76,7 @@ impl ExpectedDataset {
         }
     }
 
-    fn assert_readback(&self, dataset: &hdf5_pure::Dataset<'_>) {
+    fn assert_readback(&self, dataset: &hdf5_pure::Dataset) {
         match self {
             Self::I32(expected) => {
                 assert_eq!(dataset.read_i32().expect("read i32"), *expected);

--- a/fuzz/fuzz_targets/streaming_differential.rs
+++ b/fuzz/fuzz_targets/streaming_differential.rs
@@ -54,8 +54,8 @@ fn assert_same_file_metadata(buffered: &File, streaming: &File) {
 fn assert_same_group(
     buffered_file: &File,
     streaming_file: &File,
-    buffered_group: &Group<'_>,
-    streaming_group: &Group<'_>,
+    buffered_group: &Group,
+    streaming_group: &Group,
     path: &str,
     depth: usize,
 ) {
@@ -112,7 +112,7 @@ fn assert_same_group(
     }
 }
 
-fn assert_same_dataset(buffered: &Dataset<'_>, streaming: &Dataset<'_>) {
+fn assert_same_dataset(buffered: &Dataset, streaming: &Dataset) {
     assert_same_result(buffered.shape(), streaming.shape());
     assert_same_result(buffered.dtype(), streaming.dtype());
     assert_same_attrs(buffered.attrs(), streaming.attrs());

--- a/src/element.rs
+++ b/src/element.rs
@@ -63,7 +63,7 @@ mod sealed {
 pub trait H5Element: sealed::Sealed + Copy {
     /// Read every element of `ds` as `Self`, in row-major order.
     #[doc(hidden)]
-    fn read_from(ds: &Dataset<'_>) -> Result<Vec<Self>, Error>;
+    fn read_from(ds: &Dataset) -> Result<Vec<Self>, Error>;
 
     /// Set `builder`'s data and datatype from a flat row-major slice.
     #[doc(hidden)]
@@ -90,7 +90,7 @@ macro_rules! impl_h5_element {
     ($ty:ty, $read:ident, $write:ident, $append:ident, |$raw:ident, $dt:ident| $convert:expr) => {
         impl sealed::Sealed for $ty {}
         impl H5Element for $ty {
-            fn read_from(ds: &Dataset<'_>) -> Result<Vec<Self>, Error> {
+            fn read_from(ds: &Dataset) -> Result<Vec<Self>, Error> {
                 ds.$read()
             }
             fn write_into(builder: &mut DatasetBuilder, data: &[Self]) {
@@ -209,7 +209,7 @@ impl DatasetBuilder {
     }
 }
 
-impl Dataset<'_> {
+impl Dataset {
     /// Read the dataset into a `Vec<T>` for any supported scalar type, in
     /// row-major order.
     ///

--- a/src/error.rs
+++ b/src/error.rs
@@ -675,6 +675,11 @@ pub enum Error {
     /// A SWMR operation (e.g. [`crate::File::refresh`]) was requested on a file
     /// that was not opened for SWMR reading via `File::open_swmr`.
     SwmrUnsupported,
+    /// An operation that needs exclusive access to the open file (e.g.
+    /// [`crate::File::refresh`]) was requested while owned [`crate::Dataset`] /
+    /// [`crate::Group`] handles, or a clone of the [`crate::File`], are still
+    /// alive. Drop them and retry.
+    HandlesOutstanding,
     /// The file or dataset is not a supported target for the SWMR append writer
     /// (e.g. a userblock or non-latest-format file, or a dataset that is
     /// filtered, not rank-1 with an unlimited dimension, or not
@@ -736,6 +741,10 @@ impl fmt::Display for Error {
             Error::SwmrUnsupported => write!(
                 f,
                 "refresh requires a file opened with File::open_swmr (live handle)"
+            ),
+            Error::HandlesOutstanding => write!(
+                f,
+                "operation needs exclusive file access: drop outstanding Dataset/Group handles and File clones first"
             ),
             Error::SwmrAppendUnsupported(reason) => {
                 write!(f, "unsupported SWMR append target: {reason}")

--- a/src/mat/de/mcos_reader.rs
+++ b/src/mat/de/mcos_reader.rs
@@ -106,8 +106,8 @@ const FIELD_TYPE_INLINE: u32 = 2;
 /// Holds the dereferenced MCOS cell array (the property-value heap) and the
 /// parsed [`FileWrapper`] metadata. Opaque parent datasets index into it by
 /// object id. Parsed once per file and shared across every opaque dataset read.
-pub(crate) struct Mcos<'f> {
-    cells: Vec<Object<'f>>,
+pub(crate) struct Mcos {
+    cells: Vec<Object>,
     wrapper: FileWrapper,
 }
 
@@ -179,10 +179,10 @@ pub(crate) enum PropValue {
     Name(String),
 }
 
-impl<'f> Mcos<'f> {
+impl Mcos {
     /// Parse the `#subsystem#/MCOS` store, or `Ok(None)` if the file has no
     /// `#subsystem#` group (a file with no opaque objects).
-    pub(crate) fn parse(file: &'f File) -> Result<Option<Self>, MatError> {
+    pub(crate) fn parse(file: &File) -> Result<Option<Self>, MatError> {
         let subsystem = match file.group("#subsystem#") {
             Ok(g) => g,
             // No subsystem group: the file holds no opaque objects.
@@ -272,7 +272,7 @@ impl<'f> Mcos<'f> {
     }
 
     /// The property-heap cell for a 0-based `field_type == 1` heap value.
-    pub(crate) fn heap_object(&self, value: u32) -> Result<&Object<'f>, MatError> {
+    pub(crate) fn heap_object(&self, value: u32) -> Result<&Object, MatError> {
         let idx = MCOS_RESERVED_CELL_PREFIX
             .checked_add(value.to_usize()?)
             .ok_or_else(|| MatError::Custom("MCOS heap index overflow".into()))?;
@@ -321,7 +321,7 @@ impl<'f> Mcos<'f> {
     /// self-describing `uint64` blob in the property heap rather than a set of
     /// named properties, so it is read directly instead of through the property
     /// tables.
-    pub(crate) fn decode_string(&self, ds: &Dataset<'_>) -> Result<MatValue, MatError> {
+    pub(crate) fn decode_string(&self, ds: &Dataset) -> Result<MatValue, MatError> {
         let metadata = ds.read_u32().map_err(MatError::Hdf5)?;
         let object_ids = parse_opaque_metadata(&metadata)?.object_ids;
 

--- a/src/mat/de/reader.rs
+++ b/src/mat/de/reader.rs
@@ -40,8 +40,8 @@ pub(crate) fn read_file(bytes: &[u8]) -> Result<Vec<(String, MatValue)>, MatErro
 /// `in_heap` marks reads that descend from an MCOS opaque object's property
 /// heap (see [`read_dataset`]); the top level passes `false`.
 fn read_group(
-    group: &Group<'_>,
-    mcos: Option<&Mcos<'_>>,
+    group: &Group,
+    mcos: Option<&Mcos>,
     in_heap: bool,
     depth: usize,
 ) -> Result<Vec<(String, MatValue)>, MatError> {
@@ -74,8 +74,8 @@ fn read_group(
 }
 
 fn read_group_as_value(
-    group: &Group<'_>,
-    mcos: Option<&Mcos<'_>>,
+    group: &Group,
+    mcos: Option<&Mcos>,
     in_heap: bool,
     depth: usize,
 ) -> Result<MatValue, MatError> {
@@ -114,7 +114,7 @@ fn read_group_as_value(
 /// array (and then fail trying to dereference non-references). A *cell* field of
 /// a scalar struct is a reference dataset too, but carries `MATLAB_class="cell"`,
 /// so the class-attribute check keeps that case a scalar struct.
-fn is_struct_array(group: &Group<'_>) -> Result<bool, MatError> {
+fn is_struct_array(group: &Group) -> Result<bool, MatError> {
     // A nested-struct field of a scalar struct is stored as a subgroup, so any
     // subgroup means this is a scalar struct, not a struct array.
     if !group.groups().map_err(MatError::Hdf5)?.is_empty() {
@@ -153,8 +153,8 @@ fn is_struct_array(group: &Group<'_>) -> Result<bool, MatError> {
 /// a row-major array-of-structs, matching how numeric matrices present their
 /// elements.
 fn read_struct_array(
-    group: &Group<'_>,
-    mcos: Option<&Mcos<'_>>,
+    group: &Group,
+    mcos: Option<&Mcos>,
     in_heap: bool,
     depth: usize,
 ) -> Result<MatValue, MatError> {
@@ -245,8 +245,8 @@ fn read_struct_array(
 /// empty defaults — there MATLAB genuinely omits a property for an empty value,
 /// whereas a valid enumeration never omits these datasets.
 fn try_decode_enum_instance(
-    group: &Group<'_>,
-    mcos: &Mcos<'_>,
+    group: &Group,
+    mcos: &Mcos,
     depth: usize,
 ) -> Result<Option<MatValue>, MatError> {
     // The tag dataset's absence means an ordinary group, so a failed lookup is
@@ -313,7 +313,7 @@ fn enum_member_names(pool: &[String], indices: &[usize]) -> Result<Vec<String>, 
 /// Open a required enumeration-metadata dataset. The magic tag has already
 /// matched, so a missing dataset is a corrupt enumeration; map the HDF5 lookup
 /// error to a clear message rather than a bare "link not found".
-fn enum_dataset<'f>(group: &Group<'f>, field: &str) -> Result<Dataset<'f>, MatError> {
+fn enum_dataset(group: &Group, field: &str) -> Result<Dataset, MatError> {
     group.dataset(field).map_err(|e| {
         MatError::Custom(format!(
             "malformed enum instance: cannot read required dataset {field:?} ({e})"
@@ -323,7 +323,7 @@ fn enum_dataset<'f>(group: &Group<'f>, field: &str) -> Result<Dataset<'f>, MatEr
 
 /// Read an enumeration metadata field as a single `uint32` (its first element,
 /// or `0` if the dataset is empty).
-fn read_enum_scalar_u32(group: &Group<'_>, field: &str) -> Result<u32, MatError> {
+fn read_enum_scalar_u32(group: &Group, field: &str) -> Result<u32, MatError> {
     let ds = enum_dataset(group, field)?;
     Ok(ds
         .read_u32()
@@ -335,14 +335,14 @@ fn read_enum_scalar_u32(group: &Group<'_>, field: &str) -> Result<u32, MatError>
 
 /// Read an enumeration metadata field as a flat `uint32` vector. The member-name
 /// pool is a `1×N` row, so its storage order is its presentation order.
-fn read_enum_u32_vec(group: &Group<'_>, field: &str) -> Result<Vec<u32>, MatError> {
+fn read_enum_u32_vec(group: &Group, field: &str) -> Result<Vec<u32>, MatError> {
     let ds = enum_dataset(group, field)?;
     ds.read_u32().map_err(MatError::Hdf5)
 }
 
 /// Read the `ValueIndices` array as a flat `Vec<usize>` in the crate's row-major
 /// presentation order.
-fn read_enum_indices(group: &Group<'_>, depth: usize) -> Result<Vec<usize>, MatError> {
+fn read_enum_indices(group: &Group, depth: usize) -> Result<Vec<usize>, MatError> {
     let ds = enum_dataset(group, "ValueIndices")?;
     // Reject a non-`uint32` index array up front with a dtype-specific message
     // (mirrors the saveobj-payload datatype guard), so corruption surfaces
@@ -381,7 +381,7 @@ fn enum_indices_to_usize(value: &MatValue) -> Result<Vec<usize>, MatError> {
 
 /// The group's `MATLAB_class` attribute, unless it is the generic `"struct"`
 /// (an in-heap enum cell carries no real class name there).
-fn enum_class_from_attr(group: &Group<'_>) -> Option<String> {
+fn enum_class_from_attr(group: &Group) -> Option<String> {
     let attrs = group.attrs().ok()?;
     let class = mcos_reader::raw_matlab_class(&attrs)?;
     (class != "struct").then_some(class)
@@ -400,8 +400,8 @@ fn enum_class_from_attr(group: &Group<'_>) -> Option<String> {
 /// false`) is never treated this way, so ordinary `uint32` data cannot be
 /// misread as a reference.
 fn read_dataset(
-    ds: &Dataset<'_>,
-    mcos: Option<&Mcos<'_>>,
+    ds: &Dataset,
+    mcos: Option<&Mcos>,
     in_heap: bool,
     depth: usize,
 ) -> Result<MatValue, MatError> {
@@ -511,8 +511,8 @@ fn read_dataset(
 /// into a flat [`MatValue::Cell`], matching the column-vector layout the
 /// serializer writes (the deserializer flattens a cell to a sequence).
 fn read_cell(
-    ds: &Dataset<'_>,
-    mcos: Option<&Mcos<'_>>,
+    ds: &Dataset,
+    mcos: Option<&Mcos>,
     in_heap: bool,
     depth: usize,
 ) -> Result<MatValue, MatError> {
@@ -527,8 +527,8 @@ fn read_cell(
 /// Decode a dereferenced object (a `#refs#`/`#subsystem#` dataset or struct
 /// group) into a `MatValue`, dispatching on whether it is a dataset or group.
 fn read_object(
-    obj: &Object<'_>,
-    mcos: Option<&Mcos<'_>>,
+    obj: &Object,
+    mcos: Option<&Mcos>,
     in_heap: bool,
     depth: usize,
 ) -> Result<MatValue, MatError> {
@@ -546,10 +546,10 @@ fn read_object(
 /// tables — to a typed value (`datetime`, `duration`, `categorical`) or a
 /// lossless [`MatValue::Opaque`] for classes without a dedicated decoder.
 fn decode_opaque(
-    ds: &Dataset<'_>,
+    ds: &Dataset,
     attrs: &HashMap<String, AttrValue>,
     decode: i64,
-    mcos: Option<&Mcos<'_>>,
+    mcos: Option<&Mcos>,
     depth: usize,
 ) -> Result<MatValue, MatError> {
     let class = mcos_reader::raw_matlab_class(attrs).ok_or_else(|| {
@@ -591,11 +591,7 @@ fn decode_opaque(
 /// Decode one or more MCOS object ids (from an opaque parent dataset or an
 /// embedded heap reference) into a value. A single id is the object itself; a
 /// genuine object array becomes a cell of the decoded objects.
-fn decode_object_ids(
-    mcos: &Mcos<'_>,
-    object_ids: &[u32],
-    depth: usize,
-) -> Result<MatValue, MatError> {
+fn decode_object_ids(mcos: &Mcos, object_ids: &[u32], depth: usize) -> Result<MatValue, MatError> {
     let mut values = Vec::with_capacity(object_ids.len());
     for &object_id in object_ids {
         values.push(decode_opaque_object(mcos, object_id, depth)?);
@@ -610,11 +606,7 @@ fn decode_object_ids(
 /// Assemble one MCOS object's resolved properties (reading heap cells through
 /// the full read path so nested objects/cells decode too) and finish it via a
 /// typed decoder or the lossless `Opaque` fallback.
-fn decode_opaque_object(
-    mcos: &Mcos<'_>,
-    object_id: u32,
-    depth: usize,
-) -> Result<MatValue, MatError> {
+fn decode_opaque_object(mcos: &Mcos, object_id: u32, depth: usize) -> Result<MatValue, MatError> {
     if depth > MAX_NESTING_DEPTH {
         return Err(MatError::Format(FormatError::NestingDepthExceeded));
     }
@@ -740,7 +732,7 @@ fn is_complex_dtype(dtype: &DType) -> bool {
 // Numeric reading
 // ---------------------------------------------------------------------------
 
-fn read_numeric(ds: &Dataset<'_>, shape: &[u64], class: MatClass) -> Result<MatValue, MatError> {
+fn read_numeric(ds: &Dataset, shape: &[u64], class: MatClass) -> Result<MatValue, MatError> {
     let (_, _, total) = shape_decomposition(shape)?;
 
     // For a single-element dataset we emit a Scalar of the appropriate class.
@@ -823,7 +815,7 @@ fn shape_decomposition(shape: &[u64]) -> Result<(usize, usize, usize), MatError>
     })
 }
 
-fn read_all_elements(ds: &Dataset<'_>, class: MatClass) -> Result<NumVec, MatError> {
+fn read_all_elements(ds: &Dataset, class: MatClass) -> Result<NumVec, MatError> {
     Ok(match class {
         MatClass::Double => NumVec::F64(ds.read_f64().map_err(MatError::Hdf5)?),
         MatClass::Single => NumVec::F32(ds.read_f32().map_err(MatError::Hdf5)?),
@@ -843,7 +835,7 @@ fn read_all_elements(ds: &Dataset<'_>, class: MatClass) -> Result<NumVec, MatErr
     })
 }
 
-fn read_scalar(ds: &Dataset<'_>, class: MatClass) -> Result<ScalarNum, MatError> {
+fn read_scalar(ds: &Dataset, class: MatClass) -> Result<ScalarNum, MatError> {
     Ok(match class {
         MatClass::Double => ScalarNum::F64(ds.read_f64().map_err(MatError::Hdf5)?[0]),
         MatClass::Single => ScalarNum::F32(ds.read_f32().map_err(MatError::Hdf5)?[0]),
@@ -896,7 +888,7 @@ fn transpose_col_major_to_row_major(
 // Complex reading
 // ---------------------------------------------------------------------------
 
-fn read_complex(ds: &Dataset<'_>, shape: &[u64], class: MatClass) -> Result<MatValue, MatError> {
+fn read_complex(ds: &Dataset, shape: &[u64], class: MatClass) -> Result<MatValue, MatError> {
     let (rows, cols, total) = shape_decomposition(shape)?;
     let bytes = ds.read_u8().map_err(MatError::Hdf5)?;
 

--- a/src/ndarray_support.rs
+++ b/src/ndarray_support.rs
@@ -44,7 +44,7 @@ use crate::error::Error;
 use crate::reader::Dataset;
 use crate::type_builders::DatasetBuilder;
 
-impl Dataset<'_> {
+impl Dataset {
     /// Read the dataset into a statically-ranked [`ndarray::Array`].
     ///
     /// The dimensionality `D` (e.g. [`ndarray::Ix2`](tyalias@ndarray::Ix2)) is usually inferred from

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 use std::io::{Read, Seek, SeekFrom};
+use std::sync::Arc;
 
 use crate::attribute::{extract_attributes_full, extract_attributes_full_from_source};
 use crate::chunk_cache::{ChunkCache, ChunkCacheConfig, ChunkCacheStats};
@@ -242,7 +243,7 @@ pub fn is_hdf5_bytes(data: &[u8]) -> bool {
 }
 
 /// An open HDF5 file for reading.
-pub struct File {
+struct FileInner {
     backend: Backend,
     superblock: Superblock,
     /// Byte offset to add to all relative addresses (= original base_address).
@@ -257,7 +258,7 @@ pub struct File {
     access_options: FileAccessOptions,
 }
 
-impl File {
+impl FileInner {
     /// Open an HDF5 file from a filesystem path.
     ///
     /// Reads the file into memory once. To follow a file that a concurrent
@@ -430,7 +431,7 @@ impl File {
         handle: Option<std::fs::File>,
         access_options: FileAccessOptions,
     ) -> Self {
-        let mut file = File {
+        let mut file = FileInner {
             backend,
             superblock,
             addr_offset,
@@ -524,15 +525,6 @@ impl File {
         Err(last_err.expect("refresh retried at least once before failing"))
     }
 
-    /// Returns a handle to the root group.
-    pub fn root(&self) -> Group<'_> {
-        Group {
-            file: self,
-            // root_group_address was normalized to absolute in from_bytes()
-            address: self.superblock.root_group_address,
-        }
-    }
-
     /// Resolve a path to an object-header address, dispatching on the backend.
     fn resolve_path(&self, path: &str) -> Result<u64, Error> {
         Ok(match &self.backend {
@@ -540,51 +532,6 @@ impl File {
             Backend::Streaming(s) => {
                 group_v2::resolve_path_any_from_source(s.as_ref(), &self.superblock, path)?
             }
-        })
-    }
-
-    /// Resolve a path and return a `Dataset` handle.
-    ///
-    /// The dataset uses the file-wide chunk-cache default (configured with
-    /// [`FileAccessOptions::with_chunk_cache`]). To override the cache for this
-    /// one dataset, use [`dataset_with_options`](Self::dataset_with_options).
-    pub fn dataset(&self, path: &str) -> Result<Dataset<'_>, Error> {
-        self.dataset_with_options(path, DatasetAccessOptions::new())
-    }
-
-    /// Resolve a path and return a `Dataset` handle, applying per-dataset
-    /// [`DatasetAccessOptions`] that override file-wide access defaults.
-    ///
-    /// This is the dataset-open-with-access-property-list path (HDF5's DAPL):
-    /// the options' chunk cache corresponds to `H5Pset_chunk_cache` and takes
-    /// precedence, for this dataset only, over the `H5Pset_cache`-style
-    /// file-wide default.
-    pub fn dataset_with_options(
-        &self,
-        path: &str,
-        options: DatasetAccessOptions,
-    ) -> Result<Dataset<'_>, Error> {
-        let addr = self.resolve_path(path)?;
-        let hdr = self.parse_header(addr)?;
-        if !has_message(&hdr, MessageType::DataLayout) {
-            return Err(Error::NotADataset(path.to_string()));
-        }
-        let chunk_cache = options.resolved_chunk_cache(self.access_options.chunk_cache);
-        Ok(Dataset {
-            file: self,
-            address: addr,
-            header: hdr,
-            chunk_cache: ChunkCache::with_config(chunk_cache),
-            chunk_cache_config: chunk_cache,
-        })
-    }
-
-    /// Resolve a path and return a `Group` handle.
-    pub fn group(&self, path: &str) -> Result<Group<'_>, Error> {
-        let addr = self.resolve_path(path)?;
-        Ok(Group {
-            file: self,
-            address: addr,
         })
     }
 
@@ -711,21 +658,21 @@ impl File {
     /// MAT-file userblock is accounted for here. A null (`0`) or undefined
     /// (`HADDR_UNDEF`) address, or one whose object header is neither a dataset
     /// nor a group, yields [`FormatError::InvalidObjectReference`].
-    fn object_at_relative(&self, rel_addr: u64) -> Result<Object<'_>, Error> {
+    fn object_at_relative(file: &Arc<FileInner>, rel_addr: u64) -> Result<Object, Error> {
         // HADDR_UNDEF and the null address never name a real object. (Relative
         // address 0 is where the superblock sits, not an object header.)
         if rel_addr == u64::MAX || rel_addr == 0 {
             return Err(FormatError::InvalidObjectReference(rel_addr).into());
         }
         let abs = rel_addr
-            .checked_add(self.addr_offset)
+            .checked_add(file.addr_offset)
             .ok_or(FormatError::InvalidObjectReference(rel_addr))?;
-        let hdr = self.parse_header(abs)?;
+        let hdr = file.parse_header(abs)?;
         if has_message(&hdr, MessageType::DataLayout) {
             let chunk_cache =
-                DatasetAccessOptions::new().resolved_chunk_cache(self.access_options.chunk_cache);
+                DatasetAccessOptions::new().resolved_chunk_cache(file.access_options.chunk_cache);
             Ok(Object::Dataset(Box::new(Dataset {
-                file: self,
+                file: file.clone(),
                 address: abs,
                 header: hdr,
                 chunk_cache: ChunkCache::with_config(chunk_cache),
@@ -733,7 +680,7 @@ impl File {
             })))
         } else if is_group(&hdr) {
             Ok(Object::Group(Group {
-                file: self,
+                file: file.clone(),
                 address: abs,
             }))
         } else {
@@ -866,12 +813,248 @@ impl File {
     }
 }
 
-impl std::fmt::Debug for File {
+impl std::fmt::Debug for FileInner {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("File")
             .field("size", &self.source().len())
             .field("superblock_version", &self.superblock.version)
             .finish()
+    }
+}
+
+/// An open HDF5 file.
+///
+/// A `File` is an owned, cheaply cloneable handle to an open file: cloning it (or
+/// deriving a [`Dataset`]/[`Group`] from it) shares one underlying open file
+/// rather than re-reading it. Object handles returned by [`dataset`](Self::dataset),
+/// [`group`](Self::group), and [`root`](Self::root) are **owned** — they keep the
+/// file open for as long as they live and carry no borrow of the `File`, so they
+/// can be stored in a struct, cached, and moved across threads.
+#[derive(Clone)]
+pub struct File {
+    inner: Arc<FileInner>,
+}
+
+impl std::fmt::Debug for File {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(&*self.inner, f)
+    }
+}
+
+impl File {
+    /// Open an HDF5 file from a filesystem path.
+    ///
+    /// Reads the file into memory once. To follow a file that a concurrent
+    /// single writer is appending to (SWMR), use [`File::open_swmr`] instead.
+    /// To read a file larger than memory (e.g. on a 32-bit host) without
+    /// buffering it, use [`File::open_streaming`].
+    pub fn open<P: AsRef<std::path::Path>>(path: P) -> Result<Self, Error> {
+        Ok(File {
+            inner: Arc::new(FileInner::open(path)?),
+        })
+    }
+
+    /// Open an HDF5 file from a filesystem path with explicit access options.
+    pub fn open_with_options<P: AsRef<std::path::Path>>(
+        path: P,
+        options: FileAccessOptions,
+    ) -> Result<Self, Error> {
+        Ok(File {
+            inner: Arc::new(FileInner::open_with_options(path, options)?),
+        })
+    }
+
+    /// Open an HDF5 file for **streaming** reads, fetching regions on demand from
+    /// the file instead of buffering it whole.
+    ///
+    /// This lets a host read a file larger than its address space. Metadata and
+    /// dataset chunks are read through a `ReadSeekSource`, so peak memory stays
+    /// close to one chunk plus the metadata being parsed. Attribute reading and
+    /// v1 symbol-table groups on the resolved path are not yet supported on this
+    /// backend.
+    pub fn open_streaming<P: AsRef<std::path::Path>>(path: P) -> Result<Self, Error> {
+        Ok(File {
+            inner: Arc::new(FileInner::open_streaming(path)?),
+        })
+    }
+
+    /// Open an HDF5 file for streaming reads with explicit access options.
+    pub fn open_streaming_with_options<P: AsRef<std::path::Path>>(
+        path: P,
+        options: FileAccessOptions,
+    ) -> Result<Self, Error> {
+        Ok(File {
+            inner: Arc::new(FileInner::open_streaming_with_options(path, options)?),
+        })
+    }
+
+    /// Open an HDF5 file for SWMR (single-writer/multiple-reader) reading.
+    ///
+    /// Like [`File::open`], but retains a live handle to the file so that
+    /// [`File::refresh`] can re-read data appended by a concurrent writer.
+    pub fn open_swmr<P: AsRef<std::path::Path>>(path: P) -> Result<Self, Error> {
+        Ok(File {
+            inner: Arc::new(FileInner::open_swmr(path)?),
+        })
+    }
+
+    /// Open an HDF5 file for SWMR reading with explicit access options.
+    pub fn open_swmr_with_options<P: AsRef<std::path::Path>>(
+        path: P,
+        options: FileAccessOptions,
+    ) -> Result<Self, Error> {
+        Ok(File {
+            inner: Arc::new(FileInner::open_swmr_with_options(path, options)?),
+        })
+    }
+
+    /// Open an HDF5 file from an in-memory byte vector.
+    pub fn from_bytes(data: Vec<u8>) -> Result<Self, Error> {
+        Ok(File {
+            inner: Arc::new(FileInner::from_bytes(data)?),
+        })
+    }
+
+    /// Open an HDF5 file from an in-memory byte vector with explicit access options.
+    pub fn from_bytes_with_options(
+        data: Vec<u8>,
+        options: FileAccessOptions,
+    ) -> Result<Self, Error> {
+        Ok(File {
+            inner: Arc::new(FileInner::from_bytes_with_options(data, options)?),
+        })
+    }
+
+    /// Returns an owned handle to the root group.
+    pub fn root(&self) -> Group {
+        Group {
+            // root_group_address was normalized to absolute in from_bytes()
+            address: self.inner.superblock.root_group_address,
+            file: self.inner.clone(),
+        }
+    }
+
+    /// Resolve a path and return an owned [`Dataset`] handle.
+    ///
+    /// The dataset uses the file-wide chunk-cache default (configured with
+    /// [`FileAccessOptions::with_chunk_cache`]). To override the cache for this
+    /// one dataset, use [`dataset_with_options`](Self::dataset_with_options).
+    pub fn dataset(&self, path: &str) -> Result<Dataset, Error> {
+        self.dataset_with_options(path, DatasetAccessOptions::new())
+    }
+
+    /// Resolve a path and return an owned [`Dataset`] handle, applying per-dataset
+    /// [`DatasetAccessOptions`] that override file-wide access defaults.
+    ///
+    /// This is the dataset-open-with-access-property-list path (HDF5's DAPL):
+    /// the options' chunk cache corresponds to `H5Pset_chunk_cache` and takes
+    /// precedence, for this dataset only, over the `H5Pset_cache`-style
+    /// file-wide default.
+    pub fn dataset_with_options(
+        &self,
+        path: &str,
+        options: DatasetAccessOptions,
+    ) -> Result<Dataset, Error> {
+        let addr = self.inner.resolve_path(path)?;
+        let hdr = self.inner.parse_header(addr)?;
+        if !has_message(&hdr, MessageType::DataLayout) {
+            return Err(Error::NotADataset(path.to_string()));
+        }
+        let chunk_cache = options.resolved_chunk_cache(self.inner.access_options.chunk_cache);
+        Ok(Dataset {
+            file: self.inner.clone(),
+            address: addr,
+            header: hdr,
+            chunk_cache: ChunkCache::with_config(chunk_cache),
+            chunk_cache_config: chunk_cache,
+        })
+    }
+
+    /// Resolve a path and return an owned [`Group`] handle.
+    pub fn group(&self, path: &str) -> Result<Group, Error> {
+        let addr = self.inner.resolve_path(path)?;
+        Ok(Group {
+            file: self.inner.clone(),
+            address: addr,
+        })
+    }
+
+    /// Re-read the file from disk to pick up data appended by a concurrent
+    /// writer, then re-parse the superblock.
+    ///
+    /// This is the SWMR reader's refresh primitive. Returns
+    /// [`Error::SwmrUnsupported`] if the file was not opened with
+    /// [`File::open_swmr`], and [`Error::HandlesOutstanding`] if any owned
+    /// [`Dataset`]/[`Group`] handle (or a clone of this `File`) is still alive —
+    /// drop them before refreshing, then re-fetch them afterward, since they
+    /// observe the new bytes only when re-derived from the refreshed file.
+    pub fn refresh(&mut self) -> Result<(), Error> {
+        let inner = Arc::get_mut(&mut self.inner).ok_or(Error::HandlesOutstanding)?;
+        inner.refresh()
+    }
+
+    // --- delegating value getters (forward to the shared inner state) ---
+
+    /// Returns the raw file bytes for an in-memory file, or an empty slice for a
+    /// streaming file (which has no whole-file buffer).
+    pub fn as_bytes(&self) -> &[u8] {
+        self.inner.as_bytes()
+    }
+
+    /// Return the access options used when opening this file.
+    pub fn access_options(&self) -> FileAccessOptions {
+        self.inner.access_options()
+    }
+
+    /// Returns a reference to the parsed superblock.
+    pub fn superblock(&self) -> &Superblock {
+        self.inner.superblock()
+    }
+
+    /// The file-space management strategy this file records in its superblock
+    /// extension, or `None` if it records none.
+    pub fn file_space_strategy(&self) -> Option<FileSpaceStrategy> {
+        self.inner.file_space_strategy()
+    }
+
+    /// The full [`FileSpaceInfo`] recorded in this file's superblock extension,
+    /// if present and readable.
+    pub fn file_space_info(&self) -> Option<&FileSpaceInfo> {
+        self.inner.file_space_info()
+    }
+
+    /// The free regions a file persists on disk in its free-space managers, as
+    /// `(address, length)` pairs sorted by address.
+    pub fn persisted_free_space(&self) -> Vec<(u64, u64)> {
+        self.inner.persisted_free_space()
+    }
+
+    /// The size of the underlying file in bytes (the HDF5 `H5Fget_filesize`).
+    pub fn file_size(&self) -> u64 {
+        self.inner.file_size()
+    }
+
+    /// The minimum library version required to read this file, derived from its
+    /// superblock version (the *low bound* of HDF5's `H5Fget_libver_bounds`).
+    pub fn libver_bound(&self) -> LibVer {
+        self.inner.libver_bound()
+    }
+
+    /// A `FileSource` view over the backend, for the streaming-capable paths.
+    pub(crate) fn source(&self) -> SourceView<'_> {
+        self.inner.source()
+    }
+
+    /// The whole-file byte image when this file is buffered in memory; `None`
+    /// for a streaming file. Used by cross-file object copy.
+    pub(crate) fn in_memory_image(&self) -> Option<&[u8]> {
+        self.inner.in_memory_image()
+    }
+
+    /// The base address (superblock base address) added to every stored relative
+    /// address. Zero for a file with no userblock.
+    pub(crate) fn base_address(&self) -> u64 {
+        self.inner.base_address()
     }
 }
 
@@ -893,14 +1076,14 @@ impl std::fmt::Debug for File {
 /// keeps `Object` (and a `Vec<Object>`) compact without a size disparity. The
 /// `Box` derefs transparently, so `&obj_dataset` is usable wherever a
 /// `&Dataset` is expected.
-pub enum Object<'f> {
+pub enum Object {
     /// The reference points at a group's object header.
-    Group(Group<'f>),
+    Group(Group),
     /// The reference points at a dataset's object header.
-    Dataset(Box<Dataset<'f>>),
+    Dataset(Box<Dataset>),
 }
 
-impl std::fmt::Debug for Object<'_> {
+impl std::fmt::Debug for Object {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Object::Group(_) => f.write_str("Object::Group"),
@@ -913,13 +1096,13 @@ impl std::fmt::Debug for Object<'_> {
 // Group handle
 // ---------------------------------------------------------------------------
 
-/// A lightweight handle to an HDF5 group.
-pub struct Group<'f> {
-    file: &'f File,
+/// An owned handle to an HDF5 group.
+pub struct Group {
+    file: Arc<FileInner>,
     address: u64,
 }
 
-impl<'f> Group<'f> {
+impl Group {
     /// Address of this group's object header (base-adjusted, file-absolute).
     /// Used to resolve object references that point at this group.
     pub(crate) fn header_address(&self) -> u64 {
@@ -971,7 +1154,7 @@ impl<'f> Group<'f> {
     /// The dataset uses the file-wide chunk-cache default. To override the cache
     /// for this one dataset, use
     /// [`dataset_with_options`](Self::dataset_with_options).
-    pub fn dataset(&self, name: &str) -> Result<Dataset<'f>, Error> {
+    pub fn dataset(&self, name: &str) -> Result<Dataset, Error> {
         self.dataset_with_options(name, DatasetAccessOptions::new())
     }
 
@@ -982,7 +1165,7 @@ impl<'f> Group<'f> {
         &self,
         name: &str,
         options: DatasetAccessOptions,
-    ) -> Result<Dataset<'f>, Error> {
+    ) -> Result<Dataset, Error> {
         let entries = self.children()?;
         let entry = entries
             .iter()
@@ -994,7 +1177,7 @@ impl<'f> Group<'f> {
         }
         let chunk_cache = options.resolved_chunk_cache(self.file.access_options.chunk_cache);
         Ok(Dataset {
-            file: self.file,
+            file: self.file.clone(),
             address: entry.object_header_address,
             header: hdr,
             chunk_cache: ChunkCache::with_config(chunk_cache),
@@ -1003,14 +1186,14 @@ impl<'f> Group<'f> {
     }
 
     /// Get a subgroup within this group by name.
-    pub fn group(&self, name: &str) -> Result<Group<'f>, Error> {
+    pub fn group(&self, name: &str) -> Result<Group, Error> {
         let entries = self.children()?;
         let entry = entries
             .iter()
             .find(|e| e.name == name)
             .ok_or_else(|| Error::Format(FormatError::PathNotFound(name.to_string())))?;
         Ok(Group {
-            file: self.file,
+            file: self.file.clone(),
             address: entry.object_header_address,
         })
     }
@@ -1025,9 +1208,9 @@ impl<'f> Group<'f> {
 // Dataset handle
 // ---------------------------------------------------------------------------
 
-/// A lightweight handle to an HDF5 dataset.
-pub struct Dataset<'f> {
-    file: &'f File,
+/// An owned handle to an HDF5 dataset.
+pub struct Dataset {
+    file: Arc<FileInner>,
     /// Address of this dataset's object header (base-adjusted, file-absolute).
     /// Used to resolve object references that point at this dataset.
     address: u64,
@@ -1040,7 +1223,7 @@ pub struct Dataset<'f> {
     chunk_cache_config: ChunkCacheConfig,
 }
 
-impl<'f> std::fmt::Debug for Dataset<'f> {
+impl std::fmt::Debug for Dataset {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Dataset")
             .field("messages", &self.header.messages.len())
@@ -1048,7 +1231,7 @@ impl<'f> std::fmt::Debug for Dataset<'f> {
     }
 }
 
-impl<'f> Dataset<'f> {
+impl Dataset {
     /// Address of this dataset's object header (base-adjusted, file-absolute).
     /// Used to resolve object references that point at this dataset.
     pub(crate) fn header_address(&self) -> u64 {
@@ -1734,7 +1917,7 @@ impl<'f> Dataset<'f> {
     ///   object reference.
     /// - [`FormatError::InvalidObjectReference`] if an element is a null or
     ///   undefined reference, or does not point at a group or dataset.
-    pub fn dereference(&self) -> Result<Vec<Object<'f>>, Error> {
+    pub fn dereference(&self) -> Result<Vec<Object>, Error> {
         let dt = self.datatype()?;
         if !matches!(
             dt,
@@ -1773,7 +1956,7 @@ impl<'f> Dataset<'f> {
         let mut out = Vec::with_capacity(raw.len() / elem_size);
         for chunk in raw.chunks_exact(elem_size) {
             let addr = u64::from_le_bytes(chunk[..8].try_into().expect("chunk has >= 8 bytes"));
-            out.push(self.file.object_at_relative(addr)?);
+            out.push(FileInner::object_at_relative(&self.file, addr)?);
         }
         Ok(out)
     }

--- a/tests/generic_element.rs
+++ b/tests/generic_element.rs
@@ -129,6 +129,6 @@ fn store_group<T: H5Element>(g: &mut hdf5_pure::GroupBuilder, name: &str, values
 /// `_ = Dataset::read` keeps the import used even if the inherent method is
 /// renamed; serves as a compile-time signature check.
 #[allow(dead_code)]
-fn signature_check(ds: &Dataset<'_>) -> Result<Vec<u8>, Error> {
+fn signature_check(ds: &Dataset) -> Result<Vec<u8>, Error> {
     ds.read::<u8>()
 }

--- a/tests/layout_introspection.rs
+++ b/tests/layout_introspection.rs
@@ -11,12 +11,12 @@
 use hdf5_pure::{ChunkIndex, Dataset, File, FileBuilder, Layout};
 use tempfile::tempdir;
 
-fn open<'a>(f: &'a File, name: &str) -> Dataset<'a> {
+fn open(f: &File, name: &str) -> Dataset {
     f.dataset(name).unwrap()
 }
 
 /// Chunk offsets returned by `chunks()`, sorted for order-independent asserts.
-fn sorted_offsets(ds: &Dataset<'_>) -> Vec<Vec<u64>> {
+fn sorted_offsets(ds: &Dataset) -> Vec<Vec<u64>> {
     let mut offs: Vec<Vec<u64>> = ds.chunks().unwrap().into_iter().map(|c| c.offset).collect();
     offs.sort();
     offs

--- a/tests/owned_handles.rs
+++ b/tests/owned_handles.rs
@@ -1,0 +1,96 @@
+//! Owned, cacheable object handles (issue #148).
+//!
+//! `Dataset`, `Group`, and `Object` no longer borrow `File`: they share
+//! ownership of the open file, so a handle can be returned from a function that
+//! owns its `File`, stored in a struct with no lifetime, cached, cloned, and
+//! moved across threads.
+
+use hdf5_pure::{Dataset, Error, File, FileBuilder, Group, Object};
+
+fn sample_file() -> Vec<u8> {
+    let mut builder = FileBuilder::new();
+    builder
+        .create_dataset("data")
+        .with_f64_data(&[1.0, 2.0, 3.0, 4.0])
+        .with_shape(&[4]);
+    builder.finish().unwrap()
+}
+
+/// Owns a `File` and returns a `Dataset` derived from it. This does not compile
+/// under a borrow-based `Dataset<'f>` — the returned handle would borrow a local
+/// — and is the core ergonomic the issue asks for.
+fn open_owned(bytes: Vec<u8>) -> Result<Dataset, Error> {
+    let file = File::from_bytes(bytes)?;
+    file.dataset("data")
+}
+
+#[test]
+fn dataset_outlives_the_file_binding() {
+    let ds = open_owned(sample_file()).unwrap();
+    // `file` inside `open_owned` is long gone; the handle kept the file alive.
+    assert_eq!(ds.read_f64().unwrap(), vec![1.0, 2.0, 3.0, 4.0]);
+}
+
+/// A struct holds a handle with no lifetime parameter.
+struct Cache {
+    ds: Dataset,
+}
+
+#[test]
+fn handle_stored_in_a_struct() {
+    let file = File::from_bytes(sample_file()).unwrap();
+    let cache = Cache {
+        ds: file.dataset("data").unwrap(),
+    };
+    drop(file); // the cached handle keeps the file open
+    assert_eq!(cache.ds.shape().unwrap(), vec![4]);
+}
+
+#[test]
+fn handles_are_send_sync_static() {
+    fn assert_send_sync_static<T: Send + Sync + 'static>() {}
+    assert_send_sync_static::<File>();
+    assert_send_sync_static::<Dataset>();
+    assert_send_sync_static::<Group>();
+    assert_send_sync_static::<Object>();
+}
+
+#[test]
+fn file_is_cloneable_and_both_clones_read() {
+    let file = File::from_bytes(sample_file()).unwrap();
+    let file2 = file.clone();
+    let expect = vec![1.0, 2.0, 3.0, 4.0];
+    assert_eq!(file.dataset("data").unwrap().read_f64().unwrap(), expect);
+    assert_eq!(file2.dataset("data").unwrap().read_f64().unwrap(), expect);
+}
+
+#[test]
+fn two_handles_to_one_dataset_read_consistently() {
+    let file = File::from_bytes(sample_file()).unwrap();
+    let a = file.dataset("data").unwrap();
+    let b = file.dataset("data").unwrap();
+    assert_eq!(a.read_f64().unwrap(), b.read_f64().unwrap());
+}
+
+#[test]
+fn refresh_reports_outstanding_handles() {
+    let mut file = File::from_bytes(sample_file()).unwrap();
+    let ds = file.dataset("data").unwrap();
+    // A live handle shares ownership, so a mutating refresh is refused with a
+    // clear error rather than mutating a view others hold.
+    assert!(matches!(file.refresh(), Err(Error::HandlesOutstanding)));
+    drop(ds);
+    // With the handle dropped, refresh has exclusive access and now fails only
+    // because this file was not opened for SWMR.
+    assert!(matches!(file.refresh(), Err(Error::SwmrUnsupported)));
+}
+
+#[test]
+fn handle_moves_across_threads() {
+    let file = File::from_bytes(sample_file()).unwrap();
+    let ds = file.dataset("data").unwrap();
+    let sum = std::thread::spawn(move || ds.read_f64().unwrap().iter().sum::<f64>())
+        .join()
+        .unwrap();
+    assert_eq!(sum, 10.0);
+}

--- a/tests/proptest_roundtrip.rs
+++ b/tests/proptest_roundtrip.rs
@@ -182,7 +182,7 @@ proptest! {
 /// the test; the goal here is "parsing primitives never panic", not exhaustive
 /// traversal.
 fn exercise(file: &File) {
-    let root: Group<'_> = file.root();
+    let root: Group = file.root();
     if let Ok(names) = root.datasets() {
         for name in names.iter().take(16) {
             if let Ok(ds) = root.dataset(name) {


### PR DESCRIPTION
Phase 1 of #148 (owned, cacheable mutable object handles): make the read-side object handles owned so they can be stored, cached, and moved across threads. Write-through handles follow in phase 2.

## What changed

- `File` is now a cheaply cloneable `Arc`-backed handle.
- `Dataset`, `Group`, and `Object` drop their `<'f>` lifetime and share ownership of the open file, so a handle can be returned from a function that owns its `File`, stored in a struct with no lifetime, cached, cloned, and sent across threads.
- `File::refresh` takes exclusive access via `Arc::get_mut` and returns the new `Error::HandlesOutstanding` when a handle or `File` clone is still alive (was a compile-time borrow rule).

## Breaking

`Dataset`, `Group`, and `Object` lose their `<'f>` lifetime parameter. Code that never named the handle lifetime is unaffected; code that wrote `Dataset<'_>` should drop the lifetime.

## Verification

- Full suite: **1333 pass, 0 fail** (2 pre-existing ignores), including all 13 C-crosscheck suites — the owned-handle read path round-trips byte-identically against the reference HDF5 C library.
- New `tests/owned_handles.rs`: handle outlives its `File`, stored in a struct, `Send + Sync + 'static`, `File` clone, two-handle coherence, cross-thread move, and `HandlesOutstanding`.
- `cargo fmt --check`, `clippy -D warnings`, `no_std` build, `rustdoc -D warnings`, and the i686 narrowing-cast gate all clean.