### PR TITLE
Deprecate SwmrWriter and the public EditSession surface (#148, PR D)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `EditSession::space_accounting` reports a mutating session's live space usage as a `SpaceAccounting` — the current logical file size, the total reusable free bytes, and the reusable free regions as absolute `(offset, length)` pairs — the active-editor counterpart of `File::file_size` and `persisted_free_space`; it reflects committed state plus immediate in-place appends, not edits still staged for `commit` ([#150](https://github.com/stephenberry/hdf5-pure/issues/150)).
 - `DatasetBuilder::with_fill_value` records a dataset's fill value — the value HDF5 reports for never-written elements — and `Dataset::fill_value` reads one back, from this crate's files as well as the reference C library's and h5py's; the fill value's type must match the dataset datatype ([#151](https://github.com/stephenberry/hdf5-pure/issues/151)).
 
+### Deprecated
+
+- `SwmrWriter` and `EditSession` are deprecated in favor of the owned-handle API and will be removed in a later release: open with `File::open_swmr_writer` or `File::open_rw` and mutate through owned `Dataset`/`Group` handles that read and write one file by name (`Dataset::append`/`append_staged`/`write`, `Group::create_dataset`/`create_group`/`delete`, `File::copy_from`/`commit`/`clear_swmr_flag`) ([#148](https://github.com/stephenberry/hdf5-pure/issues/148)).
+
 ### Fixed
 
 - Reading an attribute or dataset whose dataspace declares dimensions whose product overflows `u64` no longer panics: the element count now saturates so the size and limit checks reject the file as a format error ([#142](https://github.com/stephenberry/hdf5-pure/issues/142)).

--- a/README.md
+++ b/README.md
@@ -109,18 +109,20 @@ lossless read. For N-dimensional arrays see the `ndarray` feature below.
 
 `EditSession` opens an existing file and adds, deletes, or copies objects, appends to chunked unlimited datasets in place (including filtered/compressed ones, via `append_dataset`), or edits compact group attributes without reading it all in and rewriting it. New data and the rebuilt object headers are appended at the end of the file and the superblock is repointed last, so the cost is proportional to what changes and a failed commit leaves the file valid. For many repeated appends to a single 1-D unlimited dataset, `AppendWriter` holds the file open and grows the index in place at amortized `O(1)` cost instead of re-reading and rebuilding it on every `append_dataset` commit; unfiltered appends may be any length, while filtered appends this way must be chunk-aligned.
 
+> **Deprecated:** the path-based `EditSession` API is superseded by the owned-handle API shown here — open with `File::open_rw` and edit through owned `Dataset`/`Group` handles that also read back by name — and will be removed in a later release.
+
 ```rust,no_run
-use hdf5_pure::{AttrValue, EditSession};
+use hdf5_pure::File;
 
-let mut session = EditSession::open("output.h5").unwrap();
+let file = File::open_rw("output.h5").unwrap();
+let root = file.root();
 
-session.create_group("run2");
-session.set_group_attr("run2", "kind", AttrValue::AsciiString("trial".into()));
-session.create_dataset("run2/signal").with_f64_data(&[1.0, 2.0, 3.0]);
-session.copy("temperature", "temperature_backup");  // H5Ocopy
-session.delete("sensors/pressure");                 // H5Ldelete
+root.create_group("run2").unwrap();
+root.create_dataset("run2/signal", |b| { b.with_f64_data(&[1.0, 2.0, 3.0]); }).unwrap();
+file.copy("temperature", "temperature_backup").unwrap();  // H5Ocopy
+root.delete("sensors/pressure").unwrap();                 // H5Ldelete
 
-session.commit().unwrap();  // apply everything in place
+file.commit().unwrap();  // apply staged edits in place
 ```
 
 Contiguous and chunked datasets — the latter with any supported filter (deflate, shuffle, fletcher32, scale-offset) and optionally extensible (unlimited) dimensions — and compact-link groups are supported, and the editor edits files across every on-disk format the reference C library and h5py produce — version 0/1/2/3 superblocks, single- and multi-chunk object headers (a multi-chunk header is collapsed into one chunk on rewrite, and a version 0/1 symbol-table group on the edited path is converted to the latest compact-link format). It refuses, rather than silently degrade the file, anything it cannot reproduce faithfully — a chunked or extensible variable-length addition, dense-storage headers on the edited path, or copying a chunked or version-1 object. Within a session the space a deletion frees — for contiguous and chunked datasets alike, including the chunk index — is reused for later writes and the file is truncated when the freed bytes reach the end, so add/delete churn stays bounded instead of only ever growing; for guaranteed compaction across a reopen, see `repack` below.
@@ -269,13 +271,16 @@ builder.write("stream.h5").unwrap();
 
 Append in place (each call flushes durably; the file stays valid for concurrent readers throughout):
 
-```rust
-use hdf5_pure::SwmrWriter;
+> **Deprecated:** the `SwmrWriter` type is superseded by the owned-handle API shown here — open with `File::open_swmr_writer` and append through a `Dataset` handle — and will be removed in a later release.
 
-let mut writer = SwmrWriter::open("stream.h5").unwrap();
-writer.append_i32("log", &[3, 4, 5]).unwrap();
-writer.append_i32("log", &[6, 7]).unwrap();
-writer.close().unwrap(); // clears the SWMR flag; or just drop the writer
+```rust,no_run
+use hdf5_pure::File;
+
+let file = File::open_swmr_writer("stream.h5").unwrap();
+let mut log = file.dataset("log").unwrap();
+log.append(&[3i32, 4, 5]).unwrap();
+log.append(&[6, 7]).unwrap();
+file.close().unwrap(); // clears the SWMR flag; or just drop the file
 ```
 
 Follow a growing file from another process (or the reference C library / h5py writing in SWMR mode):
@@ -291,7 +296,7 @@ let ds = file.dataset("log").unwrap();
 println!("now {} rows", ds.shape().unwrap()[0]);
 ```
 
-Supported subset: one unlimited dimension, chunked, unfiltered (no compression on the appended dataset), chunk-aligned appends, no userblock. Growth is unbounded. SWMR requires the `std` filesystem (not the in-memory/WASM path). If a writer process exits without `close()`, the file is left marked as having an active SWMR writer; recover it with `SwmrWriter::clear_swmr_flag(path)` (the equivalent of `h5clear`).
+Supported subset: one unlimited dimension, chunked, unfiltered (no compression on the appended dataset), chunk-aligned appends, no userblock. Growth is unbounded. SWMR requires the `std` filesystem (not the in-memory/WASM path). If a writer process exits without `close()`, the file is left marked as having an active SWMR writer; recover it with `File::clear_swmr_flag(path)` (the equivalent of `h5clear`).
 
 ## Supported data types
 

--- a/docs/guide/editing.md
+++ b/docs/guide/editing.md
@@ -2,6 +2,9 @@
 
 `EditSession` opens an existing HDF5 file and adds, copies, or deletes objects, or edits group attributes, without reading the whole file in and rewriting it. New data and rebuilt object headers are appended at the end of the file and the superblock is repointed last, so the cost is proportional to what changes rather than to the file size, and a failed commit leaves the original file valid.
 
+!!! warning "Deprecated"
+    `EditSession` is superseded by the owned-handle API and will be removed in a later release. Open a file for reading **and** writing with `File::open_rw` and edit it through owned `Dataset` and `Group` handles that reach every object by name: `Dataset::append`/`write`/`append_staged`, `Group::create_dataset`/`create_group`/`delete`/`set_attr`, and `File::copy`/`copy_from`/`commit`. One open file both writes and reads back, with no separate session type.
+
 !!! tip "Runnable example"
     This page mirrors [`examples/edit_in_place.rs`](https://github.com/stephenberry/hdf5-pure/blob/main/examples/edit_in_place.rs). Run it with:
 

--- a/docs/guide/swmr.md
+++ b/docs/guide/swmr.md
@@ -2,6 +2,9 @@
 
 SWMR lets a single process append to an unlimited dataset in place while other processes read it concurrently, and it interoperates with the reference HDF5 C library and h5py in both directions. This page covers how to lay out a SWMR-capable dataset, append to it durably, follow it from a reader, and recover a file left flagged by a writer that exited uncleanly.
 
+!!! warning "Deprecated"
+    `SwmrWriter` is superseded by the owned-handle API and will be removed in a later release. Open with `File::open_swmr_writer` and append through a `Dataset` handle, then `File::close` to clear the SWMR-write flag; recover a flag left set by a crashed writer with `File::clear_swmr_flag`. The same no-lock, unfiltered, chunk-aligned SWMR contract applies.
+
 !!! tip "Runnable example"
     A complete single-process demonstration lives in [`examples/swmr.rs`](https://github.com/stephenberry/hdf5-pure/blob/main/examples/swmr.rs). Run it with:
 

--- a/examples/append_dataset.rs
+++ b/examples/append_dataset.rs
@@ -16,6 +16,7 @@
 //! cargo run --example append_dataset
 //! ```
 
+#![allow(deprecated)] // exercises the deprecated EditSession/SwmrWriter shims (issue #148)
 use hdf5_pure::{EditSession, File, FileBuilder};
 
 fn main() {

--- a/examples/edit_in_place.rs
+++ b/examples/edit_in_place.rs
@@ -12,6 +12,7 @@
 //! cargo run --example edit_in_place
 //! ```
 
+#![allow(deprecated)] // exercises the deprecated EditSession/SwmrWriter shims (issue #148)
 use hdf5_pure::{AttrValue, EditSession, File, FileBuilder};
 
 fn main() {

--- a/examples/file_space.rs
+++ b/examples/file_space.rs
@@ -19,6 +19,7 @@
 //! cargo run --example file_space
 //! ```
 
+#![allow(deprecated)] // exercises the deprecated EditSession/SwmrWriter shims (issue #148)
 use hdf5_pure::{EditSession, File, FileBuilder, FileSpaceStrategy};
 use std::path::Path;
 

--- a/examples/swmr.rs
+++ b/examples/swmr.rs
@@ -13,6 +13,7 @@
 //! cargo run --example swmr
 //! ```
 
+#![allow(deprecated)] // exercises the deprecated EditSession/SwmrWriter shims (issue #148)
 use hdf5_pure::{File, FileBuilder, SwmrWriter};
 
 fn main() {

--- a/src/chunk_index_inplace.rs
+++ b/src/chunk_index_inplace.rs
@@ -442,12 +442,12 @@ impl Located {
                 // yet: an empty dataset the C library created without writing any
                 // chunk (this crate's writer allocates it eagerly). In-place
                 // growth needs an existing index; make the first append through
-                // `EditSession::append_dataset`, which materializes the index, or
+                // `Dataset::append_staged`, which materializes the index, or
                 // create the dataset with initial data.
                 return Err(unsupported(
                     "the dataset's extensible-array index is not allocated yet (an empty \
                      dataset with no chunks); write initial data at creation or make the \
-                     first append with EditSession::append_dataset",
+                     first append with Dataset::append_staged",
                 ));
             }
             _ => {
@@ -1065,7 +1065,7 @@ pub(crate) fn plan_ea_append<F: InPlaceBytes>(
         return Err(Error::AppendUnsupported(
             "a filtered dataset can only be appended in place in whole chunks (the current \
              length and the appended length must both be multiples of the chunk length); \
-             use EditSession::append_dataset for a non-chunk-aligned filtered append",
+             use Dataset::append_staged for a non-chunk-aligned filtered append",
         ));
     }
 

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -1042,13 +1042,13 @@ impl WriteEngine {
         if self.superblock.base_address != 0 {
             return Err(Error::AppendInPlaceUnsupported(
                 "in-place append does not support a file with a userblock (non-zero base \
-                 address); use EditSession::append_dataset",
+                 address); use Dataset::append_staged",
             ));
         }
         if self.superblock.version < 2 {
             return Err(Error::AppendInPlaceUnsupported(
                 "in-place append requires a latest-format file (v2/v3 superblock); use \
-                 EditSession::append_dataset",
+                 Dataset::append_staged",
             ));
         }
         // A file that persists its free space keeps on-disk free-space managers (and,
@@ -1059,7 +1059,7 @@ impl WriteEngine {
         if self.persist.is_some() {
             return Err(Error::AppendInPlaceUnsupported(
                 "in-place append is not supported on a file that persists its free space \
-                 (H5Pset_file_space_strategy persist=true); use EditSession::append_dataset",
+                 (H5Pset_file_space_strategy persist=true); use Dataset::append_staged",
             ));
         }
 
@@ -1071,7 +1071,7 @@ impl WriteEngine {
         if self.append_conflicts_with_pending(&target) {
             return Err(Error::AppendInPlaceUnsupported(
                 "the dataset or an ancestor has a staged edit pending in this session; commit \
-                 the staged edits before appending in place, or use EditSession::append_dataset",
+                 the staged edits before appending in place, or use Dataset::append_staged",
             ));
         }
 
@@ -5275,6 +5275,7 @@ append_inplace_typed! {
 /// # Example
 ///
 /// ```no_run
+/// # #![allow(deprecated)]
 /// use hdf5_pure::{AttrValue, EditSession};
 ///
 /// let mut session = EditSession::open("existing.h5")?;
@@ -5290,10 +5291,46 @@ append_inplace_typed! {
 /// This type is the public face of the crate's in-place write engine: every
 /// method forwards to it, and the owned read-write [`File`](crate::File) drives
 /// the same engine directly behind its `Backend::Mirror`.
+///
+/// # Deprecated
+///
+/// Superseded by the owned-handle API. Open a file for reading **and** writing
+/// with [`File::open_rw`](crate::File::open_rw), then reach every object by name
+/// through owned [`Dataset`](crate::Dataset) and [`Group`](crate::Group) handles
+/// that both read and mutate in place — no separate, write-blind session type.
+/// The two commit models carry over unchanged: immediate
+/// [`Dataset::append`](crate::Dataset::append), and staged
+/// [`Group::create_dataset`](crate::Group::create_dataset) /
+/// [`Group::create_group`](crate::Group::create_group) /
+/// [`Dataset::write`](crate::Dataset::write) /
+/// [`Dataset::append_staged`](crate::Dataset::append_staged) / attribute edits /
+/// [`File::copy`](crate::File::copy) / [`Group::delete`](crate::Group::delete),
+/// applied by [`File::commit`](crate::File::commit).
+///
+/// ```no_run
+/// use hdf5_pure::File;
+///
+/// let file = File::open_rw("existing.h5")?;
+/// let root = file.root();
+/// root.create_group("run2")?; // staged
+/// root.create_dataset("run2/signal", |b| {
+///     b.with_f64_data(&[1.0, 2.0, 3.0]);
+/// })?; // staged
+/// file.commit()?; // apply staged edits
+/// let _values: Vec<f64> = file.dataset("run2/signal")?.read()?; // read back, one handle
+/// # Ok::<(), hdf5_pure::Error>(())
+/// ```
+///
+/// The type will be removed in a later release.
+#[deprecated(
+    since = "0.22.0",
+    note = "use File::open_rw and owned Dataset/Group handles; see the EditSession type docs for migration"
+)]
 pub struct EditSession {
     engine: WriteEngine,
 }
 
+#[allow(deprecated)] // this wrapper's own impl legitimately names and builds the (deprecated) type
 impl EditSession {
     /// Open an existing HDF5 file for in-place editing, taking an exclusive OS
     /// advisory lock held for the session's life. Fails with
@@ -5436,6 +5473,7 @@ impl EditSession {
 /// each delegating to the [`WriteEngine`] method of the same name.
 macro_rules! forward_append_inplace_typed {
     ($($method:ident, $ty:ty;)*) => {
+        #[allow(deprecated)] // forwarders on the deprecated wrapper
         impl EditSession {
             $(
                 #[doc = concat!("Append `", stringify!($ty), "` values to `dataset` in \

--- a/src/file_lock.rs
+++ b/src/file_lock.rs
@@ -121,7 +121,7 @@ pub(crate) fn acquire_exclusive(
         Err(TryLockError::WouldBlock) => Err(Error::FileLocked(format!(
             "{}: file is already locked by another process. If a previous writer \
              crashed, the OS lock is released automatically (try again); a leftover \
-             on-disk SWMR flag can be cleared with SwmrWriter::clear_swmr_flag. Set \
+             on-disk SWMR flag can be cleared with File::clear_swmr_flag. Set \
              HDF5_USE_FILE_LOCKING=FALSE or pass FileLocking::Disabled to bypass locking.",
             path.display(),
         ))),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,29 +50,32 @@
 //!
 //! # Editing files in place
 //!
-//! [`EditSession`] opens an existing file and adds, deletes, copies, or
-//! overwrites objects without reading it all in and rewriting it. New data and
-//! rebuilt object headers are appended at end-of-file and the superblock is
-//! repointed last, so the cost is proportional to what changes rather than to the
-//! file size. It edits files written by this crate, the reference HDF5 C library,
-//! and h5py across all of their on-disk formats, and refuses — rather than
-//! silently degrade the file — anything it cannot reproduce faithfully.
+//! Open an existing file for reading **and** writing with [`File::open_rw`] and
+//! reach every object by name through owned [`Dataset`] and [`Group`] handles
+//! that add, delete, copy, or overwrite objects without reading it all in and
+//! rewriting it. New data and rebuilt object headers are appended at end-of-file
+//! and the superblock is repointed last, so the cost is proportional to what
+//! changes rather than to the file size. It edits files written by this crate,
+//! the reference HDF5 C library, and h5py across all of their on-disk formats,
+//! and refuses — rather than silently degrade the file — anything it cannot
+//! reproduce faithfully.
 //!
 //! ```rust,no_run
-//! use hdf5_pure::EditSession;
+//! use hdf5_pure::File;
 //!
-//! let mut session = EditSession::open("output.h5").unwrap();
-//! session.create_dataset("extra").with_f64_data(&[4.0, 5.0]);
-//! session.write_dataset("data").with_f64_data(&[7.0, 8.0]); // H5Dwrite (overwrite)
-//! session.delete("old");             // H5Ldelete
-//! session.commit().unwrap();
+//! let file = File::open_rw("output.h5").unwrap();
+//! let root = file.root();
+//! root.create_dataset("extra", |b| { b.with_f64_data(&[4.0, 5.0]); }).unwrap();
+//! file.dataset("data").unwrap().write(&[7.0, 8.0]).unwrap(); // H5Dwrite (overwrite)
+//! root.delete("old").unwrap();                               // H5Ldelete
+//! file.commit().unwrap();                                    // apply staged edits
 //! ```
 //!
-//! [`write_dataset`](EditSession::write_dataset) overwrites an existing
-//! contiguous or compact dataset's values; the replacement must match the
-//! on-disk datatype and shape (it is a value write, not a reshape/retype), and a
-//! same-length contiguous overwrite is applied straight into the existing data
-//! block without rewriting any header.
+//! A value overwrite ([`Dataset::write`]) must match the on-disk datatype and
+//! shape (it is a value write, not a reshape/retype); a same-length contiguous
+//! overwrite is applied straight into the existing data block without rewriting
+//! any header. Immediate, amortized-`O(1)` row appends use [`Dataset::append`]
+//! and need no commit.
 //!
 //! # Streaming large files
 //!
@@ -262,13 +265,18 @@ pub use types::{AttrValue, DType};
 pub use writer::FileBuilder;
 
 #[cfg(feature = "std")]
+#[allow(deprecated)] // re-exporting the deprecated shim; users still see the deprecation
 pub use swmr_writer::SwmrWriter;
 
 #[cfg(feature = "std")]
 pub use append_writer::AppendWriter;
 
 #[cfg(feature = "std")]
-pub use edit::{AppendBuilder, EditSession, SpaceAccounting};
+pub use edit::{AppendBuilder, SpaceAccounting};
+
+#[cfg(feature = "std")]
+#[allow(deprecated)] // re-exporting the deprecated shim; users still see the deprecation
+pub use edit::EditSession;
 
 #[cfg(feature = "std")]
 pub use repack::{RepackOptions, repack};

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -674,8 +674,8 @@ impl FileInner {
     /// The whole-file byte image when this file is buffered in memory
     /// ([`open`](Self::open) / [`from_bytes`](Self::from_bytes)); `None` for a
     /// streaming file ([`open_streaming`](Self::open_streaming)). Cross-file
-    /// object copy ([`EditSession::copy_from`](crate::EditSession::copy_from))
-    /// uses this to read source objects by absolute address.
+    /// object copy ([`File::copy_from`](crate::File::copy_from)) uses this to read
+    /// source objects by absolute address.
     pub(crate) fn in_memory_image(&self) -> Option<&[u8]> {
         match &self.backend {
             Backend::InMemory(data) => Some(data),
@@ -1166,7 +1166,7 @@ impl File {
     /// recovering a file the reference C library then refuses to open. A no-op if
     /// the flag is already clear.
     pub fn clear_swmr_flag<P: AsRef<std::path::Path>>(path: P) -> Result<(), Error> {
-        crate::swmr_writer::SwmrWriter::clear_swmr_flag(path)
+        crate::swmr_writer::clear_swmr_flag_at(path.as_ref())
     }
 
     /// Create a new, empty HDF5 file at `path` and open it for reading and
@@ -1876,7 +1876,7 @@ impl Dataset {
     /// Together with [`is_chunked`](Self::is_chunked) and
     /// [`chunk_shape`](Self::chunk_shape), this lets a caller check up front
     /// whether a dataset is eligible for
-    /// [`EditSession::append_dataset`](crate::EditSession::append_dataset)
+    /// [`Dataset::append_staged`](crate::Dataset::append_staged)
     /// (which requires a chunked dataset whose first maximum dimension is
     /// `u64::MAX`) instead of relying on the append's refusal error.
     pub fn maxshape(&self) -> Result<Option<Vec<u64>>, Error> {

--- a/src/swmr_writer.rs
+++ b/src/swmr_writer.rs
@@ -1,5 +1,11 @@
 //! SWMR (single-writer / multiple-reader) append writer.
 //!
+//! **Deprecated:** superseded by the owned-handle API — open with
+//! [`crate::File::open_swmr_writer`] and append through a [`crate::Dataset`]
+//! handle, then [`crate::File::close`] to clear the flag; recover a stale flag
+//! with [`crate::File::clear_swmr_flag`]. See the [`SwmrWriter`] type docs for the
+//! migration.
+//!
 //! Opens an existing HDF5 file (created by this crate, the reference C library,
 //! or h5py with the latest format) and appends chunks to a one-dimensional,
 //! unlimited, Extensible-Array-indexed dataset *in place*: each appended chunk
@@ -40,7 +46,8 @@
 //! Recover such a file with [`SwmrWriter::clear_swmr_flag`] (the `h5clear -s`
 //! equivalent).
 //!
-//! Unlike [`crate::EditSession`], the SWMR writer takes **no OS file lock**: SWMR
+//! Unlike a read-write [`crate::File::open_rw`] handle, the SWMR writer takes
+//! **no OS file lock**: SWMR
 //! is single-writer by contract and built for concurrent reads (the reference
 //! library likewise runs SWMR with file locking disabled), so a whole-file lock
 //! would block readers — fatally so on Windows, where locks are mandatory. The
@@ -63,6 +70,33 @@ use crate::superblock::Superblock;
 /// so it can read existing structures and recompute checksums without hitting
 /// the disk. For the unbounded "streaming log" use case this grows with the
 /// file; a future revision could bound it, but v1 favors simplicity.
+///
+/// # Deprecated
+///
+/// Superseded by the owned-handle API: open the file with
+/// [`File::open_swmr_writer`](crate::File::open_swmr_writer) and append through a
+/// [`Dataset`](crate::Dataset) handle. That path layers the same SWMR policy on
+/// the shared in-place engine — no OS lock, the `0x05` SWMR-write flag raised
+/// while active and cleared on [`File::close`](crate::File::close), and the same
+/// unfiltered, chunk-aligned append subset — and the one open file also reads
+/// back what it appends. Recover a flag left set by a crashed writer with
+/// [`File::clear_swmr_flag`](crate::File::clear_swmr_flag).
+///
+/// ```no_run
+/// use hdf5_pure::File;
+///
+/// let file = File::open_swmr_writer("log.h5")?;
+/// let mut samples = file.dataset("samples")?;
+/// samples.append(&[8i32, 9, 10, 11])?; // one whole chunk
+/// file.close()?; // clears the SWMR-write flag
+/// # Ok::<(), hdf5_pure::Error>(())
+/// ```
+///
+/// The type will be removed in a later release.
+#[deprecated(
+    since = "0.22.0",
+    note = "use File::open_swmr_writer + Dataset::append; see the SwmrWriter type docs for migration"
+)]
 pub struct SwmrWriter {
     /// In-memory mirror + on-disk handle, shared with the general append writer.
     file: InPlaceFile,
@@ -77,6 +111,7 @@ pub struct SwmrWriter {
 /// clean close — matching the reference C library and h5py.
 const SWMR_WRITE_FLAGS: u32 = 0x05;
 
+#[allow(deprecated)] // this type's own impl legitimately names and builds the (deprecated) type
 impl SwmrWriter {
     /// Open an existing HDF5 file for appending.
     ///
@@ -121,38 +156,7 @@ impl SwmrWriter {
     /// without a clean close (the h5clear equivalent). Safe to call on a file
     /// with the flag already clear.
     pub fn clear_swmr_flag<P: AsRef<Path>>(path: P) -> Result<(), Error> {
-        let path = path.as_ref();
-        let mut w = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open(path)
-            .map_err(Error::Io)?;
-        // Refuse to clear the flag out from under a live writer: an exclusive
-        // lock here fails with `FileLocked` if another writer still holds the
-        // file. A stale flag from a *crashed* writer has no live lock, so this
-        // succeeds and the recovery proceeds.
-        file_lock::acquire_exclusive(&w, FileLocking::Enabled, path)?;
-        let mut data = Vec::new();
-        w.read_to_end(&mut data).map_err(Error::Io)?;
-        let sig = signature::find_signature(&data)?;
-        let mut sb = Superblock::parse(&data, sig)?;
-        if sb.version < 2 {
-            // `Superblock::serialize` emits the v2/v3 layout, so rewriting a
-            // v0/v1 superblock here would corrupt it (the same hazard `open`
-            // guards against). This crate never SWMR-flags a v0/v1 file, so
-            // there is nothing to clear; treat it as already clean rather than
-            // risk a destructive rewrite.
-            return Ok(());
-        }
-        if sb.consistency_flags == 0 {
-            return Ok(());
-        }
-        sb.consistency_flags = 0;
-        let bytes = sb.serialize();
-        w.seek(SeekFrom::Start(sig as u64)).map_err(Error::Io)?;
-        w.write_all(&bytes).map_err(Error::Io)?;
-        w.sync_data().map_err(Error::Io)?;
-        Ok(())
+        clear_swmr_flag_at(path.as_ref())
     }
 
     /// Append `i32` values to an unlimited dataset.
@@ -298,6 +302,46 @@ impl SwmrWriter {
     }
 }
 
+/// Clear a stale SWMR-write flag left in `path` by a writer that exited without a
+/// clean close — the `h5clear -s` equivalent, shared by the deprecated
+/// [`SwmrWriter::clear_swmr_flag`] and the owned
+/// [`File::clear_swmr_flag`](crate::File::clear_swmr_flag). Safe to call on a file
+/// whose flag is already clear.
+pub(crate) fn clear_swmr_flag_at(path: &Path) -> Result<(), Error> {
+    let mut w = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(path)
+        .map_err(Error::Io)?;
+    // Refuse to clear the flag out from under a live writer: an exclusive
+    // lock here fails with `FileLocked` if another writer still holds the
+    // file. A stale flag from a *crashed* writer has no live lock, so this
+    // succeeds and the recovery proceeds.
+    file_lock::acquire_exclusive(&w, FileLocking::Enabled, path)?;
+    let mut data = Vec::new();
+    w.read_to_end(&mut data).map_err(Error::Io)?;
+    let sig = signature::find_signature(&data)?;
+    let mut sb = Superblock::parse(&data, sig)?;
+    if sb.version < 2 {
+        // `Superblock::serialize` emits the v2/v3 layout, so rewriting a
+        // v0/v1 superblock here would corrupt it (the same hazard `open`
+        // guards against). This crate never SWMR-flags a v0/v1 file, so
+        // there is nothing to clear; treat it as already clean rather than
+        // risk a destructive rewrite.
+        return Ok(());
+    }
+    if sb.consistency_flags == 0 {
+        return Ok(());
+    }
+    sb.consistency_flags = 0;
+    let bytes = sb.serialize();
+    w.seek(SeekFrom::Start(sig as u64)).map_err(Error::Io)?;
+    w.write_all(&bytes).map_err(Error::Io)?;
+    w.sync_data().map_err(Error::Io)?;
+    Ok(())
+}
+
+#[allow(deprecated)] // Drop impl of the deprecated type
 impl Drop for SwmrWriter {
     /// Best-effort clear of the SWMR-write flag so a writer that is merely
     /// dropped (rather than `close`d) still leaves the file cleanly marked. Use
@@ -310,6 +354,7 @@ impl Drop for SwmrWriter {
 }
 
 #[cfg(test)]
+#[allow(deprecated)] // exercises the deprecated SwmrWriter shim
 mod tests {
     use super::*;
     use crate::reader::File as PureFile;

--- a/tests/append.rs
+++ b/tests/append.rs
@@ -3,6 +3,7 @@
 //! filtered and unfiltered, chunk-aligned and not — and read the result back
 //! with this crate. C-library interop lives in `append_crosscheck.rs`.
 
+#![allow(deprecated)] // exercises the deprecated EditSession/SwmrWriter shims (issue #148)
 use hdf5_pure::{AppendBuilder, EditSession, Error, File, FileBuilder, ScaleOffset};
 use tempfile::tempdir;
 

--- a/tests/append_crosscheck.rs
+++ b/tests/append_crosscheck.rs
@@ -8,6 +8,7 @@
 //! datasets the C library itself created, whose incompressible chunks carry a
 //! nonzero per-chunk filter mask that the append must preserve.
 
+#![allow(deprecated)] // exercises the deprecated EditSession/SwmrWriter shims (issue #148)
 use hdf5::Extent;
 use hdf5::file::LibraryVersion;
 use hdf5_pure::{EditSession, File, FileBuilder};

--- a/tests/c_write_compat.rs
+++ b/tests/c_write_compat.rs
@@ -20,6 +20,7 @@
 //! Every call here goes through the safe `hdf5-metno` API, which serializes its
 //! own C calls through an internal lock, so these tests need no extra guard.
 
+#![allow(deprecated)] // exercises the deprecated EditSession/SwmrWriter shims (issue #148)
 use hdf5_pure::{EditSession, File, FileBuilder};
 use tempfile::tempdir;
 

--- a/tests/edit_append_inplace.rs
+++ b/tests/edit_append_inplace.rs
@@ -6,6 +6,7 @@
 //! hard-link aliasing and a combined mixed-edit file) lives in
 //! `edit_crosscheck.rs`.
 
+#![allow(deprecated)] // exercises the deprecated EditSession/SwmrWriter shims (issue #148)
 use hdf5_pure::{AttrValue, EditSession, Error, File, FileBuilder, FileSpaceStrategy};
 use tempfile::tempdir;
 

--- a/tests/edit_append_inplace_crosscheck.rs
+++ b/tests/edit_append_inplace_crosscheck.rs
@@ -13,6 +13,7 @@
 //! compact-attribute walkers must accept it rather than mistake it for dense
 //! storage.
 
+#![allow(deprecated)] // exercises the deprecated EditSession/SwmrWriter shims (issue #148)
 use hdf5::Extent;
 use hdf5::file::LibraryVersion;
 use hdf5_pure::{AttrValue, EditSession, Error, File};

--- a/tests/edit_crosscheck.rs
+++ b/tests/edit_crosscheck.rs
@@ -15,6 +15,7 @@
 //! compact-link format on rewrite, the superblock's root symbol-table entry is
 //! repointed, and the result is read back correctly by the C library.
 
+#![allow(deprecated)] // exercises the deprecated EditSession/SwmrWriter shims (issue #148)
 use hdf5::file::LibraryVersion;
 use hdf5_pure::{AttrValue, EditSession, File, FileBuilder, ScaleOffset};
 use tempfile::tempdir;

--- a/tests/edit_dataset_attr.rs
+++ b/tests/edit_dataset_attr.rs
@@ -5,6 +5,7 @@
 //! (dataset and group), the dense-storage refusal, and the single-hard-link refusal
 //! — lives in `edit_crosscheck.rs`.
 
+#![allow(deprecated)] // exercises the deprecated EditSession/SwmrWriter shims (issue #148)
 use hdf5_pure::{AttrValue, EditSession, Error, File, FileBuilder};
 use tempfile::tempdir;
 

--- a/tests/edit_dense_attr_copy.rs
+++ b/tests/edit_dense_attr_copy.rs
@@ -14,6 +14,7 @@
 //! sources, copy them, and verify every attribute (name + value) survives, in
 //! this crate's reader and the reference C library.
 
+#![allow(deprecated)] // exercises the deprecated EditSession/SwmrWriter shims (issue #148)
 use hdf5::file::LibraryVersion;
 use hdf5_pure::{AttrValue, EditSession, File, FileBuilder};
 use std::collections::HashMap;

--- a/tests/edit_free_space.rs
+++ b/tests/edit_free_space.rs
@@ -6,6 +6,7 @@
 //! run reaches end-of-file. These tests pin down both the size behavior and that
 //! survivors stay byte-exact and the file stays valid.
 
+#![allow(deprecated)] // exercises the deprecated EditSession/SwmrWriter shims (issue #148)
 use hdf5_pure::{EditSession, File, FileBuilder, FileSpaceStrategy};
 
 fn tmp(name: &str) -> std::path::PathBuf {

--- a/tests/edit_in_place.rs
+++ b/tests/edit_in_place.rs
@@ -1,6 +1,7 @@
 //! Tests for in-place editing via `EditSession` (issue #32, Group C):
 //! add, delete, and copy datasets and groups at any path.
 
+#![allow(deprecated)] // exercises the deprecated EditSession/SwmrWriter shims (issue #148)
 use hdf5_pure::{AttrValue, DType, EditSession, File, FileBuilder, Object, ScaleOffset};
 
 /// Write a starter file with one dataset, returning its path.

--- a/tests/edit_space_accounting.rs
+++ b/tests/edit_space_accounting.rs
@@ -8,6 +8,7 @@
 //! its reusable free from disk on open, and the total always equals the summed
 //! region lengths.
 
+#![allow(deprecated)] // exercises the deprecated EditSession/SwmrWriter shims (issue #148)
 use hdf5_pure::{EditSession, File, FileBuilder, FileSpaceStrategy};
 use tempfile::tempdir;
 

--- a/tests/edit_userblock.rs
+++ b/tests/edit_userblock.rs
@@ -16,6 +16,7 @@
 //! userblock-specific operation still refused — cross-file copy from a userblock
 //! *source* — is covered below; a refusal never corrupts the file.
 
+#![allow(deprecated)] // exercises the deprecated EditSession/SwmrWriter shims (issue #148)
 use hdf5_pure::{AttrValue, EditSession, File, FileBuilder, Object};
 
 const UB: usize = 512;

--- a/tests/edit_userblock_chunked.rs
+++ b/tests/edit_userblock_chunked.rs
@@ -13,6 +13,7 @@
 //!     the old chunk storage reclaimed), including reuse of that reclaimed space
 //!     by a later commit in the same session.
 
+#![allow(deprecated)] // exercises the deprecated EditSession/SwmrWriter shims (issue #148)
 use hdf5_pure::{EditSession, File, FileBuilder};
 
 const UB: usize = 512;

--- a/tests/edit_userblock_crosscheck.rs
+++ b/tests/edit_userblock_crosscheck.rs
@@ -8,6 +8,7 @@
 //! result back through `hdf5` is the external tripwire that the editor stored
 //! every root/link/layout address relative to the base address correctly.
 
+#![allow(deprecated)] // exercises the deprecated EditSession/SwmrWriter shims (issue #148)
 use hdf5::dataset::Layout;
 use hdf5::file::LibraryVersion;
 use hdf5_pure::{EditSession, File, FileBuilder};

--- a/tests/edit_userblock_followups.rs
+++ b/tests/edit_userblock_followups.rs
@@ -11,6 +11,7 @@
 //! create the never-written-contiguous and compact-layout fixtures those paths
 //! need.)
 
+#![allow(deprecated)] // exercises the deprecated EditSession/SwmrWriter shims (issue #148)
 use hdf5_pure::{AttrValue, EditSession, File, FileBuilder};
 
 const UB: usize = 512;

--- a/tests/file_locking.rs
+++ b/tests/file_locking.rs
@@ -7,6 +7,7 @@
 //! editor still holds its lock, because that read is permitted on Unix but
 //! blocked by the OS on Windows.
 
+#![allow(deprecated)] // exercises the deprecated EditSession/SwmrWriter shims (issue #148)
 use hdf5_pure::{EditSession, Error, File, FileBuilder, FileLocking, SwmrWriter};
 use tempfile::tempdir;
 

--- a/tests/file_space_crosscheck.rs
+++ b/tests/file_space_crosscheck.rs
@@ -7,6 +7,7 @@
 //! hdf5-pure — including a persisted (persist=true) file whose File Space Info
 //! message carries free-space-manager addresses.
 
+#![allow(deprecated)] // exercises the deprecated EditSession/SwmrWriter shims (issue #148)
 use hdf5::plist::file_create::FileSpaceStrategy as CStrategy;
 use hdf5_pure::{EditSession, File, FileBuilder, FileSpaceStrategy};
 use std::sync::{Mutex, MutexGuard};

--- a/tests/file_space_strategy.rs
+++ b/tests/file_space_strategy.rs
@@ -3,6 +3,7 @@
 //! issue #21): the writer records the chosen strategy in a superblock-extension
 //! File Space Info message, and the reader reads it back.
 
+#![allow(deprecated)] // exercises the deprecated EditSession/SwmrWriter shims (issue #148)
 use hdf5_pure::{File, FileBuilder, FileSpaceStrategy};
 
 fn tmp(name: &str) -> std::path::PathBuf {

--- a/tests/fill_value.rs
+++ b/tests/fill_value.rs
@@ -6,6 +6,7 @@
 //! value" default, the datatype/size validation, and that a fill value set on an
 //! `EditSession`-created dataset is honored.
 
+#![allow(deprecated)] // exercises the deprecated EditSession/SwmrWriter shims (issue #148)
 use hdf5_pure::{Dataset, EditSession, Error, File, FileBuilder, FormatError, H5Element};
 use tempfile::tempdir;
 

--- a/tests/swmr_append.rs
+++ b/tests/swmr_append.rs
@@ -7,6 +7,7 @@
 //! reference C library. Appends cross the inline -> direct-block -> super-block
 //! boundaries so the in-place index growth is exercised.
 
+#![allow(deprecated)] // exercises the deprecated EditSession/SwmrWriter shims (issue #148)
 use hdf5::Extent;
 use hdf5::file::LibraryVersion;
 use hdf5_pure::{Error, File, FileBuilder, FormatError, SwmrWriter};

--- a/tests/swmr_concurrent.rs
+++ b/tests/swmr_concurrent.rs
@@ -11,6 +11,7 @@
 //!
 //! `uv run` puts a pinned python3 + h5py on PATH for the duration of the test.
 
+#![allow(deprecated)] // exercises the deprecated EditSession/SwmrWriter shims (issue #148)
 use hdf5_pure::{FileBuilder, SwmrWriter};
 use tempfile::tempdir;
 


### PR DESCRIPTION
**Stacked on #167 (PR C), which stacks on #166/#165.** Review/merge the stack in order; this PR's own diff is just the deprecation commit.

Deprecates `SwmrWriter` and the public `EditSession` surface (issue #148, **PR D**, the final absorption step). With owned-handle parity in place (#165), SWMR-writer mode added (#166), and the engine split from its wrapper (#167), both legacy writer types now have a live owned-handle replacement, so each `#[deprecated]` note names one.

## What it does

- **`#[deprecated(since = "0.22.0")]`** on `SwmrWriter` and on the public `EditSession` wrapper, each with a module-doc note and a `# Deprecated` section carrying an owned-handle migration example. The internal `WriteEngine` (which `Backend::Mirror` drives) stays undeprecated and lint-clean — the reason PR C split the type first.
- **Decouples `File::clear_swmr_flag` from the deprecated type.** The flag-clearing implementation moves verbatim to a `pub(crate) fn clear_swmr_flag_at(path: &Path)`; both `File::clear_swmr_flag` and the deprecated `SwmrWriter::clear_swmr_flag` delegate to it, so the owned method no longer names a deprecated type.
- **Repoints internal cross-references** to their owned replacements: the in-place-append refusal error strings and the `reader.rs`/`edit.rs` doc links now steer to `Dataset::append_staged` and `File::copy_from` instead of `EditSession::append_dataset`/`copy_from`.
- **Splits the `lib.rs` re-exports** so `#[allow(deprecated)]` is isolated to the `EditSession` and `SwmrWriter` re-export lines (a combined line would silently swallow a future `AppendBuilder`/`SpaceAccounting` deprecation, and re-exporting a deprecated item on a `pub use` line is a hard error under `-D warnings`).
- **Migrates the user-facing examples** — the crate-doc editing example, the `docs/guide` editing + SWMR pages, and the README editing + SWMR code blocks — to `File::open_rw` / `File::open_swmr_writer` and owned handles, with deprecation admonitions.

## Migration

| Old | New |
|---|---|
| `EditSession::open` | `File::open_rw` |
| `EditSession::open_with_locking` | `File::open_rw_with_locking` |
| `EditSession::append_inplace[_raw]` | `Dataset::append` / `append_raw` |
| `EditSession::append_dataset` | `Dataset::append_staged` |
| `EditSession::write_dataset` | `Dataset::write` |
| `EditSession::set/remove_dataset_attr` | `Dataset::set_attr` / `remove_attr` |
| `EditSession::create_dataset` / `create_group` / `delete` | `Group::create_dataset` / `create_group` / `delete` |
| `EditSession::set/remove_group_attr` | `Group::set_attr` / `remove_attr` |
| `EditSession::copy` / `copy_from` | `File::copy` / `copy_from` |
| `EditSession::commit` / `space_accounting` / `has_staged_edits` | `File::commit` / `space_accounting` / `has_staged_edits` |
| `SwmrWriter::open` / `append*` / `close` | `File::open_swmr_writer` + `Dataset::append` + `File::close` |
| `SwmrWriter::clear_swmr_flag` | `File::clear_swmr_flag` |

## Notes

- Test and example files that still exercise the shims carry a file-level `#![allow(deprecated)]` (25 files); the owned-handle paths are separately covered by `tests/owned_parity.rs` and `tests/owned_swmr.rs`. The flagship `examples/edit_in_place.rs` and `examples/swmr.rs` still demonstrate the deprecated types under that allow and can be migrated when the types are removed.
- `AppendWriter`'s deprecation is a separate PR (#164, based on `main`); this PR does not touch it.

## Verification

`cargo fmt --check`, `clippy --all-targets --all-features -D warnings`, rustdoc `-D warnings`, `build --no-default-features`, and `test --all-features` all pass (0 failed; 1369 tests, including the migrated doctests). `cargo-semver-checks` stays red, unchanged, from the unreleased #148 break.
