### PR TITLE
Port the in-place append engine onto bounded Source reads (#147, PR A)

### DIFF
--- a/src/append_writer.rs
+++ b/src/append_writer.rs
@@ -66,6 +66,8 @@ use crate::element::H5Element;
 use crate::error::Error;
 use crate::file_lock::FileLocking;
 use crate::filter_pipeline::FilterPipeline;
+use crate::group_v2;
+use crate::source::Source;
 
 /// Per-dataset state located once, then maintained across appends.
 struct DatasetState {
@@ -232,19 +234,26 @@ impl AppendWriter {
         if self.datasets.contains_key(dataset) {
             return Ok(());
         }
-        let result = Located::locate(&self.file, dataset, Error::AppendUnsupported)?;
+        let oh_addr = group_v2::resolve_path_any(self.file.data(), &self.file.superblock, dataset)?;
+        let result = Located::locate_at(&self.file, oh_addr, Error::AppendUnsupported)?;
         if result.located.chunk_elems == 0 {
             return Err(Error::AppendUnsupported(
                 "append requires a nonzero chunk length",
             ));
         }
-        let data = self.file.data();
         let (dt_off, dt_size) = result.spans.datatype;
-        let (datatype, _) = Datatype::parse(&data[dt_off..dt_off + dt_size])
+        let dt_bytes = self
+            .file
+            .read_metadata_at(dt_off, dt_size)
+            .map_err(|_| Error::AppendUnsupported("dataset datatype could not be parsed"))?;
+        let (datatype, _) = Datatype::parse(&dt_bytes)
             .map_err(|_| Error::AppendUnsupported("dataset datatype could not be parsed"))?;
         let pipeline = match result.spans.filter {
             Some((fb, fsize)) => {
-                let parsed = FilterPipeline::parse(&data[fb..fb + fsize]).map_err(|_| {
+                let fp_bytes = self.file.read_metadata_at(fb, fsize).map_err(|_| {
+                    Error::AppendUnsupported("dataset filter pipeline could not be parsed")
+                })?;
+                let parsed = FilterPipeline::parse(&fp_bytes).map_err(|_| {
                     Error::AppendUnsupported("dataset filter pipeline could not be parsed")
                 })?;
                 if !pipeline_reencodable(&parsed) {

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -16,7 +16,7 @@ use crate::fractal_heap::FractalHeapHeader;
 use crate::message_type::MessageType;
 use crate::object_header::ObjectHeader;
 use crate::shared_message;
-use crate::source::FileSource;
+use crate::source::Source;
 
 /// A parsed HDF5 attribute message.
 #[derive(Debug, Clone)]
@@ -352,9 +352,9 @@ pub fn extract_attributes_full(
 ///
 /// Reads compact attribute messages from the (already-parsed) object header,
 /// resolves shared attribute references, and walks dense storage (fractal heap +
-/// B-tree v2) through a [`FileSource`] on demand instead of indexing a whole-file
+/// B-tree v2) through a [`Source`] on demand instead of indexing a whole-file
 /// slice. Used by the streaming reader backend.
-pub fn extract_attributes_full_from_source<S: FileSource + ?Sized>(
+pub fn extract_attributes_full_from_source<S: Source + ?Sized>(
     source: &S,
     header: &ObjectHeader,
     offset_size: u8,
@@ -454,8 +454,8 @@ fn extract_dense_attributes(
 }
 
 /// Streaming counterpart of [`extract_dense_attributes`]: walks the fractal heap
-/// and B-tree v2 through a [`FileSource`] on demand.
-fn extract_dense_attributes_from_source<S: FileSource + ?Sized>(
+/// and B-tree v2 through a [`Source`] on demand.
+fn extract_dense_attributes_from_source<S: Source + ?Sized>(
     source: &S,
     attr_info: &AttributeInfoMessage,
     fh_addr: u64,

--- a/src/btree_v1.rs
+++ b/src/btree_v1.rs
@@ -5,7 +5,7 @@ use alloc::vec::Vec;
 
 use crate::convert::TryToUsize;
 use crate::error::FormatError;
-use crate::source::FileSource;
+use crate::source::Source;
 
 /// Size of the size-of-offsets-independent prefix of a version 1 B-tree node:
 /// `signature(4) + node_type(1) + node_level(1) + entries_used(2)`. The two
@@ -157,11 +157,11 @@ impl BTreeV1Node {
         })
     }
 
-    /// Parse a B-tree v1 (type 0, group) node from a [`FileSource`] on demand.
+    /// Parse a B-tree v1 (type 0, group) node from a [`Source`] on demand.
     ///
     /// Reads the fixed node prefix to learn `entries_used`, then the exact node
     /// body, so no more than one node is resident at a time.
-    pub fn parse_from_source<S: FileSource + ?Sized>(
+    pub fn parse_from_source<S: Source + ?Sized>(
         source: &S,
         address: u64,
         offset_size: u8,
@@ -259,12 +259,12 @@ fn collect_symbol_table_nodes_inner(
 }
 
 /// Streaming counterpart of [`collect_symbol_table_nodes`]: walks the v1 B-tree
-/// through a [`FileSource`], reading one node at a time.
+/// through a [`Source`], reading one node at a time.
 ///
 /// `base_address` is the superblock base address; all B-tree node and SNOD
 /// addresses are stored relative to it. The returned SNOD addresses are also
 /// relative (the caller adds `base_address` to obtain absolute file offsets).
-pub fn collect_symbol_table_nodes_from_source<S: FileSource + ?Sized>(
+pub fn collect_symbol_table_nodes_from_source<S: Source + ?Sized>(
     source: &S,
     btree_address: u64,
     offset_size: u8,
@@ -283,7 +283,7 @@ pub fn collect_symbol_table_nodes_from_source<S: FileSource + ?Sized>(
 
 /// Depth-tracking core of [`collect_symbol_table_nodes_from_source`]; see
 /// [`collect_symbol_table_nodes_inner`] for why the bound is required.
-fn collect_symbol_table_nodes_from_source_inner<S: FileSource + ?Sized>(
+fn collect_symbol_table_nodes_from_source_inner<S: Source + ?Sized>(
     source: &S,
     btree_address: u64,
     offset_size: u8,

--- a/src/btree_v2.rs
+++ b/src/btree_v2.rs
@@ -8,7 +8,7 @@ use byteorder::{ByteOrder, LittleEndian};
 
 use crate::convert::TryToUsize;
 use crate::error::FormatError;
-use crate::source::FileSource;
+use crate::source::Source;
 
 /// Parsed B-tree v2 header (signature "BTHD").
 #[derive(Debug, Clone)]
@@ -161,11 +161,11 @@ impl BTreeV2Header {
         })
     }
 
-    /// Parse a B-tree v2 header from a [`FileSource`].
+    /// Parse a B-tree v2 header from a [`Source`].
     ///
     /// The header is fully self-contained (signature + fixed fields + a root
     /// pointer + checksum), so only a small bounded window is read.
-    pub fn parse_from_source<S: FileSource + ?Sized>(
+    pub fn parse_from_source<S: Source + ?Sized>(
         source: &S,
         address: u64,
         offset_size: u8,
@@ -479,9 +479,9 @@ fn collect_internal_records(
 }
 
 /// Collect all records from a B-tree v2 by traversing from the root, reading
-/// each fixed-size node from a [`FileSource`] on demand rather than indexing a
+/// each fixed-size node from a [`Source`] on demand rather than indexing a
 /// whole-file buffer.
-pub fn collect_btree_v2_records_from_source<S: FileSource + ?Sized>(
+pub fn collect_btree_v2_records_from_source<S: Source + ?Sized>(
     source: &S,
     header: &BTreeV2Header,
     offset_size: u8,
@@ -515,7 +515,7 @@ pub fn collect_btree_v2_records_from_source<S: FileSource + ?Sized>(
 /// children. Mirrors the buffered [`collect_btree_v2_records`] traversal and
 /// produces records in the same order.
 #[allow(clippy::too_many_arguments)]
-fn collect_node_from_source<S: FileSource + ?Sized>(
+fn collect_node_from_source<S: Source + ?Sized>(
     source: &S,
     address: u64,
     num_records: u16,

--- a/src/chunk_index_inplace.rs
+++ b/src/chunk_index_inplace.rs
@@ -1458,3 +1458,228 @@ fn read_uint(data: &[u8], pos: usize, size: usize) -> Result<u64, Error> {
     }
     Ok(v)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::group_v2;
+    use crate::writer::FileBuilder;
+    use std::cell::{Cell, RefCell};
+
+    /// An in-test [`Store`] over a `Vec<u8>` that records every read window, so
+    /// the tests below can assert the engine's bounded-memory contract: the
+    /// append path never reads more than a bounded window at once, no matter how
+    /// large the file is. This is the seam contract issue #147's mirror-less
+    /// bounded backend relies on.
+    struct WindowProbeStore {
+        data: Vec<u8>,
+        superblock: Superblock,
+        sb_sig_off: usize,
+        max_read: Cell<usize>,
+        total_read: Cell<usize>,
+        reads: RefCell<Vec<(u64, usize)>>,
+    }
+
+    impl WindowProbeStore {
+        fn open(data: Vec<u8>) -> Self {
+            let sb_sig_off = signature::find_signature(&data).unwrap();
+            let superblock = Superblock::parse(&data, sb_sig_off).unwrap();
+            Self {
+                data,
+                superblock,
+                sb_sig_off,
+                max_read: Cell::new(0),
+                total_read: Cell::new(0),
+                reads: RefCell::new(Vec::new()),
+            }
+        }
+
+        fn reset_counters(&self) {
+            self.max_read.set(0);
+            self.total_read.set(0);
+            self.reads.borrow_mut().clear();
+        }
+    }
+
+    impl Source for WindowProbeStore {
+        fn len(&self) -> u64 {
+            self.data.len() as u64
+        }
+        fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), FormatError> {
+            self.max_read.set(self.max_read.get().max(buf.len()));
+            self.total_read.set(self.total_read.get() + buf.len());
+            self.reads.borrow_mut().push((offset, buf.len()));
+            BytesSource::new(&self.data).read_at(offset, buf)
+        }
+    }
+
+    impl Store for WindowProbeStore {
+        fn offset_size(&self) -> u8 {
+            self.superblock.offset_size
+        }
+        fn length_size(&self) -> u8 {
+            self.superblock.length_size
+        }
+        fn append_bytes(&mut self, bytes: &[u8]) -> Result<u64, Error> {
+            let addr = self.data.len() as u64;
+            self.data.extend_from_slice(bytes);
+            Ok(addr)
+        }
+        fn write_at(&mut self, offset: u64, bytes: &[u8]) -> Result<(), Error> {
+            let offset = offset.to_usize()?;
+            self.data[offset..offset + bytes.len()].copy_from_slice(bytes);
+            Ok(())
+        }
+        fn patch_superblock_eof(&mut self) -> Result<(), Error> {
+            self.superblock.eof_address = self.data.len() as u64;
+            let bytes = self.superblock.serialize();
+            let off = self.sb_sig_off;
+            self.data[off..off + bytes.len()].copy_from_slice(&bytes);
+            Ok(())
+        }
+        fn sync(&mut self) -> Result<(), Error> {
+            Ok(())
+        }
+    }
+
+    /// Build an in-memory latest-format file with one unlimited chunked i32
+    /// dataset seeded with `0..n`, returning its bytes.
+    fn build_unlimited(n: i32, chunk: u64) -> Vec<u8> {
+        let data: Vec<i32> = (0..n).collect();
+        let mut b = FileBuilder::new();
+        b.create_dataset("d")
+            .with_i32_data(&data)
+            .with_shape(&[n as u64])
+            .with_maxshape(&[u64::MAX])
+            .with_chunks(&[chunk]);
+        b.finish().unwrap()
+    }
+
+    /// Drive the full located-append path (`locate_at` + `plan_ea_append` +
+    /// `apply_ea_append`) through the probe store and return the located state.
+    fn locate(store: &WindowProbeStore) -> (Located, crate::datatype::Datatype) {
+        let oh_addr = group_v2::resolve_path_any(&store.data, &store.superblock, "d").unwrap();
+        let result = Located::locate_at(store, oh_addr, Error::AppendUnsupported).unwrap();
+        let (dt_off, dt_size) = result.spans.datatype;
+        let dt_bytes = store.read_metadata_at(dt_off, dt_size).unwrap();
+        let (datatype, _) = crate::datatype::Datatype::parse(&dt_bytes).unwrap();
+        (result.located, datatype)
+    }
+
+    fn append_i32s(
+        store: &mut WindowProbeStore,
+        loc: &mut Located,
+        datatype: &crate::datatype::Datatype,
+        values: std::ops::Range<i32>,
+    ) {
+        let raw: Vec<u8> = values.clone().flat_map(|v| v.to_le_bytes()).collect();
+        let new_elems = (values.end - values.start) as u64;
+        let spatial = vec![loc.chunk_elems];
+        let plan = plan_ea_append(
+            store,
+            loc,
+            datatype,
+            &spatial,
+            loc.elem_bytes,
+            None,
+            &raw,
+            new_elems,
+        )
+        .unwrap();
+        apply_ea_append(store, loc, &plan, 4).unwrap();
+    }
+
+    /// The engine's bounded-read contract: appends against a file far larger
+    /// than any metadata structure never read more than a bounded window at
+    /// once, and never the whole file.
+    #[test]
+    fn append_reads_stay_bounded_windows() {
+        // ~400 KiB of data: far larger than any single bounded window below.
+        let n = 100_000i32;
+        let mut store = WindowProbeStore::open(build_unlimited(n, 256));
+        let file_len = store.data.len();
+        assert!(
+            file_len > 300_000,
+            "test file unexpectedly small: {file_len}"
+        );
+
+        let (mut loc, datatype) = locate(&store);
+        // Setup (locate + datatype) already obeys the window bound.
+        const WINDOW: usize = 16 * 1024;
+        assert!(
+            store.max_read.get() <= WINDOW,
+            "locate read a {}-byte window (> {WINDOW})",
+            store.max_read.get()
+        );
+
+        // A small append against the large file: every read (trailing chunk,
+        // element slots, checksum regions) stays within the window bound, and
+        // the total read volume is a small constant, not O(file size).
+        store.reset_counters();
+        append_i32s(&mut store, &mut loc, &datatype, n..n + 10);
+        assert!(
+            store.max_read.get() <= WINDOW,
+            "append read a {}-byte window (> {WINDOW})",
+            store.max_read.get()
+        );
+        assert!(
+            store.total_read.get() <= 64 * 1024,
+            "append read {} bytes total (> 64 KiB) on a {file_len}-byte file",
+            store.total_read.get()
+        );
+        assert!(
+            store
+                .reads
+                .borrow()
+                .iter()
+                .all(|&(_, len)| len < file_len / 2),
+            "an append read scaled with file size"
+        );
+
+        // Growth loop: the per-append read volume stays flat as the file grows.
+        let mut worst = 0usize;
+        let mut next = n + 10;
+        for _ in 0..20 {
+            store.reset_counters();
+            append_i32s(&mut store, &mut loc, &datatype, next..next + 300);
+            worst = worst.max(store.total_read.get());
+            next += 300;
+        }
+        assert!(
+            worst <= 64 * 1024,
+            "per-append read volume grew to {worst} bytes"
+        );
+
+        // The grown file reads back correctly through the public reader.
+        let file = crate::File::from_bytes(store.data).unwrap();
+        let ds = file.dataset("d").unwrap();
+        let got = ds.read_i32().unwrap();
+        let expected: Vec<i32> = (0..next).collect();
+        assert_eq!(got.len(), expected.len());
+        assert_eq!(got, expected);
+    }
+
+    /// Unaligned appends rewrite the trailing partial chunk: still bounded — the
+    /// one chunk is the largest data read the plan performs.
+    #[test]
+    fn partial_tail_append_reads_one_chunk_window() {
+        let n = 50_000i32;
+        let chunk = 256u64;
+        let mut store = WindowProbeStore::open(build_unlimited(n + 7, chunk));
+        let (mut loc, datatype) = locate(&store);
+
+        store.reset_counters();
+        append_i32s(&mut store, &mut loc, &datatype, n + 7..n + 7 + 13);
+        let chunk_bytes = (chunk as usize) * 4;
+        assert!(
+            store.max_read.get() <= chunk_bytes.max(8 * 1024),
+            "partial-tail append read a {}-byte window",
+            store.max_read.get()
+        );
+
+        let file = crate::File::from_bytes(store.data).unwrap();
+        let got = file.dataset("d").unwrap().read_i32().unwrap();
+        let expected: Vec<i32> = (0..n + 7 + 13).collect();
+        assert_eq!(got, expected);
+    }
+}

--- a/src/chunk_index_inplace.rs
+++ b/src/chunk_index_inplace.rs
@@ -37,9 +37,9 @@ use crate::extensible_array::{EaGeometry, ExtensibleArrayHeader};
 use crate::file_lock::{self, FileLocking};
 use crate::filter_pipeline::FilterPipeline;
 use crate::filters::{ChunkContext, compress_chunk, decompress_chunk};
-use crate::group_v2;
 use crate::message_type::MessageType;
 use crate::signature;
+use crate::source::{BytesSource, Source};
 use crate::superblock::Superblock;
 
 /// The undefined-address sentinel for a given offset size.
@@ -205,39 +205,39 @@ impl InPlaceFile {
     }
 }
 
-/// Byte-level in-place I/O the Extensible-Array growth engine ([`Located`])
-/// depends on, abstracted over its two owners: [`InPlaceFile`] (the append/SWMR
-/// writers' own mirror + handle) and [`EditSession`](crate::EditSession)'s
-/// borrowed mirror. Genericizing the engine over this trait lets a long-lived
+/// Writable byte-level I/O the Extensible-Array growth engine ([`Located`])
+/// depends on, extending the read-only [`Source`] seam with in-place mutation.
+/// Its owners today are [`InPlaceFile`] (the append/SWMR writers' own mirror +
+/// handle) and [`EditSession`](crate::EditSession)'s borrowed mirror; issue #147's
+/// bounded backend adds a store with no mirror at all, which is why every engine
+/// *read* goes through [`Source`] (bounded, random-access) rather than a
+/// whole-file `&[u8]`. Genericizing the engine over this trait lets a long-lived
 /// `EditSession` drive an O(1) in-place append against its *own* single mirror and
 /// exclusive lock rather than constructing a second `InPlaceFile` (which would
 /// take a second exclusive lock and keep a divergent mirror). Each owner keeps its
 /// own crash-safety discipline for the primitives — `InPlaceFile` mirrors before
 /// disk, the edit mirror writes disk before mirror — while sharing the checksummed
 /// slot/block/super-block mechanics through the derived operations below.
-pub(crate) trait InPlaceBytes {
-    /// The full in-memory mirror of the file.
-    fn data(&self) -> &[u8];
+pub(crate) trait Store: Source {
     /// This file's address (offset) field width in bytes.
     fn offset_size(&self) -> u8;
     /// This file's length field width in bytes.
     fn length_size(&self) -> u8;
-    fn superblock(&self) -> &Superblock;
 
     /// Append `bytes` at end-of-file, returning their start address. The bytes are
     /// made durable-visible immediately (not buffered until the next `sync`), so a
     /// later in-place patch of the region lands on bytes that already exist.
     fn append_bytes(&mut self, bytes: &[u8]) -> Result<u64, Error>;
     /// Overwrite `[offset, offset + bytes.len())` in place.
-    fn write_at(&mut self, offset: usize, bytes: &[u8]) -> Result<(), Error>;
-    /// Advance the superblock's recorded end-of-file to the current mirror length
-    /// and rewrite the superblock.
+    fn write_at(&mut self, offset: u64, bytes: &[u8]) -> Result<(), Error>;
+    /// Advance the superblock's recorded end-of-file to the store's current
+    /// logical length and rewrite the superblock.
     fn patch_superblock_eof(&mut self) -> Result<(), Error>;
     /// Flush buffered writes to durable storage (an `fsync` barrier).
     fn sync(&mut self) -> Result<(), Error>;
 
     /// Write an offset-sized address at `offset`.
-    fn write_addr_at(&mut self, offset: usize, addr: u64) -> Result<(), Error> {
+    fn write_addr_at(&mut self, offset: u64, addr: u64) -> Result<(), Error> {
         #[expect(
             clippy::cast_possible_truncation,
             reason = "the 4-byte arm is taken only when this file's offset_size is 4 bytes"
@@ -249,7 +249,7 @@ pub(crate) trait InPlaceBytes {
     }
 
     /// Write a length-sized value at `offset`.
-    fn write_length_at(&mut self, offset: usize, val: u64) -> Result<(), Error> {
+    fn write_length_at(&mut self, offset: u64, val: u64) -> Result<(), Error> {
         #[expect(
             clippy::cast_possible_truncation,
             reason = "the 4-byte arm is taken only when this file's length_size is 4 bytes"
@@ -260,40 +260,44 @@ pub(crate) trait InPlaceBytes {
         }
     }
 
-    /// Read an offset-sized address at `offset` from the mirror.
-    fn read_addr_at(&self, offset: usize) -> u64 {
-        match self.offset_size() {
-            4 => u32::from_le_bytes(self.data()[offset..offset + 4].try_into().unwrap()) as u64,
-            _ => u64::from_le_bytes(self.data()[offset..offset + 8].try_into().unwrap()),
-        }
+    /// Read an offset-sized address at `offset`.
+    fn read_addr_at(&self, offset: u64) -> Result<u64, Error> {
+        let mut buf = [0u8; 8];
+        let width = if self.offset_size() == 4 { 4 } else { 8 };
+        self.read_at(offset, &mut buf[..width])?;
+        Ok(u64::from_le_bytes(buf))
     }
 
     /// Recompute the Jenkins checksum over `[start, cks_off)` and store it at
     /// `cks_off`.
-    fn rechecksum_range(&mut self, start: usize, cks_off: usize) -> Result<(), Error> {
-        let cks = jenkins_lookup3(&self.data()[start..cks_off]);
+    fn rechecksum_range(&mut self, start: u64, cks_off: u64) -> Result<(), Error> {
+        let bytes = self.read_exact_at(start, (cks_off - start).to_usize()?)?;
+        let cks = jenkins_lookup3(&bytes);
         self.write_at(cks_off, &cks.to_le_bytes())
     }
 }
 
-impl InPlaceBytes for InPlaceFile {
-    fn data(&self) -> &[u8] {
-        &self.data
+impl Source for InPlaceFile {
+    fn len(&self) -> u64 {
+        self.data.len() as u64
     }
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), crate::error::FormatError> {
+        BytesSource::new(&self.data).read_at(offset, buf)
+    }
+}
+
+impl Store for InPlaceFile {
     fn offset_size(&self) -> u8 {
         self.offset_size
     }
     fn length_size(&self) -> u8 {
         self.length_size
     }
-    fn superblock(&self) -> &Superblock {
-        &self.superblock
-    }
     fn append_bytes(&mut self, bytes: &[u8]) -> Result<u64, Error> {
         InPlaceFile::append_bytes(self, bytes)
     }
-    fn write_at(&mut self, offset: usize, bytes: &[u8]) -> Result<(), Error> {
-        InPlaceFile::write_at(self, offset, bytes)
+    fn write_at(&mut self, offset: u64, bytes: &[u8]) -> Result<(), Error> {
+        InPlaceFile::write_at(self, offset.to_usize()?, bytes)
     }
     fn patch_superblock_eof(&mut self) -> Result<(), Error> {
         InPlaceFile::patch_superblock_eof(self)
@@ -303,13 +307,13 @@ impl InPlaceBytes for InPlaceFile {
     }
 }
 
-/// Byte offsets (into [`InPlaceFile::data`]) of the object-header messages a
-/// caller may need to parse after locating a dataset.
+/// Absolute file offsets of the object-header messages a caller may need to
+/// parse after locating a dataset.
 pub(crate) struct MessageSpans {
     /// `(data_off, size)` of the Datatype message.
-    pub datatype: (usize, usize),
+    pub datatype: (u64, usize),
     /// `(data_off, size)` of the Filter Pipeline message, when present.
-    pub filter: Option<(usize, usize)>,
+    pub filter: Option<(u64, usize)>,
 }
 
 /// Result of locating a dataset: its maintained geometry plus the message spans
@@ -323,14 +327,14 @@ pub(crate) struct LocateResult {
 /// Metadata located once per dataset, then maintained across appends.
 pub(crate) struct Located {
     /// File offset of the dataspace message's first current-dimension value.
-    pub dim0_off: usize,
+    pub dim0_off: u64,
     /// Current length along the unlimited (axis-0) dimension.
     pub current_dim: u64,
     /// Object-header chunk that contains the dataspace message: the byte range
     /// whose Jenkins checksum must be recomputed after patching the dimension.
     /// The checksum itself occupies `chunk_msg_end .. chunk_msg_end + 4`.
-    pub ohdr_chunk_start: usize,
-    pub ohdr_chunk_msg_end: usize,
+    pub ohdr_chunk_start: u64,
+    pub ohdr_chunk_msg_end: u64,
 
     /// Elements per chunk along axis 0 (the only varying axis for rank 1).
     pub chunk_elems: u64,
@@ -343,7 +347,7 @@ pub(crate) struct Located {
     /// filtered (`address + compressed_size + filter_mask` element).
     pub client_id: u8,
     /// Extensible Array header address and derived geometry.
-    pub ea_addr: usize,
+    pub ea_addr: u64,
     pub geom: EaGeometry,
     pub idx_blk_elmts: u64,
     /// Size of one stored EA element in bytes (offset size for unfiltered; wider
@@ -353,30 +357,25 @@ pub(crate) struct Located {
     /// Block-offset field width inside EA blocks (= ceil(max_nelmts_bits / 8)).
     pub blk_off_size: usize,
     /// Address of the EA index block (`EAIB`).
-    pub index_block_addr: usize,
+    pub index_block_addr: u64,
     /// Current number of chunks indexed (EA element count).
     pub num_chunks: u64,
 }
 
 impl Located {
-    /// Locate `dataset` in `file`, deriving its dataspace/layout/Extensible-Array
-    /// geometry. Filter-neutral: it records whether the dataset is filtered and
-    /// returns the datatype/filter message spans, leaving the accept/reject
-    /// policy to the caller. `unsupported` builds the caller's "unsupported
-    /// target" error so each writer reports through its own variant.
-    pub(crate) fn locate<F: InPlaceBytes>(
-        file: &F,
-        dataset: &str,
-        unsupported: fn(&'static str) -> Error,
-    ) -> Result<LocateResult, Error> {
-        let oh_addr = group_v2::resolve_path_any(file.data(), file.superblock(), dataset)?;
-        Self::locate_at(file, oh_addr, unsupported)
-    }
-
-    /// Like [`locate`](Self::locate), but for a dataset whose object-header
-    /// address is already known — an owned handle carries its address, so the
-    /// path-resolution step is skipped.
-    pub(crate) fn locate_at<F: InPlaceBytes>(
+    /// Locate the dataset whose object-header address is `oh_addr`, deriving its
+    /// dataspace/layout/Extensible-Array geometry. Filter-neutral: it records
+    /// whether the dataset is filtered and returns the datatype/filter message
+    /// spans, leaving the accept/reject policy to the caller. `unsupported`
+    /// builds the caller's "unsupported target" error so each writer reports
+    /// through its own variant. Path resolution is the caller's job: an owned
+    /// handle already carries its address, and the path-addressed writers
+    /// resolve against their own mirrors.
+    ///
+    /// Every read is a bounded [`Source`] window (the object-header chunks, one
+    /// message span, the EA header), so this works over a store with no
+    /// whole-file mirror.
+    pub(crate) fn locate_at<F: Store>(
         file: &F,
         oh_addr: u64,
         unsupported: fn(&'static str) -> Error,
@@ -384,7 +383,7 @@ impl Located {
         let os = file.offset_size();
         let ls = file.length_size();
 
-        let walk = walk_v2_object_header(file.data(), oh_addr.to_usize()?, os, ls)?;
+        let walk = walk_v2_object_header(file, oh_addr, os, ls)?;
 
         let dataspace_msg = walk
             .messages
@@ -407,9 +406,8 @@ impl Located {
             .find(|m| m.msg_type == MessageType::FilterPipeline);
 
         // Parse the dataspace: must be rank 1 with one unlimited dimension.
-        let data = file.data();
-        let ds_bytes = &data[dataspace_msg.data_off..dataspace_msg.data_off + dataspace_msg.size];
-        let dataspace = Dataspace::parse(ds_bytes, ls)?;
+        let ds_bytes = file.read_metadata_at(dataspace_msg.data_off, dataspace_msg.size)?;
+        let dataspace = Dataspace::parse(&ds_bytes, ls)?;
         if dataspace.rank != 1 {
             return Err(unsupported("only rank-1 datasets are supported"));
         }
@@ -424,15 +422,15 @@ impl Located {
         let dim0_off = dataspace_msg.data_off + 4;
 
         // Parse the layout: must be a v4 chunked Extensible Array (index type 4).
-        let layout_bytes = &data[layout_msg.data_off..layout_msg.data_off + layout_msg.size];
-        let layout = DataLayout::parse(layout_bytes, os, ls)?;
+        let layout_bytes = file.read_metadata_at(layout_msg.data_off, layout_msg.size)?;
+        let layout = DataLayout::parse(&layout_bytes, os, ls)?;
         let (ea_addr, chunk_dims) = match layout {
             DataLayout::Chunked {
                 chunk_index_type: Some(4),
                 btree_address: Some(addr),
                 chunk_dimensions,
                 ..
-            } => (addr.to_usize()?, chunk_dimensions),
+            } => (addr, chunk_dimensions),
             DataLayout::Chunked {
                 chunk_index_type: Some(4),
                 btree_address: None,
@@ -472,7 +470,7 @@ impl Located {
         }
         let chunk_bytes = chunk_elems.to_usize()? * elem_bytes;
 
-        let ea_header = ExtensibleArrayHeader::parse(data, ea_addr, os, ls)?;
+        let ea_header = ExtensibleArrayHeader::parse_from_source(file, ea_addr, os, ls)?;
         let has_filters = filter_msg.is_some();
         if (ea_header.client_id == 1) != has_filters {
             return Err(unsupported(
@@ -492,7 +490,7 @@ impl Located {
         let geom = EaGeometry::from_header(&ea_header);
         let page_nelmts = 1u64 << ea_header.max_dblk_nelmts_bits;
         let blk_off_size = (ea_header.max_nelmts_bits as usize).div_ceil(8);
-        let index_block_addr = ea_header.index_block_address.to_usize()?;
+        let index_block_addr = ea_header.index_block_address;
         // The dataspace dimension is the single commit point; the EA element
         // count is published one step earlier. If a prior writer crashed between
         // the two, the on-disk EA count is ahead of the committed dimension. Seed
@@ -536,10 +534,10 @@ impl Located {
     /// For an unfiltered array only the address is written; for a filtered array
     /// the full `address + compressed_size + filter_mask` record is written,
     /// refusing a stored size that does not fit the array's fixed element width.
-    fn write_element_at<F: InPlaceBytes>(
+    fn write_element_at<F: Store>(
         &self,
         file: &mut F,
-        off: usize,
+        off: u64,
         rec: ElemRecord,
     ) -> Result<(), Error> {
         if self.client_id == 0 {
@@ -553,47 +551,49 @@ impl Located {
             ));
         }
         file.write_addr_at(off, rec.addr)?;
-        file.write_at(off + os, &rec.stored_size.to_le_bytes()[..csz])?;
-        file.write_at(off + os + csz, &rec.filter_mask.to_le_bytes())
+        file.write_at(off + os as u64, &rec.stored_size.to_le_bytes()[..csz])?;
+        file.write_at(off + (os + csz) as u64, &rec.filter_mask.to_le_bytes())
     }
 
     /// Read the element record stored at byte offset `off`.
-    fn read_element_at<F: InPlaceBytes>(&self, file: &F, off: usize) -> ElemRecord {
+    fn read_element_at<F: Store>(&self, file: &F, off: u64) -> Result<ElemRecord, Error> {
         let os = file.offset_size() as usize;
-        let addr = file.read_addr_at(off);
         if self.client_id == 0 {
-            return ElemRecord::addr_only(addr);
+            return Ok(ElemRecord::addr_only(file.read_addr_at(off)?));
         }
+        // One bounded read of the whole fixed-width element record.
+        let elem = file.read_exact_at(off, self.ea_elem_size)?;
+        let addr_w = if file.offset_size() == 4 { 4 } else { 8 };
+        let mut a = [0u8; 8];
+        a[..addr_w].copy_from_slice(&elem[..addr_w]);
+        let addr = u64::from_le_bytes(a);
         let csz = self.ea_elem_size - os - 4;
-        let data = file.data();
         let mut stored_size = 0u64;
         for i in 0..csz {
-            stored_size |= (data[off + os + i] as u64) << (8 * i);
+            stored_size |= (elem[os + i] as u64) << (8 * i);
         }
-        let fm = off + os + csz;
-        let filter_mask = u32::from_le_bytes([data[fm], data[fm + 1], data[fm + 2], data[fm + 3]]);
-        ElemRecord {
+        let fm = os + csz;
+        let filter_mask = u32::from_le_bytes([elem[fm], elem[fm + 1], elem[fm + 2], elem[fm + 3]]);
+        Ok(ElemRecord {
             addr,
             stored_size,
             filter_mask,
-        }
+        })
     }
 
     /// Byte offset of element `e`'s record, or `None` when the containing block
     /// (or super block) is not yet allocated, i.e. the element does not exist on
     /// disk yet.
-    fn elem_slot_off<F: InPlaceBytes>(&self, file: &F, e: u64) -> Result<Option<usize>, Error> {
+    fn elem_slot_off<F: Store>(&self, file: &F, e: u64) -> Result<Option<u64>, Error> {
         let os = file.offset_size() as usize;
-        let elem_size = self.ea_elem_size;
+        let elem_size = self.ea_elem_size as u64;
         let idx = self.idx_blk_elmts;
         let blk_off = self.blk_off_size;
         let page_nelmts = self.page_nelmts;
 
         if e < idx {
-            let ib_prefix = 4 + 1 + 1 + os;
-            return Ok(Some(
-                self.index_block_addr + ib_prefix + e.to_usize()? * elem_size,
-            ));
+            let ib_prefix = (4 + 1 + 1 + os) as u64;
+            return Ok(Some(self.index_block_addr + ib_prefix + e * elem_size));
         }
 
         let region = locate_data_block(&self.geom, idx, e);
@@ -603,13 +603,13 @@ impl Located {
             ));
         }
         let is_paged = region.dblk_nelmts > page_nelmts;
-        let slot = (e - region.db_start).to_usize()?;
+        let slot = e - region.db_start;
 
         // Resolve the owning super block (if any) and the data-block pointer,
         // returning None if either is unallocated.
         let sblk_addr = match region.parent {
             Parent::Super { sblk_j, .. } => {
-                let a = self.super_block_addr(file, sblk_j);
+                let a = self.super_block_addr(file, sblk_j)?;
                 if is_undef(a, file.offset_size()) {
                     return Ok(None);
                 }
@@ -618,21 +618,20 @@ impl Located {
             Parent::IndexDirect { .. } => None,
         };
         let dblk_ptr_off = self.dblk_ptr_off(sblk_addr, &region, os, blk_off)?;
-        let dblk_addr = file.read_addr_at(dblk_ptr_off);
+        let dblk_addr = file.read_addr_at(dblk_ptr_off)?;
         if is_undef(dblk_addr, file.offset_size()) {
             return Ok(None);
         }
 
         let off = if !is_paged {
-            let db_prefix = 4 + 1 + 1 + os + blk_off;
-            dblk_addr.to_usize()? + db_prefix + slot * elem_size
+            let db_prefix = (4 + 1 + 1 + os + blk_off) as u64;
+            dblk_addr + db_prefix + slot * elem_size
         } else {
-            let page_nelmts = page_nelmts.to_usize()?;
-            let header_size = 4 + 1 + 1 + os + blk_off + 4;
+            let header_size = (4 + 1 + 1 + os + blk_off + 4) as u64;
             let page = slot / page_nelmts;
             let slot_in_page = slot % page_nelmts;
             let page_bytes = page_nelmts * elem_size + 4;
-            let page_off = dblk_addr.to_usize()? + header_size + page * page_bytes;
+            let page_off = dblk_addr + header_size + page * page_bytes;
             page_off + slot_in_page * elem_size
         };
         Ok(Some(off))
@@ -646,14 +645,14 @@ impl Located {
         region: &DataBlockLoc,
         os: usize,
         blk_off: usize,
-    ) -> Result<usize, Error> {
+    ) -> Result<u64, Error> {
         match region.parent {
             Parent::IndexDirect { ordinal } => {
-                let ib_prefix = 4 + 1 + 1 + os;
+                let ib_prefix = (4 + 1 + 1 + os) as u64;
                 Ok(self.index_block_addr
                     + ib_prefix
-                    + self.idx_blk_elmts.to_usize()? * self.ea_elem_size
-                    + ordinal * os)
+                    + self.idx_blk_elmts * self.ea_elem_size as u64
+                    + (ordinal * os) as u64)
             }
             Parent::Super { dblk_local, .. } => {
                 let sblk_addr = sblk_addr.expect("super-block address resolved for a Super parent");
@@ -671,7 +670,7 @@ impl Located {
     }
 
     /// Read element `e`, or `None` if its slot is not allocated / is undefined.
-    pub(crate) fn read_element<F: InPlaceBytes>(
+    pub(crate) fn read_element<F: Store>(
         &self,
         file: &F,
         e: u64,
@@ -679,7 +678,7 @@ impl Located {
         match self.elem_slot_off(file, e)? {
             None => Ok(None),
             Some(off) => {
-                let rec = self.read_element_at(file, off);
+                let rec = self.read_element_at(file, off)?;
                 if is_undef(rec.addr, file.offset_size()) {
                     Ok(None)
                 } else {
@@ -695,21 +694,21 @@ impl Located {
     /// block is allocated on first touch) and an in-place update of an existing
     /// element (the block already exists, so it is reused rather than
     /// re-allocated). Handles non-paged and paged data blocks.
-    pub(crate) fn ea_insert<F: InPlaceBytes>(
+    pub(crate) fn ea_insert<F: Store>(
         &self,
         file: &mut F,
         e: u64,
         rec: ElemRecord,
     ) -> Result<(), Error> {
         let os = file.offset_size() as usize;
-        let elem_size = self.ea_elem_size;
+        let elem_size = self.ea_elem_size as u64;
         let idx = self.idx_blk_elmts;
         let blk_off = self.blk_off_size;
 
         // Inline element slots live directly in the index block.
         if e < idx {
-            let ib_prefix = 4 + 1 + 1 + os;
-            let slot_off = self.index_block_addr + ib_prefix + e.to_usize()? * elem_size;
+            let ib_prefix = (4 + 1 + 1 + os) as u64;
+            let slot_off = self.index_block_addr + ib_prefix + e * elem_size;
             self.write_element_at(file, slot_off, rec)?;
             self.rechecksum_index_block(file)?;
             return Ok(());
@@ -723,7 +722,7 @@ impl Located {
         }
         let dblk_nelmts = region.dblk_nelmts;
         let is_paged = dblk_nelmts > self.page_nelmts;
-        let slot = (e - region.db_start).to_usize()?;
+        let slot = e - region.db_start;
         let block_offset_rel = region.db_start - idx;
         let ndblks = region.ndblks;
 
@@ -744,7 +743,7 @@ impl Located {
         // pointer being undefined -- rather than on `slot == 0` -- makes an
         // in-place element update reuse the existing block instead of leaking it.
         let dblk_ptr_off = self.dblk_ptr_off(sblk_addr, &region, os, blk_off)?;
-        let existing = file.read_addr_at(dblk_ptr_off);
+        let existing = file.read_addr_at(dblk_ptr_off)?;
         let dblk_addr = if is_undef(existing, file.offset_size()) {
             let new_addr = if is_paged {
                 self.alloc_undef_paged_data_block(file, dblk_nelmts, block_offset_rel)?
@@ -769,28 +768,27 @@ impl Located {
         };
 
         if !is_paged {
-            let db_prefix = 4 + 1 + 1 + os + blk_off;
-            let dblk_addr = dblk_addr.to_usize()?;
+            let db_prefix = (4 + 1 + 1 + os + blk_off) as u64;
             let elem_off = dblk_addr + db_prefix + slot * elem_size;
             self.write_element_at(file, elem_off, rec)?;
-            let cks_off = dblk_addr + db_prefix + dblk_nelmts.to_usize()? * elem_size;
+            let cks_off = dblk_addr + db_prefix + dblk_nelmts * elem_size;
             file.rechecksum_range(dblk_addr, cks_off)?;
         } else {
-            let page_nelmts = self.page_nelmts.to_usize()?;
-            let header_size = 4 + 1 + 1 + os + blk_off + 4;
+            let page_nelmts = self.page_nelmts;
+            let header_size = (4 + 1 + 1 + os + blk_off + 4) as u64;
             let page = slot / page_nelmts;
             let slot_in_page = slot % page_nelmts;
             let page_bytes = page_nelmts * elem_size + 4;
-            let page_off = dblk_addr.to_usize()? + header_size + page * page_bytes;
+            let page_off = dblk_addr + header_size + page * page_bytes;
             self.write_element_at(file, page_off + slot_in_page * elem_size, rec)?;
             let page_cks_off = page_off + page_nelmts * elem_size;
             file.rechecksum_range(page_off, page_cks_off)?;
 
             if slot_in_page == 0 {
                 let sblk_addr = sblk_addr.unwrap();
-                let npages = (dblk_nelmts / self.page_nelmts).to_usize()?;
+                let npages = dblk_nelmts / self.page_nelmts;
                 if let Parent::Super { dblk_local, .. } = region.parent {
-                    let global_page = dblk_local * npages + page;
+                    let global_page = dblk_local as u64 * npages + page;
                     self.set_sb_page_bit(file, sblk_addr, blk_off, global_page)?;
                     self.rechecksum_super_block(
                         file,
@@ -808,22 +806,21 @@ impl Located {
 
     /// Address of an already-allocated super block (`sblk_j`-th super-block
     /// pointer in the index block); the undefined sentinel when not yet allocated.
-    fn super_block_addr<F: InPlaceBytes>(&self, file: &F, sblk_j: usize) -> u64 {
+    fn super_block_addr<F: Store>(&self, file: &F, sblk_j: usize) -> Result<u64, Error> {
         let os = file.offset_size() as usize;
-        let ib_prefix = 4 + 1 + 1 + os;
+        let ib_prefix = (4 + 1 + 1 + os) as u64;
         let ndblk_addrs = self.geom.direct_dblk_nelmts.len();
         let slot_off = self.index_block_addr
             + ib_prefix
-            + self.idx_blk_elmts.to_usize().unwrap_or(0) * self.ea_elem_size
-            + ndblk_addrs * os
-            + sblk_j * os;
+            + self.idx_blk_elmts * self.ea_elem_size as u64
+            + ((ndblk_addrs + sblk_j) * os) as u64;
         file.read_addr_at(slot_off)
     }
 
     /// Return the address of super block `sblk_j`, allocating an empty one (all
     /// data-block pointers undefined, plus a zeroed page-init bitmap when its data
     /// blocks are paged) at EOF if it does not exist yet.
-    fn ensure_super_block<F: InPlaceBytes>(
+    fn ensure_super_block<F: Store>(
         &self,
         file: &mut F,
         sblk_j: usize,
@@ -831,18 +828,18 @@ impl Located {
         ndblks: u64,
         dblk_nelmts: u64,
     ) -> Result<u64, Error> {
-        let existing = self.super_block_addr(file, sblk_j);
+        let existing = self.super_block_addr(file, sblk_j)?;
         if !is_undef(existing, file.offset_size()) {
             return Ok(existing);
         }
         let os = file.offset_size() as usize;
-        let ib_prefix = 4 + 1 + 1 + os;
+        let ib_prefix = (4 + 1 + 1 + os) as u64;
         let ndblk_addrs = self.geom.direct_dblk_nelmts.len();
 
         let bitmap = vec![0u8; sb_bitmap_size(ndblks, dblk_nelmts, self.page_nelmts)?];
         let undef = vec![undef_addr(file.offset_size()); ndblks.to_usize()?];
         let aesb = crate::chunked_write::build_aesb(
-            self.ea_addr as u64,
+            self.ea_addr,
             sb_block_offset,
             &bitmap,
             &undef,
@@ -854,9 +851,8 @@ impl Located {
 
         let slot_off = self.index_block_addr
             + ib_prefix
-            + self.idx_blk_elmts.to_usize()? * self.ea_elem_size
-            + ndblk_addrs * os
-            + sblk_j * os;
+            + self.idx_blk_elmts * self.ea_elem_size as u64
+            + ((ndblk_addrs + sblk_j) * os) as u64;
         file.write_addr_at(slot_off, new_addr)?;
         self.rechecksum_index_block(file)?;
         Ok(new_addr)
@@ -864,7 +860,7 @@ impl Located {
 
     /// Allocate a fresh non-paged data block (`EADB`) at EOF with every element
     /// slot undefined, returning its address.
-    fn alloc_undef_data_block<F: InPlaceBytes>(
+    fn alloc_undef_data_block<F: Store>(
         &self,
         file: &mut F,
         dblk_nelmts: u64,
@@ -875,7 +871,7 @@ impl Located {
         buf.extend_from_slice(b"EADB");
         buf.push(0); // version
         buf.push(self.client_id);
-        write_ea_addr(&mut buf, self.ea_addr as u64, os);
+        write_ea_addr(&mut buf, self.ea_addr, os);
         buf.extend_from_slice(&block_offset_rel.to_le_bytes()[..self.blk_off_size]);
         for _ in 0..dblk_nelmts {
             push_undef_element(&mut buf, os, self.ea_elem_size);
@@ -888,7 +884,7 @@ impl Located {
     /// Allocate a fresh *paged* data block (`EADB`) at EOF: a header carrying its
     /// own checksum, followed by `dblk_nelmts / page_nelmts` fully-undefined pages
     /// (each `page_nelmts` undefined elements + a checksum).
-    fn alloc_undef_paged_data_block<F: InPlaceBytes>(
+    fn alloc_undef_paged_data_block<F: Store>(
         &self,
         file: &mut F,
         dblk_nelmts: u64,
@@ -900,7 +896,7 @@ impl Located {
         buf.extend_from_slice(b"EADB");
         buf.push(0); // version
         buf.push(self.client_id);
-        write_ea_addr(&mut buf, self.ea_addr as u64, os);
+        write_ea_addr(&mut buf, self.ea_addr, os);
         buf.extend_from_slice(&block_offset_rel.to_le_bytes()[..self.blk_off_size]);
         let header_cks = jenkins_lookup3(&buf);
         buf.extend_from_slice(&header_cks.to_le_bytes());
@@ -919,37 +915,37 @@ impl Located {
     }
 
     /// Set page `global_page`'s bit in a super block's page-init bitmap
-    /// (MSB-first), in memory and on disk.
-    fn set_sb_page_bit<F: InPlaceBytes>(
+    /// (MSB-first).
+    fn set_sb_page_bit<F: Store>(
         &self,
         file: &mut F,
         sblk_addr: u64,
         blk_off: usize,
-        global_page: usize,
+        global_page: u64,
     ) -> Result<(), Error> {
         let os = file.offset_size() as usize;
-        let bitmap_start = sblk_addr.to_usize()? + 4 + 1 + 1 + os + blk_off;
+        let bitmap_start = sblk_addr + (4 + 1 + 1 + os + blk_off) as u64;
         let byte = bitmap_start + global_page / 8;
         let mask = 0x80u8 >> (global_page % 8);
-        let v = file.data()[byte] | mask;
-        file.write_at(byte, &[v])
+        let mut v = [0u8; 1];
+        file.read_at(byte, &mut v)?;
+        file.write_at(byte, &[v[0] | mask])
     }
 
     /// Recompute the index block checksum from the located dataset metadata.
-    fn rechecksum_index_block<F: InPlaceBytes>(&self, file: &mut F) -> Result<(), Error> {
+    fn rechecksum_index_block<F: Store>(&self, file: &mut F) -> Result<(), Error> {
         let os = file.offset_size() as usize;
-        let ib_prefix = 4 + 1 + 1 + os;
+        let ib_prefix = (4 + 1 + 1 + os) as u64;
         let ndblk_addrs = self.geom.direct_dblk_nelmts.len();
         let nsblk_addrs = self.geom.nsblk_addrs;
         let cks_off = self.index_block_addr
             + ib_prefix
-            + self.idx_blk_elmts.to_usize()? * self.ea_elem_size
-            + ndblk_addrs * os
-            + nsblk_addrs * os;
+            + self.idx_blk_elmts * self.ea_elem_size as u64
+            + ((ndblk_addrs + nsblk_addrs) * os) as u64;
         file.rechecksum_range(self.index_block_addr, cks_off)
     }
 
-    fn rechecksum_super_block<F: InPlaceBytes>(
+    fn rechecksum_super_block<F: Store>(
         &self,
         file: &mut F,
         sblk_addr: u64,
@@ -959,15 +955,14 @@ impl Located {
         blk_off: usize,
     ) -> Result<(), Error> {
         let os = file.offset_size() as usize;
-        let prefix = 4 + 1 + 1 + os + blk_off;
-        let bitmap = sb_bitmap_size(ndblks, dblk_nelmts, page_nelmts)?;
-        let sblk_off = sblk_addr.to_usize()?;
-        let cks_off = sblk_off + prefix + bitmap + ndblks.to_usize()? * os;
-        file.rechecksum_range(sblk_off, cks_off)
+        let prefix = (4 + 1 + 1 + os + blk_off) as u64;
+        let bitmap = sb_bitmap_size(ndblks, dblk_nelmts, page_nelmts)? as u64;
+        let cks_off = sblk_addr + prefix + bitmap + ndblks * os as u64;
+        file.rechecksum_range(sblk_addr, cks_off)
     }
 
     /// Patch the six EA header statistics and recompute the header checksum.
-    pub(crate) fn update_ea_header<F: InPlaceBytes>(
+    pub(crate) fn update_ea_header<F: Store>(
         &self,
         file: &mut F,
         num_chunks: u64,
@@ -981,7 +976,7 @@ impl Located {
             self.blk_off_size,
             num_chunks,
         );
-        let ls = file.length_size() as usize;
+        let ls = file.length_size() as u64;
         let ea_addr = self.ea_addr;
         file.write_length_at(ea_addr + 12, stats.nsuper_blks)?;
         file.write_length_at(ea_addr + 12 + ls, stats.super_blk_size)?;
@@ -990,14 +985,14 @@ impl Located {
         file.write_length_at(ea_addr + 12 + 4 * ls, stats.max_idx_set)?;
         file.write_length_at(ea_addr + 12 + 5 * ls, stats.nelmts)?;
         let aehd_size =
-            ExtensibleArrayHeader::serialized_size(file.offset_size(), file.length_size());
+            ExtensibleArrayHeader::serialized_size(file.offset_size(), file.length_size()) as u64;
         let cks_off = ea_addr + aehd_size - 4;
         file.rechecksum_range(ea_addr, cks_off)
     }
 
     /// Publish `new_dim` as the dataspace axis-0 dimension (the commit point) and
     /// recompute the containing object-header chunk's checksum.
-    pub(crate) fn patch_dimension<F: InPlaceBytes>(
+    pub(crate) fn patch_dimension<F: Store>(
         &self,
         file: &mut F,
         new_dim: u64,
@@ -1033,7 +1028,7 @@ pub(crate) struct AppendPlan {
 /// filtered append is refused here rather than repointing a multi-field trailing
 /// element whose in-place overwrite is not power-loss atomic; use
 /// [`EditSession::append_dataset`](crate::EditSession::append_dataset) for that.
-pub(crate) fn plan_ea_append<F: InPlaceBytes>(
+pub(crate) fn plan_ea_append<F: Store>(
     file: &F,
     loc: &Located,
     datatype: &Datatype,
@@ -1078,27 +1073,25 @@ pub(crate) fn plan_ea_append<F: InPlaceBytes>(
             .ok_or(Error::AppendUnsupported(
                 "trailing partial chunk is missing from the index",
             ))?;
-        let start = usize::try_from(rec.addr)
-            .map_err(|_| Error::AppendUnsupported("chunk address exceeds this platform"))?;
         let stored_len = if pipeline.is_some() {
             usize::try_from(rec.stored_size)
                 .map_err(|_| Error::AppendUnsupported("chunk size exceeds this platform"))?
         } else {
             chunk_elems.to_usize()? * element_size
         };
-        let data = file.data();
-        let end = start
-            .checked_add(stored_len)
-            .filter(|&e| e <= data.len())
+        rec.addr
+            .checked_add(stored_len as u64)
+            .filter(|&e| e <= file.len())
             .ok_or(Error::AppendUnsupported(
                 "trailing chunk extends past end-of-file",
             ))?;
-        let stored = &data[start..end];
+        // One bounded read of the single trailing chunk.
+        let stored = file.read_exact_at(rec.addr, stored_len)?;
         let full = if let Some(pl) = pipeline {
             let ctx = ChunkContext::from_datatype(spatial, datatype);
-            decompress_chunk(stored, pl, ctx, rec.filter_mask).map_err(Error::Format)?
+            decompress_chunk(&stored, pl, ctx, rec.filter_mask).map_err(Error::Format)?
         } else {
-            stored.to_vec()
+            stored
         };
         let live_elems = usize::try_from(current_dim % chunk_elems)
             .map_err(|_| Error::AppendUnsupported("chunk length exceeds this platform"))?;
@@ -1145,7 +1138,7 @@ pub(crate) fn plan_ea_append<F: InPlaceBytes>(
 /// general append writer and `EditSession`'s in-place append so this ordered
 /// write sequence — the crash-safety heart of the engine — lives in exactly one
 /// place and is never copy-pasted.
-pub(crate) fn apply_ea_append<F: InPlaceBytes>(
+pub(crate) fn apply_ea_append<F: Store>(
     file: &mut F,
     loc: &mut Located,
     plan: &AppendPlan,
@@ -1225,10 +1218,10 @@ fn sb_dblk_slot_off(
     dblk_nelmts: u64,
     page_nelmts: u64,
     blk_off: usize,
-) -> Result<usize, Error> {
-    let prefix = 4 + 1 + 1 + os + blk_off;
-    let bitmap = sb_bitmap_size(ndblks, dblk_nelmts, page_nelmts)?;
-    Ok(sblk_addr.to_usize()? + prefix + bitmap + dblk_local * os)
+) -> Result<u64, Error> {
+    let prefix = (4 + 1 + 1 + os + blk_off) as u64;
+    let bitmap = sb_bitmap_size(ndblks, dblk_nelmts, page_nelmts)? as u64;
+    Ok(sblk_addr + prefix + bitmap + (dblk_local * os) as u64)
 }
 
 // ---------------------------------------------------------------------------
@@ -1306,12 +1299,13 @@ fn locate_data_block(geom: &EaGeometry, idx_blk_elmts: u64, e: u64) -> DataBlock
 
 struct WalkedMessage {
     msg_type: MessageType,
-    data_off: usize,
+    /// Absolute file offset of the message body.
+    data_off: u64,
     size: usize,
     /// Containing chunk's checksum coverage: `[chunk_start, chunk_msg_end)`, with
     /// the 4-byte checksum stored at `chunk_msg_end`.
-    chunk_start: usize,
-    chunk_msg_end: usize,
+    chunk_start: u64,
+    chunk_msg_end: u64,
 }
 
 struct Walk {
@@ -1319,18 +1313,28 @@ struct Walk {
 }
 
 /// Walk a version-2 object header (chunk 0 plus any continuation chunks),
-/// recording each message's data offset and its containing chunk's checksum
-/// region.
-fn walk_v2_object_header(
-    data: &[u8],
-    offset: usize,
+/// recording each message's absolute data offset and its containing chunk's
+/// checksum region. Reads one bounded window per header chunk from `source`, so
+/// the walk works over a store with no whole-file mirror.
+fn walk_v2_object_header<S: Source + ?Sized>(
+    source: &S,
+    offset: u64,
     offset_size: u8,
     length_size: u8,
 ) -> Result<Walk, Error> {
-    if offset + 6 > data.len() || &data[offset..offset + 4] != b"OHDR" {
+    let head = match source.read_metadata_at(offset, 6) {
+        Ok(head) => head,
+        // A header running past end-of-file reads as a missing signature, like
+        // the whole-buffer walk before it; other backend errors pass through.
+        Err(FormatError::UnexpectedEof { .. }) => {
+            return Err(Error::Format(FormatError::InvalidObjectHeaderSignature));
+        }
+        Err(e) => return Err(Error::Format(e)),
+    };
+    if &head[..4] != b"OHDR" {
         return Err(Error::Format(FormatError::InvalidObjectHeaderSignature));
     }
-    let flags = data[offset + 5];
+    let flags = head[5];
     let mut pos = offset + 6;
     if flags & 0x20 != 0 {
         pos += 16; // timestamps
@@ -1339,20 +1343,21 @@ fn walk_v2_object_header(
         pos += 4; // attr storage phase-change
     }
     let chunk_size_width = 1usize << (flags & 0x03);
-    let chunk0_size = read_uint(data, pos, chunk_size_width)?.to_usize()?;
-    pos += chunk_size_width;
+    let size_buf = source.read_metadata_at(pos, chunk_size_width)?;
+    let chunk0_size = read_uint(&size_buf, 0, chunk_size_width)?.to_usize()?;
+    pos += chunk_size_width as u64;
     let chunk0_start = offset;
     let chunk0_msg_start = pos;
-    let chunk0_msg_end = chunk0_msg_start + chunk0_size;
+    let chunk0_msg_end = chunk0_msg_start + chunk0_size as u64;
 
     let has_creation_order = flags & 0x04 != 0;
     let mut messages = Vec::new();
-    let mut continuations: Vec<(usize, usize)> = Vec::new();
+    let mut continuations: Vec<(u64, usize)> = Vec::new();
 
+    let chunk0 = source.read_metadata_at(chunk0_msg_start, chunk0_size)?;
     walk_messages(
-        data,
+        &chunk0,
         chunk0_msg_start,
-        chunk0_msg_end,
         chunk0_start,
         chunk0_msg_end,
         has_creation_order,
@@ -1368,15 +1373,20 @@ fn walk_v2_object_header(
         if guard == 0 {
             return Err(Error::Format(FormatError::NestingDepthExceeded));
         }
-        if cont_off + 4 > data.len() || &data[cont_off..cont_off + 4] != b"OCHK" {
+        // A continuation chunk is `OCHK` + messages + a trailing 4-byte
+        // checksum, so anything shorter than 8 bytes is malformed.
+        if cont_len < 8 {
+            return Err(Error::Format(FormatError::InvalidObjectHeaderSignature));
+        }
+        let chunk = source.read_metadata_at(cont_off, cont_len)?;
+        if &chunk[..4] != b"OCHK" {
             return Err(Error::Format(FormatError::InvalidObjectHeaderSignature));
         }
         let msg_start = cont_off + 4;
-        let msg_end = cont_off + cont_len - 4; // checksum is the last 4 bytes
+        let msg_end = cont_off + (cont_len - 4) as u64; // checksum is the last 4 bytes
         walk_messages(
-            data,
+            &chunk[4..cont_len - 4],
             msg_start,
-            msg_end,
             cont_off,
             msg_end,
             has_creation_order,
@@ -1390,38 +1400,41 @@ fn walk_v2_object_header(
     Ok(Walk { messages })
 }
 
+/// Scan one object-header chunk's message region. `chunk` holds exactly the
+/// message bytes and `base` is the absolute file offset of `chunk[0]`, so
+/// recorded message offsets are absolute.
 #[allow(clippy::too_many_arguments)]
 fn walk_messages(
-    data: &[u8],
-    start: usize,
-    end: usize,
-    chunk_start: usize,
-    chunk_msg_end: usize,
+    chunk: &[u8],
+    base: u64,
+    chunk_start: u64,
+    chunk_msg_end: u64,
     has_creation_order: bool,
     offset_size: u8,
     length_size: u8,
     messages: &mut Vec<WalkedMessage>,
-    continuations: &mut Vec<(usize, usize)>,
+    continuations: &mut Vec<(u64, usize)>,
 ) -> Result<(), Error> {
     let msg_header_size = if has_creation_order { 6 } else { 4 };
-    let mut pos = start;
+    let end = chunk.len();
+    let mut pos = 0usize;
     while pos + msg_header_size <= end {
-        let msg_type_raw = data[pos] as u16;
-        let msg_data_size = u16::from_le_bytes([data[pos + 1], data[pos + 2]]) as usize;
+        let msg_type_raw = chunk[pos] as u16;
+        let msg_data_size = u16::from_le_bytes([chunk[pos + 1], chunk[pos + 2]]) as usize;
         pos += msg_header_size;
         if pos + msg_data_size > end {
             break; // padding
         }
         let msg_type = MessageType::from_u16(msg_type_raw);
         if msg_type == MessageType::ObjectHeaderContinuation {
-            let cont_off = read_uint(data, pos, offset_size as usize)?.to_usize()?;
+            let cont_off = read_uint(chunk, pos, offset_size as usize)?;
             let cont_len =
-                read_uint(data, pos + offset_size as usize, length_size as usize)?.to_usize()?;
+                read_uint(chunk, pos + offset_size as usize, length_size as usize)?.to_usize()?;
             continuations.push((cont_off, cont_len));
         } else {
             messages.push(WalkedMessage {
                 msg_type,
-                data_off: pos,
+                data_off: base + pos as u64,
                 size: msg_data_size,
                 chunk_start,
                 chunk_msg_end,

--- a/src/chunked_read.rs
+++ b/src/chunked_read.rs
@@ -21,7 +21,7 @@ use crate::filters::{ChunkContext, decompress_chunk};
 use crate::fixed_array::{
     FixedArrayHeader, read_fixed_array_chunks, read_fixed_array_chunks_from_source,
 };
-use crate::source::FileSource;
+use crate::source::Source;
 
 #[cfg(feature = "parallel")]
 use crate::parallel_read;
@@ -69,13 +69,13 @@ fn decompress_all_chunks(
     Ok(result)
 }
 
-/// Decompress all chunks, reading each chunk's bytes from a [`FileSource`].
+/// Decompress all chunks, reading each chunk's bytes from a [`Source`].
 ///
 /// Streaming counterpart of [`decompress_all_chunks`]. Sequential only: the
 /// lane-partitioned parallel path borrows a whole-file `&[u8]` inside a `Send`
 /// rayon closure, and a `ReadSeekSource` serializes on its mutex anyway, so a
 /// parallel streaming variant is a separate follow-up.
-fn decompress_all_chunks_from_source<S: FileSource + ?Sized>(
+fn decompress_all_chunks_from_source<S: Source + ?Sized>(
     source: &S,
     chunks: &[ChunkInfo],
     pipeline: Option<&FilterPipeline>,
@@ -387,13 +387,13 @@ fn collect_chunk_btree_node_spans_inner(
     Ok(())
 }
 
-/// Traverse B-tree v1 type 1 from a [`FileSource`], reading each node on demand.
+/// Traverse B-tree v1 type 1 from a [`Source`], reading each node on demand.
 ///
 /// The streaming counterpart of [`collect_chunk_info`]: it reads the node header
 /// and the key/child region as two bounded windows via `read_at`, recursing into
 /// child nodes by reading their regions, so the index can be walked without a
 /// whole-file buffer.
-pub fn collect_chunk_info_from_source<S: FileSource + ?Sized>(
+pub fn collect_chunk_info_from_source<S: Source + ?Sized>(
     source: &S,
     btree_address: u64,
     ndims: usize,
@@ -405,7 +405,7 @@ pub fn collect_chunk_info_from_source<S: FileSource + ?Sized>(
 
 /// Depth-tracking core of [`collect_chunk_info_from_source`]; see
 /// [`collect_chunk_info_inner`] for why the bound is required.
-fn collect_chunk_info_from_source_inner<S: FileSource + ?Sized>(
+fn collect_chunk_info_from_source_inner<S: Source + ?Sized>(
     source: &S,
     btree_address: u64,
     ndims: usize,
@@ -717,7 +717,7 @@ pub fn read_chunked_data(
     ))
 }
 
-/// Read a chunked dataset from a [`FileSource`], reading the chunk index and
+/// Read a chunked dataset from a [`Source`], reading the chunk index and
 /// each chunk's bytes on demand via `read_at`.
 ///
 /// Streaming counterpart of [`read_chunked_data`], with the same chunk-index
@@ -725,7 +725,7 @@ pub fn read_chunked_data(
 /// Fixed-Array, and Extensible-Array indexes (index types 1-4). A v4 index
 /// type 5 (version-2 B-tree) is not supported, matching the buffered reader.
 /// The decompression is sequential.
-pub fn read_chunked_data_from_source<S: FileSource + ?Sized>(
+pub fn read_chunked_data_from_source<S: Source + ?Sized>(
     source: &S,
     layout: &DataLayout,
     dataspace: &Dataspace,
@@ -829,12 +829,12 @@ pub fn read_chunked_data_from_source<S: FileSource + ?Sized>(
     ))
 }
 
-/// Read a chunked dataset from a [`FileSource`] with parsed-index and
+/// Read a chunked dataset from a [`Source`] with parsed-index and
 /// decompressed-chunk caching.
 ///
 /// This is the streaming counterpart of [`read_chunked_data_cached`].
 #[allow(clippy::too_many_arguments)]
-pub fn read_chunked_data_cached_from_source<S: FileSource + ?Sized>(
+pub fn read_chunked_data_cached_from_source<S: Source + ?Sized>(
     source: &S,
     layout: &DataLayout,
     dataspace: &Dataspace,
@@ -995,7 +995,7 @@ pub fn read_chunked_data_cached_from_source<S: FileSource + ?Sized>(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn collect_chunks_for_layout_from_source<S: FileSource + ?Sized>(
+pub(crate) fn collect_chunks_for_layout_from_source<S: Source + ?Sized>(
     source: &S,
     version: u8,
     chunk_index_type: Option<u8>,

--- a/src/data_read.rs
+++ b/src/data_read.rs
@@ -14,7 +14,7 @@ use crate::dataspace::Dataspace;
 use crate::datatype::{Datatype, DatatypeByteOrder};
 use crate::error::FormatError;
 use crate::filter_pipeline::FilterPipeline;
-use crate::source::FileSource;
+use crate::source::Source;
 
 /// Read raw bytes for a dataset given its layout and the file data buffer,
 /// using default filter/size parameters.
@@ -135,20 +135,20 @@ pub fn read_raw_data_cached(
 }
 
 // ---------------------------------------------------------------------------
-// Streaming variants (read from a `FileSource` instead of a whole-file buffer)
+// Streaming variants (read from a `Source` instead of a whole-file buffer)
 // ---------------------------------------------------------------------------
 //
 // These mirror `read_raw_data_full` / `read_raw_data` / `read_raw_data_cached`
-// but fetch bytes on demand via `FileSource::read_exact_at`, so a 32-bit host
+// but fetch bytes on demand via `Source::read_exact_at`, so a 32-bit host
 // can read a dataset out of a file larger than its address space. They always
 // return an owned `Vec<u8>`: a lazy source cannot hand out a borrow, and the
 // public API already returns owned data. The zero-copy `read_raw_data_zerocopy`
 // stays the in-memory-only fast path and is intentionally not given a streaming
 // variant.
 
-/// Read raw bytes for a dataset from a [`FileSource`] (streaming counterpart of
+/// Read raw bytes for a dataset from a [`Source`] (streaming counterpart of
 /// [`read_raw_data_full`]).
-pub fn read_raw_data_full_from_source<S: FileSource + ?Sized>(
+pub fn read_raw_data_full_from_source<S: Source + ?Sized>(
     source: &S,
     layout: &DataLayout,
     dataspace: &Dataspace,
@@ -208,7 +208,7 @@ pub fn read_raw_data_full_from_source<S: FileSource + ?Sized>(
 
 /// Streaming counterpart of [`read_raw_data_cached`].
 #[allow(clippy::too_many_arguments)]
-pub fn read_raw_data_cached_from_source<S: FileSource + ?Sized>(
+pub fn read_raw_data_cached_from_source<S: Source + ?Sized>(
     source: &S,
     layout: &DataLayout,
     dataspace: &Dataspace,

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -161,7 +161,7 @@ use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::Path;
 
 use crate::checksum::jenkins_lookup3;
-use crate::chunk_index_inplace::{InPlaceBytes, Located, apply_ea_append, plan_ea_append};
+use crate::chunk_index_inplace::{Located, Store, apply_ea_append, plan_ea_append};
 use crate::chunked_read::{chunk_index_spans_buffered, enumerate_chunks_buffered, plan_dense_grid};
 use crate::chunked_write::{
     ChunkMeta, ChunkOptions, ChunkProvider, WrittenChunk, build_chunked_data_at_ext,
@@ -1092,7 +1092,7 @@ impl WriteEngine {
                 superblock: &mut self.superblock,
                 sb_sig_off: self.sb_sig_off,
             };
-            let state = locate_dataset_state(&mirror, dataset)?;
+            let state = locate_dataset_state(&mirror, oh_addr)?;
             self.located.insert(oh_addr, state);
         }
 
@@ -5102,7 +5102,7 @@ struct FlatDataset {
 /// lock and keep a divergent mirror). It borrows only the mirror-carrying fields,
 /// leaving [`EditSession::located`] independently borrowable. Its primitives write
 /// to disk *before* the mirror — the session's discipline, the opposite of the
-/// append/SWMR writers' mirror-before-disk order; the [`InPlaceBytes`] trait lets
+/// append/SWMR writers' mirror-before-disk order; the [`Store`] trait lets
 /// each owner keep its own failure-path discipline while sharing the checksummed
 /// slot/block mechanics.
 struct EditMirror<'a> {
@@ -5112,18 +5112,21 @@ struct EditMirror<'a> {
     sb_sig_off: usize,
 }
 
-impl InPlaceBytes for EditMirror<'_> {
-    fn data(&self) -> &[u8] {
-        &self.data[..]
+impl crate::source::Source for EditMirror<'_> {
+    fn len(&self) -> u64 {
+        self.data.len() as u64
     }
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), crate::error::FormatError> {
+        crate::source::BytesSource::new(&self.data[..]).read_at(offset, buf)
+    }
+}
+
+impl Store for EditMirror<'_> {
     fn offset_size(&self) -> u8 {
         self.superblock.offset_size
     }
     fn length_size(&self) -> u8 {
         self.superblock.length_size
-    }
-    fn superblock(&self) -> &Superblock {
-        &*self.superblock
     }
     fn append_bytes(&mut self, bytes: &[u8]) -> Result<u64, Error> {
         // Disk before mirror, so a failed write never leaves the mirror ahead of
@@ -5134,12 +5137,13 @@ impl InPlaceBytes for EditMirror<'_> {
         self.data.extend_from_slice(bytes);
         Ok(addr)
     }
-    fn write_at(&mut self, offset: usize, bytes: &[u8]) -> Result<(), Error> {
+    fn write_at(&mut self, offset: u64, bytes: &[u8]) -> Result<(), Error> {
         // Disk before mirror (see `append_bytes`).
         self.handle
-            .seek(SeekFrom::Start(offset as u64))
+            .seek(SeekFrom::Start(offset))
             .map_err(Error::Io)?;
         self.handle.write_all(bytes).map_err(Error::Io)?;
+        let offset = offset.to_usize()?;
         self.data[offset..offset + bytes.len()].copy_from_slice(bytes);
         Ok(())
     }
@@ -5152,7 +5156,7 @@ impl InPlaceBytes for EditMirror<'_> {
         let eof = self.data.len() as u64;
         self.superblock.eof_address = eof;
         let bytes = self.superblock.serialize();
-        self.write_at(self.sb_sig_off, &bytes)
+        self.write_at(self.sb_sig_off as u64, &bytes)
     }
     fn sync(&mut self) -> Result<(), Error> {
         self.handle.flush().map_err(Error::Io)?;
@@ -5179,24 +5183,30 @@ fn as_inplace_error(e: Error) -> Error {
     }
 }
 
-/// Locate `dataset` in `file` and build its [`LocatedState`], validating in-place
-/// append eligibility (rank-1 / unlimited / Extensible-Array indexed, a nonzero
-/// chunk length, and a re-encodable filter pipeline). Mirrors the append writer's
-/// `ensure_located`, reporting through [`Error::AppendInPlaceUnsupported`].
-fn locate_dataset_state<F: InPlaceBytes>(file: &F, dataset: &str) -> Result<LocatedState, Error> {
-    let result = Located::locate(file, dataset, Error::AppendInPlaceUnsupported)?;
+/// Locate the dataset at `oh_addr` in `file` and build its [`LocatedState`],
+/// validating in-place append eligibility (rank-1 / unlimited / Extensible-Array
+/// indexed, a nonzero chunk length, and a re-encodable filter pipeline). Mirrors
+/// the append writer's `ensure_located`, reporting through
+/// [`Error::AppendInPlaceUnsupported`].
+fn locate_dataset_state<F: Store>(file: &F, oh_addr: u64) -> Result<LocatedState, Error> {
+    let result = Located::locate_at(file, oh_addr, Error::AppendInPlaceUnsupported)?;
     if result.located.chunk_elems == 0 {
         return Err(Error::AppendInPlaceUnsupported(
             "in-place append requires a nonzero chunk length",
         ));
     }
-    let data = file.data();
     let (dt_off, dt_size) = result.spans.datatype;
-    let (datatype, _) = Datatype::parse(&data[dt_off..dt_off + dt_size])
+    let dt_bytes = file
+        .read_metadata_at(dt_off, dt_size)
+        .map_err(|_| Error::AppendInPlaceUnsupported("dataset datatype could not be parsed"))?;
+    let (datatype, _) = Datatype::parse(&dt_bytes)
         .map_err(|_| Error::AppendInPlaceUnsupported("dataset datatype could not be parsed"))?;
     let pipeline = match result.spans.filter {
         Some((fb, fsize)) => {
-            let parsed = FilterPipeline::parse(&data[fb..fb + fsize]).map_err(|_| {
+            let fp_bytes = file.read_metadata_at(fb, fsize).map_err(|_| {
+                Error::AppendInPlaceUnsupported("dataset filter pipeline could not be parsed")
+            })?;
+            let parsed = FilterPipeline::parse(&fp_bytes).map_err(|_| {
                 Error::AppendInPlaceUnsupported("dataset filter pipeline could not be parsed")
             })?;
             if !pipeline_reencodable(&parsed) {

--- a/src/extensible_array.rs
+++ b/src/extensible_array.rs
@@ -12,7 +12,7 @@ use alloc::{format, vec, vec::Vec};
 use crate::chunked_read::ChunkInfo;
 use crate::convert::{TryToUsize, is_undefined_addr, u32_from};
 use crate::error::FormatError;
-use crate::source::FileSource;
+use crate::source::Source;
 
 /// Parsed Extensible Array header (AEHD).
 #[derive(Debug, Clone)]
@@ -153,8 +153,8 @@ impl ExtensibleArrayHeader {
         4 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 6 * length_size as usize + offset_size as usize + 4
     }
 
-    /// Parse an Extensible Array header from a [`FileSource`] (bounded window).
-    pub fn parse_from_source<S: FileSource + ?Sized>(
+    /// Parse an Extensible Array header from a [`Source`] (bounded window).
+    pub fn parse_from_source<S: Source + ?Sized>(
         source: &S,
         address: u64,
         offset_size: u8,
@@ -971,17 +971,17 @@ fn easb_data_block_spans(
 }
 
 // ---------------------------------------------------------------------------
-// Streaming traversal (read each block from a `FileSource` on demand)
+// Streaming traversal (read each block from a `Source` on demand)
 // ---------------------------------------------------------------------------
 
-/// Read chunk records from an Extensible Array via a [`FileSource`].
+/// Read chunk records from an Extensible Array via a [`Source`].
 ///
 /// Streaming counterpart of [`read_extensible_array_chunks`]: reads the index
 /// block, then each direct data block and super block (and its paged data
 /// blocks) as bounded windows via `read_at`. The shared `read_element` /
 /// `EaGeometry` drive the decoding, so the layout logic stays in one place.
 #[allow(clippy::too_many_arguments)]
-pub fn read_extensible_array_chunks_from_source<S: FileSource + ?Sized>(
+pub fn read_extensible_array_chunks_from_source<S: Source + ?Sized>(
     source: &S,
     header: &ExtensibleArrayHeader,
     dataset_dims: &[u64],
@@ -1127,7 +1127,7 @@ pub fn read_extensible_array_chunks_from_source<S: FileSource + ?Sized>(
 
 /// Collect elements from a (non-paged) data block read from the source.
 #[allow(clippy::too_many_arguments)]
-fn read_data_block_elements_from_source<S: FileSource + ?Sized>(
+fn read_data_block_elements_from_source<S: Source + ?Sized>(
     source: &S,
     db_address: u64,
     nelmts: usize,
@@ -1185,7 +1185,7 @@ fn read_data_block_elements_from_source<S: FileSource + ?Sized>(
 
 /// Read a paged Extensible Array data block from the source.
 #[allow(clippy::too_many_arguments)]
-fn read_paged_data_block_from_source<S: FileSource + ?Sized>(
+fn read_paged_data_block_from_source<S: Source + ?Sized>(
     source: &S,
     db_address: u64,
     page_nelmts: usize,
@@ -1276,7 +1276,7 @@ fn read_paged_data_block_from_source<S: FileSource + ?Sized>(
 
 /// Read a super block (AESB) and its data blocks from the source.
 #[allow(clippy::too_many_arguments)]
-fn read_super_block_from_source<S: FileSource + ?Sized>(
+fn read_super_block_from_source<S: Source + ?Sized>(
     source: &S,
     sb_address: u64,
     ndblks: usize,

--- a/src/fixed_array.rs
+++ b/src/fixed_array.rs
@@ -9,7 +9,7 @@ use alloc::{format, vec, vec::Vec};
 use crate::chunked_read::ChunkInfo;
 use crate::convert::{TryToUsize, is_undefined_addr, u32_from};
 use crate::error::FormatError;
-use crate::source::FileSource;
+use crate::source::Source;
 
 /// Parsed Fixed Array header (FAHD).
 #[derive(Debug, Clone)]
@@ -107,8 +107,8 @@ impl FixedArrayHeader {
         })
     }
 
-    /// Parse a Fixed Array header from a [`FileSource`] (bounded window).
-    pub fn parse_from_source<S: FileSource + ?Sized>(
+    /// Parse a Fixed Array header from a [`Source`] (bounded window).
+    pub fn parse_from_source<S: Source + ?Sized>(
         source: &S,
         address: u64,
         offset_size: u8,
@@ -417,13 +417,13 @@ pub fn read_fixed_array_chunks(
     Ok(chunks)
 }
 
-/// Read chunk records from a Fixed Array via a [`FileSource`].
+/// Read chunk records from a Fixed Array via a [`Source`].
 ///
 /// Streaming counterpart of [`read_fixed_array_chunks`]: it reads the data-block
 /// prefix, then the element array (non-paged) or each initialized page
 /// (paged) as bounded windows via `read_at`, decoding the same records.
 #[allow(clippy::too_many_arguments)]
-pub fn read_fixed_array_chunks_from_source<S: FileSource + ?Sized>(
+pub fn read_fixed_array_chunks_from_source<S: Source + ?Sized>(
     source: &S,
     header: &FixedArrayHeader,
     dataset_dims: &[u64],

--- a/src/fractal_heap.rs
+++ b/src/fractal_heap.rs
@@ -11,7 +11,7 @@ use crate::btree_v2::{
 };
 use crate::convert::TryToUsize;
 use crate::error::FormatError;
-use crate::source::FileSource;
+use crate::source::Source;
 
 /// The kind of object a fractal-heap heap ID refers to, encoded in bits 4-5 of
 /// the heap ID's first byte (bits 6-7 are the format version, which must be 0).
@@ -160,7 +160,7 @@ fn slice_object(file_data: &[u8], addr: u64, len: usize) -> Result<Vec<u8>, Form
 }
 
 /// Read `len` bytes at `addr` from a streaming source.
-fn read_object_at_source<S: FileSource + ?Sized>(
+fn read_object_at_source<S: Source + ?Sized>(
     source: &S,
     addr: u64,
     len: usize,
@@ -767,11 +767,11 @@ impl FractalHeapHeader {
     }
 
     // -----------------------------------------------------------------------
-    // Streaming readers (fetch each block from a `FileSource` on demand)
+    // Streaming readers (fetch each block from a `Source` on demand)
     // -----------------------------------------------------------------------
 
-    /// Parse a fractal heap header from a [`FileSource`] (small bounded window).
-    pub fn parse_from_source<S: FileSource + ?Sized>(
+    /// Parse a fractal heap header from a [`Source`] (small bounded window).
+    pub fn parse_from_source<S: Source + ?Sized>(
         source: &S,
         address: u64,
         offset_size: u8,
@@ -787,8 +787,8 @@ impl FractalHeapHeader {
         Self::parse(&buf, 0, offset_size, length_size)
     }
 
-    /// Read a managed object from the heap (by raw heap ID) via a [`FileSource`].
-    pub fn read_managed_object_from_source<S: FileSource + ?Sized>(
+    /// Read a managed object from the heap (by raw heap ID) via a [`Source`].
+    pub fn read_managed_object_from_source<S: Source + ?Sized>(
         &self,
         source: &S,
         id_bytes: &[u8],
@@ -828,7 +828,7 @@ impl FractalHeapHeader {
     }
 
     /// Streaming counterpart to [`FractalHeapHeader::read_object`].
-    pub fn read_object_from_source<S: FileSource + ?Sized>(
+    pub fn read_object_from_source<S: Source + ?Sized>(
         &self,
         source: &S,
         id_bytes: &[u8],
@@ -846,8 +846,8 @@ impl FractalHeapHeader {
         }
     }
 
-    /// Resolve and read a "huge" object via a [`FileSource`].
-    fn read_huge_object_from_source<S: FileSource + ?Sized>(
+    /// Resolve and read a "huge" object via a [`Source`].
+    fn read_huge_object_from_source<S: Source + ?Sized>(
         &self,
         source: &S,
         id_bytes: &[u8],
@@ -881,7 +881,7 @@ impl FractalHeapHeader {
         read_object_at_source(source, addr, len.to_usize()?)
     }
 
-    fn read_from_direct_block_from_source<S: FileSource + ?Sized>(
+    fn read_from_direct_block_from_source<S: Source + ?Sized>(
         &self,
         source: &S,
         block_addr: u64,
@@ -900,7 +900,7 @@ impl FractalHeapHeader {
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn read_from_indirect_block_from_source<S: FileSource + ?Sized>(
+    fn read_from_indirect_block_from_source<S: Source + ?Sized>(
         &self,
         source: &S,
         iblock_addr: u64,

--- a/src/global_heap.rs
+++ b/src/global_heap.rs
@@ -5,7 +5,7 @@ use alloc::vec::Vec;
 
 use crate::convert::TryToUsize;
 use crate::error::FormatError;
-use crate::source::FileSource;
+use crate::source::Source;
 
 /// Magic signature for global heap collections.
 const GCOL_SIGNATURE: [u8; 4] = *b"GCOL";
@@ -74,7 +74,7 @@ fn pad8_u64(x: u64) -> Result<u64, FormatError> {
 impl GlobalHeapIndex {
     /// Parse collection metadata from a random-access source without copying
     /// object payloads.
-    pub fn parse<S: FileSource + ?Sized>(
+    pub fn parse<S: Source + ?Sized>(
         source: &S,
         offset: u64,
         length_size: u8,
@@ -274,7 +274,7 @@ mod tests {
             raw_reads: Cell<usize>,
         }
 
-        impl FileSource for TrackingSource {
+        impl Source for TrackingSource {
             fn len(&self) -> u64 {
                 self.data.len() as u64
             }

--- a/src/group_v1.rs
+++ b/src/group_v1.rs
@@ -7,7 +7,7 @@ use crate::btree_v1::{collect_symbol_table_nodes, collect_symbol_table_nodes_fro
 use crate::convert::{TryToUsize, slice_range};
 use crate::error::FormatError;
 use crate::local_heap::LocalHeap;
-use crate::source::FileSource;
+use crate::source::Source;
 use crate::symbol_table::{SymbolTableMessage, SymbolTableNode};
 
 /// A resolved group entry (child name + object header address).
@@ -83,11 +83,11 @@ pub fn resolve_v1_group_entries(
 /// Streaming counterpart of [`resolve_v1_group_entries`].
 ///
 /// Reads the local heap header, B-tree v1, and each symbol-table node from a
-/// [`FileSource`] on demand. The heap's data segment (holding the link names) is
+/// [`Source`] on demand. The heap's data segment (holding the link names) is
 /// read once and every name is sliced from that single buffer. As with the
 /// buffered version, the returned `object_header_address` values are relative to
 /// `base_address` (the caller adds it to obtain absolute file offsets).
-pub fn resolve_v1_group_entries_from_source<S: FileSource + ?Sized>(
+pub fn resolve_v1_group_entries_from_source<S: Source + ?Sized>(
     source: &S,
     sym_table_msg: &SymbolTableMessage,
     offset_size: u8,

--- a/src/group_v2.rs
+++ b/src/group_v2.rs
@@ -17,7 +17,7 @@ use crate::link_info::LinkInfoMessage;
 use crate::link_message::{LinkMessage, LinkTarget};
 use crate::message_type::MessageType;
 use crate::object_header::ObjectHeader;
-use crate::source::FileSource;
+use crate::source::Source;
 use crate::superblock::Superblock;
 use crate::symbol_table::SymbolTableMessage;
 
@@ -244,16 +244,16 @@ pub fn resolve_group_entries(
 
 // ---------------------------------------------------------------------------
 // Streaming path resolution (latest-format / v2 groups), reading each metadata
-// structure from a `FileSource` on demand.
+// structure from a `Source` on demand.
 // ---------------------------------------------------------------------------
 
 /// Streaming counterpart of [`resolve_path_any`] for latest-format files.
 ///
 /// Resolves a path to an object-header address by reading the object headers
-/// and (for dense groups) the fractal heap + B-tree v2 from a [`FileSource`].
+/// and (for dense groups) the fractal heap + B-tree v2 from a [`Source`].
 /// Only v2 (latest-format) groups are supported; a v1 symbol-table group on the
 /// path returns an error (the v1 group traversal is not yet migrated).
-pub fn resolve_path_any_from_source<S: FileSource + ?Sized>(
+pub fn resolve_path_any_from_source<S: Source + ?Sized>(
     source: &S,
     superblock: &Superblock,
     path: &str,
@@ -294,7 +294,7 @@ pub fn resolve_path_any_from_source<S: FileSource + ?Sized>(
 ///
 /// `base_address` is the superblock base address, used to convert the relative
 /// addresses stored in v1 (symbol-table) groups to absolute file offsets.
-pub fn resolve_group_entries_from_source<S: FileSource + ?Sized>(
+pub fn resolve_group_entries_from_source<S: Source + ?Sized>(
     source: &S,
     object_header: &ObjectHeader,
     offset_size: u8,
@@ -324,7 +324,7 @@ pub fn resolve_group_entries_from_source<S: FileSource + ?Sized>(
     }
 }
 
-fn resolve_v2_group_entries_from_source<S: FileSource + ?Sized>(
+fn resolve_v2_group_entries_from_source<S: Source + ?Sized>(
     source: &S,
     object_header: &ObjectHeader,
     offset_size: u8,
@@ -339,7 +339,7 @@ fn resolve_v2_group_entries_from_source<S: FileSource + ?Sized>(
     }
 }
 
-fn resolve_dense_entries_from_source<S: FileSource + ?Sized>(
+fn resolve_dense_entries_from_source<S: Source + ?Sized>(
     source: &S,
     link_info: &LinkInfoMessage,
     fh_addr: u64,

--- a/src/local_heap.rs
+++ b/src/local_heap.rs
@@ -5,7 +5,7 @@ use alloc::string::String;
 
 use crate::convert::TryToUsize;
 use crate::error::FormatError;
-use crate::source::FileSource;
+use crate::source::Source;
 
 /// Parsed HDF5 Local Heap header.
 #[derive(Debug, Clone)]
@@ -140,8 +140,8 @@ impl LocalHeap {
         Ok(String::from(s))
     }
 
-    /// Parse a local heap header from a [`FileSource`] (small bounded window).
-    pub fn parse_from_source<S: FileSource + ?Sized>(
+    /// Parse a local heap header from a [`Source`] (small bounded window).
+    pub fn parse_from_source<S: Source + ?Sized>(
         source: &S,
         address: u64,
         offset_size: u8,
@@ -158,7 +158,7 @@ impl LocalHeap {
     /// [`data_segment_address`](Self::data_segment_address)).
     ///
     /// This is the streaming counterpart of [`read_string`](Self::read_string):
-    /// the caller reads the data segment once via [`FileSource`] and slices every
+    /// the caller reads the data segment once via [`Source`] and slices every
     /// name out of it, so a group with many links costs one segment read rather
     /// than one read per name.
     pub fn read_string_in_segment(

--- a/src/object_header.rs
+++ b/src/object_header.rs
@@ -8,7 +8,7 @@ use byteorder::{ByteOrder, LittleEndian};
 use crate::convert::{TryToUsize, slice_range};
 use crate::error::FormatError;
 use crate::message_type::MessageType;
-use crate::source::FileSource;
+use crate::source::Source;
 
 /// OHDR signature for v2 object headers.
 const OHDR_SIGNATURE: [u8; 4] = *b"OHDR";
@@ -557,18 +557,18 @@ impl ObjectHeader {
     }
 
     // -----------------------------------------------------------------------
-    // Streaming parsers (read each header chunk from a `FileSource` on demand)
+    // Streaming parsers (read each header chunk from a `Source` on demand)
     // -----------------------------------------------------------------------
 
-    /// Parse an object header from a [`FileSource`], reading each header chunk
+    /// Parse an object header from a [`Source`], reading each header chunk
     /// (and continuation chunk) as a small bounded window via
-    /// [`FileSource::read_at`] rather than indexing a whole-file buffer.
+    /// [`Source::read_at`] rather than indexing a whole-file buffer.
     ///
     /// `base_address` is added to v1 continuation offsets (as in
     /// [`Self::parse_with_base`]). The result is identical to the buffered
     /// parser; this path simply never holds more than one chunk at a time, so it
     /// works against a file larger than the address space on a 32-bit host.
-    pub fn parse_from_source<S: FileSource + ?Sized>(
+    pub fn parse_from_source<S: Source + ?Sized>(
         source: &S,
         address: u64,
         offset_size: u8,
@@ -584,7 +584,7 @@ impl ObjectHeader {
         }
     }
 
-    fn parse_v2_from_source<S: FileSource + ?Sized>(
+    fn parse_v2_from_source<S: Source + ?Sized>(
         source: &S,
         address: u64,
         offset_size: u8,
@@ -717,7 +717,7 @@ impl ObjectHeader {
         })
     }
 
-    fn parse_v1_from_source<S: FileSource + ?Sized>(
+    fn parse_v1_from_source<S: Source + ?Sized>(
         source: &S,
         address: u64,
         offset_size: u8,
@@ -764,7 +764,7 @@ impl ObjectHeader {
     /// each continuation depth-first (as the buffered v1 parser does) so the
     /// resulting message order is identical.
     #[allow(clippy::too_many_arguments)]
-    fn parse_v1_chunk_from_source<S: FileSource + ?Sized>(
+    fn parse_v1_chunk_from_source<S: Source + ?Sized>(
         source: &S,
         region_addr: u64,
         region_len: u64,

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -30,7 +30,7 @@ use crate::message_type::MessageType;
 use crate::object_header::ObjectHeader;
 use crate::signature;
 use crate::source::{
-    BytesSource, FileSource, MetadataCacheConfig, MetadataCachingSource, ReadSeekSource,
+    BytesSource, Source, MetadataCacheConfig, MetadataCachingSource, ReadSeekSource,
 };
 use crate::superblock::Superblock;
 use crate::vl_data::{self, VlenStringReadOptions};
@@ -42,10 +42,10 @@ use crate::types::{AttrValue, DType, attrs_to_map, classify_datatype};
 // ---------------------------------------------------------------------------
 
 /// Backing store for a [`File`]: either the whole file buffered in memory, or a
-/// lazy [`FileSource`] that reads regions on demand (see [`File::open_streaming`]).
+/// lazy [`Source`] that reads regions on demand (see [`File::open_streaming`]).
 enum Backend {
     InMemory(Vec<u8>),
-    Streaming(Box<dyn FileSource + Send + Sync>),
+    Streaming(Box<dyn Source + Send + Sync>),
     /// A read-write file opened with [`File::open_rw`]: a [`WriteEngine`] (a
     /// whole-file mirror + exclusive OS lock + staged-edit queues) behind a lock,
     /// so owned handles can both read and mutate in place. Reads slice the
@@ -56,14 +56,14 @@ enum Backend {
     Mirror(Box<Mutex<WriteEngine>>),
 }
 
-/// A borrowed `FileSource` view over a [`File`]'s backend, used by the
+/// A borrowed `Source` view over a [`File`]'s backend, used by the
 /// streaming-capable read paths so one call site serves both backends.
 pub(crate) enum SourceView<'a> {
     Mem(&'a [u8]),
-    Stream(&'a (dyn FileSource + Send + Sync)),
+    Stream(&'a (dyn Source + Send + Sync)),
 }
 
-impl FileSource for SourceView<'_> {
+impl Source for SourceView<'_> {
     fn len(&self) -> u64 {
         match self {
             SourceView::Mem(b) => b.len() as u64,
@@ -85,7 +85,7 @@ impl FileSource for SourceView<'_> {
     }
 }
 
-/// A `FileSource` view shifted forward by a base address: every read at a
+/// A `Source` view shifted forward by a base address: every read at a
 /// base-relative `offset` is served from `inner` at `offset + base`. Used by the
 /// dataset-payload read path on a file with a userblock, where the data-layout's
 /// on-disk addresses (contiguous data, chunk index, and chunk data) are stored
@@ -94,12 +94,12 @@ impl FileSource for SourceView<'_> {
 /// slices the buffer at `base`. `len`/`read_at` shift by the base; `read_metadata_at`
 /// forwards to the inner source (at the absolute offset) so its metadata cache is
 /// shared, while payload reads keep the default uncached `read_exact_at`.
-struct BaseOffsetSource<'a, S: FileSource + ?Sized> {
+struct BaseOffsetSource<'a, S: Source + ?Sized> {
     inner: &'a S,
     base: u64,
 }
 
-impl<S: FileSource + ?Sized> FileSource for BaseOffsetSource<'_, S> {
+impl<S: Source + ?Sized> Source for BaseOffsetSource<'_, S> {
     fn len(&self) -> u64 {
         self.inner.len().saturating_sub(self.base)
     }
@@ -345,7 +345,7 @@ impl FileInner {
     ) -> Result<Self, Error> {
         let handle = std::fs::File::open(path.as_ref()).map_err(Error::Io)?;
         let source = ReadSeekSource::new(handle).map_err(Error::Format)?;
-        let source: Box<dyn FileSource + Send + Sync> = if options.metadata_cache.is_enabled() {
+        let source: Box<dyn Source + Send + Sync> = if options.metadata_cache.is_enabled() {
             Box::new(MetadataCachingSource::new(source, options.metadata_cache))
         } else {
             Box::new(source)
@@ -462,7 +462,7 @@ impl FileInner {
         Ok(())
     }
 
-    /// A `FileSource` view over the backend, for the streaming-capable paths.
+    /// A `Source` view over the backend, for the streaming-capable paths.
     pub(crate) fn source(&self) -> SourceView<'_> {
         match &self.backend {
             Backend::InMemory(v) => SourceView::Mem(v),
@@ -494,7 +494,7 @@ impl FileInner {
 
     /// Streaming counterpart of [`parse_superblock`]: locate and parse the
     /// superblock by reading only small windows from the source.
-    fn parse_superblock_source<S: FileSource + ?Sized>(
+    fn parse_superblock_source<S: Source + ?Sized>(
         source: &S,
     ) -> Result<(Superblock, u64), Error> {
         let sig_offset = signature::find_signature_in(source)?;
@@ -1417,7 +1417,7 @@ impl File {
         self.inner.libver_bound()
     }
 
-    /// A `FileSource` view over the backend, for the streaming-capable paths.
+    /// A `Source` view over the backend, for the streaming-capable paths.
     pub(crate) fn source(&self) -> SourceView<'_> {
         self.inner.source()
     }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -30,7 +30,7 @@ use crate::message_type::MessageType;
 use crate::object_header::ObjectHeader;
 use crate::signature;
 use crate::source::{
-    BytesSource, Source, MetadataCacheConfig, MetadataCachingSource, ReadSeekSource,
+    BytesSource, MetadataCacheConfig, MetadataCachingSource, ReadSeekSource, Source,
 };
 use crate::superblock::Superblock;
 use crate::vl_data::{self, VlenStringReadOptions};
@@ -494,9 +494,7 @@ impl FileInner {
 
     /// Streaming counterpart of [`parse_superblock`]: locate and parse the
     /// superblock by reading only small windows from the source.
-    fn parse_superblock_source<S: Source + ?Sized>(
-        source: &S,
-    ) -> Result<(Superblock, u64), Error> {
+    fn parse_superblock_source<S: Source + ?Sized>(source: &S) -> Result<(Superblock, u64), Error> {
         let sig_offset = signature::find_signature_in(source)?;
         let mut superblock = Superblock::parse_from_source(source, sig_offset)?;
         let addr_offset = superblock.base_address;

--- a/src/repack.rs
+++ b/src/repack.rs
@@ -90,7 +90,7 @@ use crate::filter_pipeline::{
 };
 use crate::reader::{Dataset, File, Group};
 use crate::scaleoffset::{self, ScaleOffset};
-use crate::source::FileSource;
+use crate::source::Source;
 use crate::type_builders::{
     AttrValue, DatasetBuilder, FinishedGroup, GroupBuilder, ObjectRefTarget, VlStringElement,
 };

--- a/src/shared_message.rs
+++ b/src/shared_message.rs
@@ -18,7 +18,7 @@ use crate::convert::TryToUsize;
 use crate::error::FormatError;
 use crate::message_type::MessageType;
 use crate::object_header::ObjectHeader;
-use crate::source::FileSource;
+use crate::source::Source;
 
 /// Fractal heap ID length for SOHM entries (fixed at 8 bytes).
 const FHEAP_ID_LEN: usize = 8;
@@ -162,8 +162,8 @@ pub fn resolve_shared_message(
 }
 
 /// Streaming counterpart of [`resolve_shared_message`]: reads the target object
-/// header from a [`FileSource`] on demand instead of indexing a whole-file slice.
-pub fn resolve_shared_message_from_source<S: FileSource + ?Sized>(
+/// header from a [`Source`] on demand instead of indexing a whole-file slice.
+pub fn resolve_shared_message_from_source<S: Source + ?Sized>(
     source: &S,
     shared_ref: &SharedMessageRef,
     target_msg_type: MessageType,

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -2,18 +2,18 @@
 
 use crate::convert::TryToUsize;
 use crate::error::FormatError;
-use crate::source::{BytesSource, FileSource};
+use crate::source::{BytesSource, Source};
 
 /// The 8-byte HDF5 magic signature.
 pub const HDF5_SIGNATURE: [u8; 8] = [0x89, b'H', b'D', b'F', b'\r', b'\n', 0x1A, b'\n'];
 
-/// Search a [`FileSource`] for the HDF5 signature, returning its byte offset.
+/// Search a [`Source`] for the HDF5 signature, returning its byte offset.
 ///
 /// The HDF5 spec allows the signature at offset 0, 512, 1024, 2048, 4096, …
 /// (powers of two starting at 512, plus offset 0). Only the candidate 8-byte
 /// windows are read, so this works against a lazy streaming source without
 /// pulling the whole file.
-pub fn find_signature_in<S: FileSource + ?Sized>(source: &S) -> Result<u64, FormatError> {
+pub fn find_signature_in<S: Source + ?Sized>(source: &S) -> Result<u64, FormatError> {
     let len = source.len();
     let mut sig = [0u8; 8];
 

--- a/src/source.rs
+++ b/src/source.rs
@@ -1,4 +1,4 @@
-//! Random-access byte sources for the reader: the [`FileSource`] trait and its
+//! Random-access byte sources for the reader: the [`Source`] trait and its
 //! backends.
 //!
 //! # Why this exists
@@ -20,7 +20,7 @@
 //! working set (the metadata being parsed, plus the data chunks currently being
 //! decompressed) resident at any time.
 //!
-//! [`FileSource`] is that abstraction. It is deliberately minimal and
+//! [`Source`] is that abstraction. It is deliberately minimal and
 //! `no_std`/`alloc`-friendly (the trait and the in-memory backends need no
 //! `std`), so it works on the same constrained targets the rest of the crate
 //! supports.
@@ -46,21 +46,21 @@
 //!
 //! # Migration plan (this is the first increment)
 //!
-//! The reader is not yet ported onto `FileSource`; that is a staged effort
+//! The reader is not yet ported onto `Source`; that is a staged effort
 //! tracked by issue #27. This module is the foundation the later stages build
 //! on. The intended path, smallest-risk first:
 //!
 //! 1. **Foundation (this commit).** Land the trait + in-memory and `Read+Seek`
 //!    backends + tests. Nothing in the existing reader changes, so there is no
 //!    risk to the current in-memory path.
-//! 2. **A cursor.** Introduce a small `Cursor<'a>` over a `&'a dyn FileSource`
+//! 2. **A cursor.** Introduce a small `Cursor<'a>` over a `&'a dyn Source`
 //!    that offers the `read_offset` / `read_length` / "give me bytes at
 //!    `[off, off+len)`" idioms the parsers already use, with the checked
 //!    [`crate::convert`] conversions built in. The ~15 duplicated per-module
 //!    `read_offset` helpers collapse into it.
 //! 3. **Bulk path first.** Port the contiguous and chunked **data** readers
 //!    (`data_read`, `chunked_read`, `parallel_read`) to fetch each chunk via
-//!    [`FileSource::read_at`] instead of slicing the whole-file buffer. This is
+//!    [`Source::read_at`] instead of slicing the whole-file buffer. This is
 //!    self-contained (a chunk is already `{address, size}`) and captures most of
 //!    the memory win, since the data payload is what is actually large. The
 //!    zero-copy `&'a [u8]` return of `data_read::read_raw_data_zerocopy` becomes
@@ -91,7 +91,7 @@ pub const DEFAULT_METADATA_CACHE_MAX_ENTRY_BYTES: usize = 64 * 1024;
 /// This is the `hdf5-pure` counterpart to the memory-budget portion of HDF5's
 /// `H5Pset_mdc_config`: it bounds the bytes retained for parsed metadata reads
 /// while a file is opened through [`crate::File::open_streaming_with_options`].
-/// Raw dataset payload reads use `FileSource::read_exact_at` and are not
+/// Raw dataset payload reads use `Source::read_exact_at` and are not
 /// admitted to this cache.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MetadataCacheConfig {
@@ -160,7 +160,7 @@ impl Default for MetadataCacheConfig {
 /// are `usize` (they must fit in a caller-provided buffer). Implementations must
 /// either fill the whole request or return an error — a short read is always an
 /// error, never silently truncated.
-pub trait FileSource {
+pub trait Source {
     /// Total number of bytes the source can supply.
     fn len(&self) -> u64;
 
@@ -181,17 +181,17 @@ pub trait FileSource {
 
     /// Read `len` bytes starting at `offset` into a freshly allocated `Vec`.
     ///
-    /// Convenience wrapper over [`read_at`](FileSource::read_at) for callers that
+    /// Convenience wrapper over [`read_at`](Source::read_at) for callers that
     /// want an owned buffer; the lazy backends keep no more than this resident.
     ///
-    /// The request is bounds-checked against [`len`](FileSource::len) *before* the
+    /// The request is bounds-checked against [`len`](Source::len) *before* the
     /// buffer is allocated. The metadata parsers feed `len` values straight from
     /// the file (a chunk-0 body size, a continuation-block length, a heap object
     /// size), so a malformed file could otherwise name a multi-gigabyte length
     /// and make this reserve `vec![0u8; len]` up front only for the read to fail
     /// EOF anyway — a cheap denial of service. Rejecting an out-of-range request
     /// before allocating avoids that; the error returned is identical to the one
-    /// the underlying [`read_at`](FileSource::read_at) would have produced.
+    /// the underlying [`read_at`](Source::read_at) would have produced.
     fn read_exact_at(&self, offset: u64, len: usize) -> Result<Vec<u8>, FormatError> {
         let end = offset
             .checked_add(len as u64)
@@ -221,9 +221,9 @@ pub trait FileSource {
     }
 }
 
-// Forward `FileSource` through references and boxes so `&S`, `&dyn FileSource`,
-// and `Box<dyn FileSource>` are all usable wherever an `S: FileSource` is.
-impl<S: FileSource + ?Sized> FileSource for &S {
+// Forward `Source` through references and boxes so `&S`, `&dyn Source`,
+// and `Box<dyn Source>` are all usable wherever an `S: Source` is.
+impl<S: Source + ?Sized> Source for &S {
     fn len(&self) -> u64 {
         (**self).len()
     }
@@ -241,7 +241,7 @@ impl<S: FileSource + ?Sized> FileSource for &S {
 }
 
 #[cfg(feature = "std")]
-impl<S: FileSource + ?Sized> FileSource for std::boxed::Box<S> {
+impl<S: Source + ?Sized> Source for std::boxed::Box<S> {
     fn len(&self) -> u64 {
         (**self).len()
     }
@@ -262,7 +262,7 @@ impl<S: FileSource + ?Sized> FileSource for std::boxed::Box<S> {
 // In-memory backend
 // ---------------------------------------------------------------------------
 
-/// A [`FileSource`] over an in-memory byte buffer: anything that is
+/// A [`Source`] over an in-memory byte buffer: anything that is
 /// `AsRef<[u8]>` (`Vec<u8>`, `&[u8]`, `Box<[u8]>`, `Arc<[u8]>`, …).
 ///
 /// This is the always-available backend that mirrors the crate's current
@@ -277,7 +277,7 @@ impl<T: AsRef<[u8]>> BytesSource<T> {
     }
 }
 
-impl<T: AsRef<[u8]>> FileSource for BytesSource<T> {
+impl<T: AsRef<[u8]>> Source for BytesSource<T> {
     fn len(&self) -> u64 {
         self.0.as_ref().len() as u64
     }
@@ -386,10 +386,10 @@ impl MetadataReadCache {
     }
 }
 
-/// A [`FileSource`] wrapper with a bounded cache for metadata reads.
+/// A [`Source`] wrapper with a bounded cache for metadata reads.
 ///
-/// The wrapper only caches calls to [`FileSource::read_metadata_at`]. Plain
-/// [`FileSource::read_exact_at`] calls still go directly to the inner source,
+/// The wrapper only caches calls to [`Source::read_metadata_at`]. Plain
+/// [`Source::read_exact_at`] calls still go directly to the inner source,
 /// which keeps raw dataset payloads out of the metadata cache.
 #[cfg(feature = "std")]
 pub struct MetadataCachingSource<S> {
@@ -411,7 +411,7 @@ impl<S> MetadataCachingSource<S> {
 }
 
 #[cfg(feature = "std")]
-impl<S: FileSource> FileSource for MetadataCachingSource<S> {
+impl<S: Source> Source for MetadataCachingSource<S> {
     fn len(&self) -> u64 {
         self.inner.len()
     }
@@ -455,10 +455,10 @@ impl<S: FileSource> FileSource for MetadataCachingSource<S> {
 // Read + Seek backend (std)
 // ---------------------------------------------------------------------------
 
-/// A lazy [`FileSource`] over any [`std::io::Read`] + [`std::io::Seek`] (a
+/// A lazy [`Source`] over any [`std::io::Read`] + [`std::io::Seek`] (a
 /// [`std::fs::File`], an in-memory `Cursor`, etc.).
 ///
-/// Each [`read_at`](FileSource::read_at) performs a `seek` + `read_exact`, so no
+/// Each [`read_at`](Source::read_at) performs a `seek` + `read_exact`, so no
 /// more than the requested bytes are ever held in memory. This is the backend
 /// that lets a 32-bit host read a file larger than its address space: the
 /// metadata and one working chunk fit even when the whole file does not.
@@ -489,7 +489,7 @@ impl<R: std::io::Read + std::io::Seek> ReadSeekSource<R> {
 }
 
 #[cfg(feature = "std")]
-impl<R: std::io::Read + std::io::Seek> FileSource for ReadSeekSource<R> {
+impl<R: std::io::Read + std::io::Seek> Source for ReadSeekSource<R> {
     fn len(&self) -> u64 {
         self.len
     }
@@ -602,7 +602,7 @@ mod tests {
     #[test]
     fn forwarding_through_reference() {
         let src = BytesSource::new(vec![9u8, 8, 7]);
-        let r: &dyn FileSource = &src;
+        let r: &dyn Source = &src;
         let mut buf = [0u8; 2];
         r.read_at(1, &mut buf).unwrap();
         assert_eq!(buf, [8, 7]);
@@ -616,7 +616,7 @@ mod tests {
             metadata_reads: Cell<usize>,
         }
 
-        impl FileSource for MetadataSource {
+        impl Source for MetadataSource {
             fn len(&self) -> u64 {
                 16
             }
@@ -632,7 +632,7 @@ mod tests {
             }
         }
 
-        fn read_metadata_via_trait<T: FileSource>(source: T) -> Vec<u8> {
+        fn read_metadata_via_trait<T: Source>(source: T) -> Vec<u8> {
             source.read_metadata_at(4, 3).unwrap()
         }
 
@@ -657,7 +657,7 @@ mod tests {
             reads: Arc<AtomicUsize>,
         }
 
-        impl FileSource for CountingSource {
+        impl Source for CountingSource {
             fn len(&self) -> u64 {
                 self.data.len() as u64
             }

--- a/src/superblock.rs
+++ b/src/superblock.rs
@@ -8,7 +8,7 @@ use byteorder::{ByteOrder, LittleEndian};
 use crate::convert::TryToUsize;
 use crate::error::FormatError;
 use crate::signature::HDF5_SIGNATURE;
-use crate::source::FileSource;
+use crate::source::Source;
 
 /// Upper bound on the on-disk size of a superblock across all versions: the
 /// largest is v1 with 8-byte offsets at 100 bytes (28 prefix + 4 addresses +
@@ -131,7 +131,7 @@ impl Superblock {
         }
     }
 
-    /// Parse a superblock from a [`FileSource`], given the byte offset where its
+    /// Parse a superblock from a [`Source`], given the byte offset where its
     /// signature was found (see [`crate::signature::find_signature_in`]).
     ///
     /// The superblock is fully self-contained: every field is stored inline and
@@ -139,7 +139,7 @@ impl Superblock {
     /// window ([`MAX_SUPERBLOCK_LEN`] bytes, clamped to the bytes available) is
     /// read. This lets the entry point be parsed from a lazy streaming source
     /// without materializing the whole file.
-    pub fn parse_from_source<S: FileSource + ?Sized>(
+    pub fn parse_from_source<S: Source + ?Sized>(
         source: &S,
         signature_offset: u64,
     ) -> Result<Superblock, FormatError> {

--- a/src/swmr_writer.rs
+++ b/src/swmr_writer.rs
@@ -61,6 +61,7 @@ use std::path::Path;
 use crate::chunk_index_inplace::{ElemRecord, InPlaceFile, Located};
 use crate::error::{Error, FormatError};
 use crate::file_lock::{self, FileLocking};
+use crate::group_v2;
 use crate::signature;
 use crate::superblock::Superblock;
 
@@ -195,7 +196,9 @@ impl SwmrWriter {
     /// callers always use `append_raw` (`max_phase = 4`).
     fn append_phased(&mut self, dataset: &str, bytes: &[u8], max_phase: u8) -> Result<(), Error> {
         if !self.located.contains_key(dataset) {
-            let result = Located::locate(&self.file, dataset, Error::SwmrAppendUnsupported)?;
+            let oh_addr =
+                group_v2::resolve_path_any(self.file.data(), &self.file.superblock, dataset)?;
+            let result = Located::locate_at(&self.file, oh_addr, Error::SwmrAppendUnsupported)?;
             if result.has_filters {
                 // The SWMR path stores bare-address EA elements and never
                 // compresses; filtered append is the general writer's job.

--- a/src/symbol_table.rs
+++ b/src/symbol_table.rs
@@ -4,7 +4,7 @@
 use alloc::vec::Vec;
 
 use crate::error::FormatError;
-use crate::source::FileSource;
+use crate::source::Source;
 
 /// Symbol Table message (type 0x0011) found in v1 group object headers.
 #[derive(Debug, Clone, PartialEq)]
@@ -145,11 +145,11 @@ impl SymbolTableNode {
         Ok(SymbolTableNode { entries })
     }
 
-    /// Parse a Symbol Table Node from a [`FileSource`] on demand.
+    /// Parse a Symbol Table Node from a [`Source`] on demand.
     ///
     /// Reads the 8-byte SNOD header to learn the symbol count, then the exact
     /// node body, so no more than one node is resident at a time.
-    pub fn parse_from_source<S: FileSource + ?Sized>(
+    pub fn parse_from_source<S: Source + ?Sized>(
         source: &S,
         address: u64,
         offset_size: u8,

--- a/src/types.rs
+++ b/src/types.rs
@@ -153,7 +153,7 @@ pub(crate) fn classify_datatype(dt: &crate::datatype::Datatype) -> DType {
 /// `base_address` is the file-level userblock offset — needed so that
 /// variable-length attribute data (stored in global heap collections with
 /// addresses relative to the base) can be located correctly.
-pub(crate) fn attrs_to_map<S: crate::source::FileSource + ?Sized>(
+pub(crate) fn attrs_to_map<S: crate::source::Source + ?Sized>(
     attrs: &[crate::attribute::AttributeMessage],
     source: &S,
     offset_size: u8,
@@ -169,7 +169,7 @@ pub(crate) fn attrs_to_map<S: crate::source::FileSource + ?Sized>(
     map
 }
 
-fn decode_attr_value<S: crate::source::FileSource + ?Sized>(
+fn decode_attr_value<S: crate::source::Source + ?Sized>(
     attr: &crate::attribute::AttributeMessage,
     source: &S,
     offset_size: u8,

--- a/src/vl_data.rs
+++ b/src/vl_data.rs
@@ -13,7 +13,7 @@ use crate::error::FormatError;
 use crate::global_heap::GlobalHeapIndex;
 #[cfg(test)]
 use crate::source::BytesSource;
-use crate::source::FileSource;
+use crate::source::Source;
 
 /// Allocation limits for reading variable-length strings.
 ///
@@ -228,7 +228,7 @@ pub fn visit_vl_strings_from_source<S, F>(
     mut visitor: F,
 ) -> Result<(), FormatError>
 where
-    S: FileSource + ?Sized,
+    S: Source + ?Sized,
     F: FnMut(&str),
 {
     check_element_limit(num_elements, options)?;
@@ -296,7 +296,7 @@ where
 }
 
 /// Resolve VL strings from a random-access file source.
-pub fn read_vl_strings_from_source<S: FileSource + ?Sized>(
+pub fn read_vl_strings_from_source<S: Source + ?Sized>(
     source: &S,
     raw_data: &[u8],
     num_elements: u64,
@@ -348,7 +348,7 @@ pub(crate) enum VlByteObject {
 /// non-string VL sequence (e.g. `H5T_VLEN { H5T_NATIVE_DOUBLE }`) the stored
 /// `length` counts base-type elements, so the heap object holds
 /// `length * element_size` bytes — exactly what is read here.
-pub(crate) fn read_vl_byte_objects_from_source<S: FileSource + ?Sized>(
+pub(crate) fn read_vl_byte_objects_from_source<S: Source + ?Sized>(
     source: &S,
     raw_data: &[u8],
     num_elements: u64,


### PR DESCRIPTION
First of two PRs for #147 (bounded-memory mutation). Pure internal refactor, no public API change: the O(1) in-place Extensible-Array append engine no longer assumes a whole-file `&[u8]` is resident, so a mirror-less bounded backend can plug in next.

## What changed

- The internal read trait `FileSource` is renamed `Source` (it stops being reader-only: the write engine now reads through it, and the writable trait extends it). Mechanical; the trait is not re-exported.
- `InPlaceBytes` is replaced by `pub(crate) trait Store: Source`. Its one whole-file-residency method, `data() -> &[u8]`, is gone: every engine read is now a bounded `Source` window — the object-header walk (one window per OHDR/OCHK chunk), single message spans, the EA header, one element record, one trailing chunk, one checksum region. `read_addr_at` is fallible and `rechecksum_range` reads back through `Source`.
- Engine offsets migrate `usize` -> `u64` (`Located` fields, slot/pointer math). File offsets are u64, and the bounded backend targets files larger than a 32-bit address space.
- `Located::locate` is removed; `locate_at(oh_addr)` is the only entry. Path resolution moves to the callers, which own whole-file mirrors and already used the slice resolver — v1-symbol-table-group paths keep working, and `WriteEngine`'s redundant double resolution disappears.
- `InPlaceFile` and `EditMirror` keep their mirrors and their existing write-ordering disciplines, serving `Source` by slicing. The 4-phase fsync-barriered apply sequence is untouched.
- New contract tests: an instrumented in-test `Store` drives the real `locate_at` + `plan_ea_append` + `apply_ea_append` path and asserts no single read exceeds a bounded window, per-append read volume stays flat as the file grows, and the partial-tail rewrite reads exactly one chunk.

## Behavior notes

- Byte-for-byte equivalent on well-formed files (all 1369 pre-existing tests pass, including crash-consistency and C-crosschecks).
- One deliberate change on malformed input: an object-header continuation chunk shorter than its mandatory signature + checksum (8 bytes) is now rejected as a format error; the old walk silently tolerated the `[4, 8)` range (walking zero messages) and panicked below 4. No conforming writer can produce such a file.

Part of #147; the bounded backend itself follows in the stacked PR.
