### PR TITLE
Bounded-memory mutation of persisted-free-space files (#173)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- `File::open_rw_bounded` now supports a file that persists its free space (`H5Pset_file_space_strategy(persist = true)`, non-paged): its on-disk free-space managers are seeded on open and rewritten into canonical shape at `File::close`, so bounded-memory appends round-trip through the reference C library; the paged strategy (`H5F_FSPACE_STRATEGY_PAGE`) is still refused at open ([#173](https://github.com/stephenberry/hdf5-pure/issues/173)).
 - `Dataset::read_raw_rows` and the typed `read_f64_rows`/`read_f32_rows`/`read_i8_rows`/`read_i16_rows`/`read_i32_rows`/`read_i64_rows`/`read_u8_rows`/`read_u16_rows`/`read_u32_rows`/`read_u64_rows`/`read_string_rows` read a leading-dimension row window `[start, start + count)` without materializing the whole dataset, so a large dataset can be streamed a fixed number of rows at a time; inner-chunked and variable-length string windows fall back to a whole read sliced to the window ([#170](https://github.com/stephenberry/hdf5-pure/pull/170)).
 
 ## [0.22.0] - 2026-07-22

--- a/src/bounded.rs
+++ b/src/bounded.rs
@@ -23,11 +23,16 @@ use std::path::Path;
 
 use crate::chunk_index_inplace::{Store, apply_ea_append, plan_ea_append};
 use crate::edit::{
-    AppendBuilder, LocatedState, as_inplace_error, locate_dataset_state, validate_gathered_append,
+    AppendBuilder, LocatedState, as_inplace_error, build_v2_object_header, locate_dataset_state,
+    read_single_chunk_ext_region, rewrite_extension_region_bytes, validate_gathered_append,
 };
 use crate::error::{Error, FormatError};
 use crate::file_lock::{self, FileLocking};
-use crate::file_space_info::FileSpaceInfo;
+use crate::file_space_info::{FileSpaceInfo, FileSpaceStrategy};
+use crate::free_space::FreeList;
+use crate::free_space_manager::{
+    FreeSection, fshd_len, read_persisted_sections_source, serialize_file_fsm,
+};
 use crate::message_type::MessageType;
 use crate::object_header::ObjectHeader;
 use crate::signature;
@@ -147,6 +152,108 @@ impl BoundedStore {
         self.handle.write_all(bytes).map_err(Error::Io)?;
         Ok(())
     }
+
+    /// Append a fresh superblock extension + free-space-manager blocks describing
+    /// `sections` at end-of-file, then repoint the superblock (root unchanged, new
+    /// EOF and extension address, consistency flags cleared) as the crash-atomic
+    /// linearization point. This is the bounded, `Store`-seam mirror of
+    /// [`WriteEngine::commit_persisting`](crate::edit): the new blocks sit strictly
+    /// past everything live and are unreferenced until the superblock repoint, so a
+    /// crash before it leaves the prior file wholly intact. Returns the extents of
+    /// the freshly written blocks (the next finalize's `old_blocks`).
+    fn write_persist_tail(
+        &mut self,
+        old_ext_region: &[u8],
+        strategy: FileSpaceStrategy,
+        threshold: u64,
+        page_size: u64,
+        sections: &[FreeSection],
+    ) -> Result<Vec<(u64, u64)>, Error> {
+        let os = self.superblock.offset_size;
+        let new_root = self.superblock.root_group_address;
+        let ext_addr = self.len;
+
+        // The persist File Space Info message is fixed-size, so the rewritten
+        // extension's length is independent of the addresses it will carry: size
+        // it with a placeholder to place the FSM blocks that follow it.
+        let placeholder =
+            FileSpaceInfo::persistent_single_manager(strategy, threshold, page_size, 0, 0);
+        let ext_len = build_v2_object_header(&rewrite_extension_region_bytes(
+            old_ext_region,
+            &placeholder,
+        )?)
+        .len() as u64;
+        let fshd_addr = ext_addr + ext_len;
+
+        let (ext_oh, fsm_blocks, final_eof) = if sections.is_empty() {
+            let info = FileSpaceInfo::persistent_empty(strategy, threshold, page_size);
+            let ext_oh =
+                build_v2_object_header(&rewrite_extension_region_bytes(old_ext_region, &info)?);
+            let final_eof = ext_addr + ext_oh.len() as u64;
+            (ext_oh, None, final_eof)
+        } else {
+            let fsse_addr = fshd_addr + fshd_len(os);
+            // `eoa_pre_fsm` points at the FSHD (the extension below it persists);
+            // see the mirror path for the shrink-and-rebuild convention.
+            let eoa_pre_fsm = fshd_addr;
+            let info = FileSpaceInfo::persistent_single_manager(
+                strategy,
+                threshold,
+                page_size,
+                fshd_addr,
+                eoa_pre_fsm,
+            );
+            let ext_oh =
+                build_v2_object_header(&rewrite_extension_region_bytes(old_ext_region, &info)?);
+            debug_assert_eq!(
+                ext_oh.len() as u64,
+                ext_len,
+                "extension length must be stable across the placeholder and real messages"
+            );
+            let (fshd, fsse) = serialize_file_fsm(sections, fshd_addr, fsse_addr, os);
+            let final_eof = fsse_addr + fsse.len() as u64;
+            (ext_oh, Some((fshd, fsse)), final_eof)
+        };
+
+        // Append the extension, then the FSM blocks, at end-of-file. They are
+        // unreferenced until the superblock repoint, so a crash here is harmless.
+        let written_ext = self.append_bytes(&ext_oh)?;
+        debug_assert_eq!(written_ext, ext_addr);
+        let mut new_old_blocks = vec![(ext_addr, ext_oh.len() as u64)];
+        if let Some((fshd, fsse)) = fsm_blocks {
+            let wf = self.append_bytes(&fshd)?;
+            debug_assert_eq!(wf, fshd_addr);
+            new_old_blocks.push((fshd_addr, fshd.len() as u64));
+            let ws = self.append_bytes(&fsse)?;
+            new_old_blocks.push((ws, fsse.len() as u64));
+        }
+
+        // Barrier, then repoint the superblock (the linearization point), then sync.
+        Store::sync(self)?;
+        self.repoint_persist_superblock(new_root, final_eof, ext_addr)?;
+        Store::sync(self)?;
+        Ok(new_old_blocks)
+    }
+
+    /// Repoint the superblock at `new_root`/`new_eof`/`new_ext_addr` and clear the
+    /// consistency flags, rewriting it in place. Called last by
+    /// [`write_persist_tail`](Self::write_persist_tail).
+    fn repoint_persist_superblock(
+        &mut self,
+        new_root: u64,
+        new_eof: u64,
+        new_ext_addr: u64,
+    ) -> Result<(), Error> {
+        self.superblock.root_group_address = new_root;
+        self.superblock.eof_address = new_eof;
+        self.superblock.superblock_extension_address = Some(new_ext_addr);
+        self.superblock.consistency_flags = 0;
+        // `self.len` already equals `new_eof` (we appended up to it); keep the
+        // store's logical length and the superblock in step.
+        self.len = new_eof;
+        let bytes = self.superblock.serialize();
+        self.write_at_raw(self.sb_sig_off, &bytes)
+    }
 }
 
 impl Source for BoundedStore {
@@ -210,6 +317,29 @@ impl Store for BoundedStore {
     }
 }
 
+/// State for a bounded session on a file that persists its free space (issue
+/// #173). Seeded from the on-disk managers at open, carried across appends, and
+/// written back into canonical (manager-at-tail) shape at
+/// [`finalize_persist`](BoundedEngine::finalize_persist). The bounded backend
+/// only ever appends at end-of-file (it never reuses a freed hole), so the
+/// seeded holes stay valid untouched throughout the session; finalize only has
+/// to re-home the managers past the appended data.
+struct BoundedPersistState {
+    strategy: FileSpaceStrategy,
+    threshold: u64,
+    page_size: u64,
+    /// The live free list: the on-disk holes seeded at open (never handed out —
+    /// the bounded engine appends only), plus, at finalize, the superseded old
+    /// manager/extension blocks.
+    free: FreeList,
+    /// `(addr, len)` of the superblock-extension header and every `FSHD`/`FSSE`
+    /// block the *current* on-disk file uses; freed and rewritten by the next
+    /// finalize.
+    old_blocks: Vec<(u64, u64)>,
+    /// Absolute address of the current superblock-extension object header.
+    old_ext_addr: u64,
+}
+
 /// The engine behind [`Backend::Bounded`](crate::reader): the store plus the
 /// object-header-address-keyed append geometry cache (the same shape as
 /// `WriteEngine::located`; two hard links to one dataset share one entry).
@@ -218,15 +348,26 @@ impl Store for BoundedStore {
 pub(crate) struct BoundedEngine {
     store: BoundedStore,
     located: HashMap<u64, LocatedState>,
+    /// Free-space persistence state when the file was created with
+    /// `H5Pset_file_space_strategy(persist = true)`; `None` for a non-persisting
+    /// file (the common case).
+    persist: Option<BoundedPersistState>,
+    /// End-of-file at open. The on-disk free-space managers become stale only
+    /// once an append grows the file past them, so `store.len() == original_len`
+    /// at [`finalize_persist`](BoundedEngine::finalize_persist) means nothing was
+    /// appended above the managers and the rewrite can be skipped (no no-op
+    /// growth on an unchanged file).
+    original_len: u64,
 }
 
 impl BoundedEngine {
     /// Open `path` read-write with bounded memory: exclusive OS lock, bounded
-    /// superblock discovery, and the same eligibility rules the immediate
-    /// in-place append enforces — refused up front (at open) because this
-    /// backend has no staged fallback: a latest-format (v2/v3) superblock,
-    /// 8-byte offsets and lengths, no userblock, and no persisted free-space
-    /// managers.
+    /// superblock discovery, and the eligibility rules refused up front (at open)
+    /// because this backend has no staged fallback: a latest-format (v2/v3)
+    /// superblock, 8-byte offsets and lengths, and no userblock. A file that
+    /// persists its free space is supported when non-paged (its managers are
+    /// seeded here and rewritten at [`finalize_persist`](Self::finalize_persist));
+    /// the paged strategy is refused (issue #173).
     pub(crate) fn open(path: &Path, metadata_cache: MetadataCacheConfig) -> Result<Self, Error> {
         let handle = std::fs::OpenOptions::new()
             .read(true)
@@ -259,17 +400,11 @@ impl BoundedEngine {
                  (non-zero base address); use File::open_rw",
             ));
         }
-        if persisted_free_space_armed(&raw, &superblock) {
-            // The mirror backend's staged commit rewrites persisted free-space
-            // managers consistently; this backend has no staged path, so an EOF
-            // append would leave the on-disk managers stale. Refuse at open
-            // (conservatively: even when the manager blocks themselves would
-            // fail to load) rather than corrupt them.
-            return Err(Error::EditUnsupported(
-                "bounded read-write access does not support a file that persists its \
-                 free space (H5Pset_file_space_strategy persist=true); use File::open_rw",
-            ));
-        }
+        // A file that persists its free space is now supported (issue #173): seed
+        // the free list from its on-disk managers and rewrite them at close. The
+        // paged strategy is still refused here (it needs page-aligned allocation,
+        // issue #173 Phase 2); `load_bounded_persist` returns that error.
+        let persist = load_bounded_persist(&raw, &superblock)?;
 
         Ok(Self {
             store: BoundedStore {
@@ -285,6 +420,8 @@ impl BoundedEngine {
                 }),
             },
             located: HashMap::new(),
+            persist,
+            original_len: len,
         })
     }
 
@@ -298,12 +435,87 @@ impl BoundedEngine {
         Store::sync(&mut self.store)
     }
 
+    /// Rewrite the on-disk free-space managers into canonical (manager-at-tail)
+    /// shape for a file that persists its free space (issue #173). A no-op for a
+    /// non-persisting file, and skipped when nothing was appended past the
+    /// managers (`store.len()` unchanged), so an unchanged file never grows.
+    /// Called by [`File::close`](crate::File::close) and, best-effort, by
+    /// `FileInner::drop` for a handle dropped without `close`: the bounded backend
+    /// appends at end-of-file throughout a session, so once it grows, the old
+    /// managers end up mid-file with data after them; this re-homes a fresh
+    /// extension + `FSHD`/`FSSE` pair past the appended data and repoints the
+    /// superblock last, leaving exactly the shape the reference C library writes
+    /// and reads back (verified in the crosscheck).
+    ///
+    /// If a session that grew the file ends without a `close` or `drop` running
+    /// (a true crash — `SIGKILL`, power loss), the managers are left mid-file with
+    /// the extension's `eoa_pre_fsm` below the appended data. Every append was
+    /// durable and crash-atomic, so no data is lost, and both this crate and the
+    /// reference C library reopen the file and read it correctly; but the on-disk
+    /// managers are non-canonical until a clean rewrite (this crate re-seeds them
+    /// from the still-valid message on the next open; a C-library reopen re-settles
+    /// them). Prefer an explicit `close` for the canonical result.
+    pub(crate) fn finalize_persist(&mut self) -> Result<(), Error> {
+        // Nothing appended past the managers -> they are still canonical; skip the
+        // rewrite so an unchanged (or partial-chunk-only) session never grows the
+        // file.
+        if self.persist.is_none() || self.store.len() == self.original_len {
+            return Ok(());
+        }
+        let Some(ps) = self.persist.take() else {
+            return Ok(());
+        };
+        let BoundedPersistState {
+            strategy,
+            threshold,
+            page_size,
+            mut free,
+            old_blocks,
+            old_ext_addr,
+        } = ps;
+
+        // The old extension + manager blocks are superseded by the rewrite, so
+        // they join the free list (their space becomes reclaimable).
+        for &(a, l) in &old_blocks {
+            free.free(a, l);
+        }
+        let sections: Vec<FreeSection> = free
+            .sections()
+            .into_iter()
+            .map(|(addr, size)| FreeSection { addr, size })
+            .collect();
+
+        // Read the current extension's message region (single chunk), then write
+        // the canonical tail past the appended data and repoint the superblock.
+        let (region, _ext_len) = read_single_chunk_ext_region(&self.store, old_ext_addr)?;
+        let new_old_blocks = self
+            .store
+            .write_persist_tail(&region, strategy, threshold, page_size, &sections)?;
+
+        // Re-arm from the just-written shape so a subsequent finalize (or a
+        // future append+finalize) stays consistent. `free` is the post list; the
+        // new extension address is the one the repoint recorded.
+        self.persist = Some(BoundedPersistState {
+            strategy,
+            threshold,
+            page_size,
+            free,
+            old_blocks: new_old_blocks,
+            old_ext_addr: self
+                .store
+                .superblock
+                .superblock_extension_address
+                .unwrap_or(old_ext_addr),
+        });
+        Ok(())
+    }
+
     /// Locate (or fetch the cached) append geometry for the dataset at
     /// `oh_addr`, so the public append path can slice a large call into
     /// aligned batches *before* building each batch's byte buffer — keeping
     /// peak memory at one batch rather than the whole call.
     pub(crate) fn append_geometry(&mut self, oh_addr: u64) -> Result<AppendGeometry, Error> {
-        let Self { store, located } = self;
+        let Self { store, located, .. } = self;
         let st = match located.entry(oh_addr) {
             std::collections::hash_map::Entry::Occupied(e) => e.into_mut(),
             std::collections::hash_map::Entry::Vacant(e) => {
@@ -343,7 +555,7 @@ impl BoundedEngine {
                 "append mixes element types in one call; use one element type per append",
             ));
         }
-        let Self { store, located } = self;
+        let Self { store, located, .. } = self;
         let st = match located.entry(oh_addr) {
             std::collections::hash_map::Entry::Occupied(e) => e.into_mut(),
             std::collections::hash_map::Entry::Vacant(e) => {
@@ -409,39 +621,98 @@ impl BoundedEngine {
     }
 }
 
-/// Whether the file records persisted free-space managers (the
-/// `H5Pset_file_space_strategy(..., persist = true)` case): a parseable File
-/// Space Info message in the superblock extension with its persist flag set.
-/// Best-effort on the *extension* itself (a missing or malformed extension
-/// reads as non-persisting, matching `WriteEngine`'s loader).
-fn persisted_free_space_armed(raw: &RawSource<'_>, superblock: &Superblock) -> bool {
-    let Some(rel) = superblock.superblock_extension_address else {
-        return false;
-    };
+/// Parse the File Space Info message from the file's superblock extension, if
+/// present and readable. Best-effort on the *extension* itself (a missing or
+/// malformed extension reads as `None`, matching `WriteEngine`'s loader).
+fn ext_file_space_info(raw: &RawSource<'_>, superblock: &Superblock) -> Option<FileSpaceInfo> {
+    let rel = superblock.superblock_extension_address?;
     if rel == u64::MAX {
-        return false;
+        return None;
     }
     // base_address == 0 is validated before this runs, so `rel` is absolute.
-    let Ok(header) = ObjectHeader::parse_from_source(
+    let header = ObjectHeader::parse_from_source(
         raw,
         rel,
         superblock.offset_size,
         superblock.length_size,
         0,
-    ) else {
-        return false;
-    };
-    let Some(msg) = header
+    )
+    .ok()?;
+    let msg = header
         .messages
         .iter()
-        .find(|m| m.msg_type == MessageType::FileSpaceInfo)
-    else {
-        return false;
+        .find(|m| m.msg_type == MessageType::FileSpaceInfo)?;
+    FileSpaceInfo::parse(&msg.data, superblock.offset_size, superblock.length_size).ok()
+}
+
+/// Seed a [`BoundedPersistState`] for a file that persists its free space (issue
+/// #173), or `Ok(None)` when the file does not persist. Mirrors
+/// `WriteEngine::load_persisted_free_space` over a random-access [`Source`]: it
+/// reads only the small manager/extension blocks, so it stays bounded-memory.
+/// The paged strategy is refused (it needs page-aligned allocation, Phase 2).
+/// The caller has already validated `base_address == 0` and a v2/v3 superblock.
+fn load_bounded_persist(
+    raw: &RawSource<'_>,
+    superblock: &Superblock,
+) -> Result<Option<BoundedPersistState>, Error> {
+    let Some(info) = ext_file_space_info(raw, superblock) else {
+        return Ok(None);
     };
-    matches!(
-        FileSpaceInfo::parse(&msg.data, superblock.offset_size, superblock.length_size),
-        Ok(info) if info.persist
-    )
+    // Refuse the paged strategy regardless of the persist flag: the writer does
+    // not yet do page-aligned allocation, so appending at a raw end-of-file would
+    // break the paged invariants (issue #173 Phase 2). Checked before the persist
+    // early-return so a paged, non-persisting file is refused too, matching the
+    // documented behavior.
+    if info.strategy == FileSpaceStrategy::Page {
+        return Err(Error::EditUnsupported(
+            "bounded read-write does not yet support the paged file-space strategy \
+             (H5F_FSPACE_STRATEGY_PAGE); use File::open_rw",
+        ));
+    }
+    if !info.persist {
+        return Ok(None);
+    }
+    let os = superblock.offset_size;
+    let ext_addr = superblock
+        .superblock_extension_address
+        .expect("ext_file_space_info returned Some, so the extension address is set");
+
+    // Seed the free list from the on-disk managers. A malformed or truncated
+    // manager is tolerated exactly as the mirror loader tolerates it (open, arm
+    // persistence, seed nothing) rather than failing the open — the file stays
+    // openable, and the finalize simply rewrites whatever we could recover.
+    let (mut sections, manager_blocks) =
+        read_persisted_sections_source(raw, &info.manager_addrs, 0, os)
+            .unwrap_or_else(|_| (Vec::new(), Vec::new()));
+    let mut free = FreeList::new();
+    let file_len = raw.len();
+    sections.sort_by_key(|s| s.addr);
+    let mut prev_end = 0u64;
+    for s in sections {
+        let Some(end) = s.addr.checked_add(s.size) else {
+            continue;
+        };
+        if s.size == 0 || end > file_len || s.addr < prev_end {
+            continue;
+        }
+        prev_end = end;
+        free.free(s.addr, s.size);
+    }
+
+    // Record the blocks the live file uses (extension header + each FSHD/FSSE) so
+    // the next finalize frees them when it writes replacements.
+    let mut old_blocks = manager_blocks;
+    let (_region, ext_len) = read_single_chunk_ext_region(raw, ext_addr)?;
+    old_blocks.push((ext_addr, ext_len));
+
+    Ok(Some(BoundedPersistState {
+        strategy: info.strategy,
+        threshold: info.threshold,
+        page_size: info.page_size,
+        free,
+        old_blocks,
+        old_ext_addr: ext_addr,
+    }))
 }
 
 #[cfg(test)]
@@ -533,5 +804,42 @@ mod tests {
             .unwrap();
         assert_eq!(got.len(), total as usize);
         assert!(got.iter().enumerate().all(|(i, &v)| v == i as i32));
+    }
+
+    /// A persisting file appended through the bounded engine and dropped WITHOUT
+    /// `finalize_persist` (the true-crash case — `BoundedEngine` itself has no
+    /// `Drop`; only `FileInner::drop` finalizes) still reads back every durable
+    /// append. Dropping the engine releases the exclusive lock, so the reopen is
+    /// portable (no leaked lock). The finalize-at-close path is covered by the
+    /// `tests/bounded_append.rs` integration tests.
+    #[test]
+    fn persist_append_without_finalize_is_readable() {
+        let dir = tempdir().unwrap();
+        let p = dir.path().join("persist_crash.h5");
+        let mut b = FileBuilder::new();
+        b.with_file_space_strategy(crate::FileSpaceStrategy::FsmAggr, true, 1);
+        b.create_dataset("d")
+            .with_i32_data(&(0..6).collect::<Vec<i32>>())
+            .with_shape(&[6])
+            .with_maxshape(&[u64::MAX])
+            .with_chunks(&[4]);
+        b.write(&p).unwrap();
+        {
+            let mut engine = BoundedEngine::open(&p, MetadataCacheConfig::disabled()).unwrap();
+            assert!(engine.persist.is_some(), "persist state is armed at open");
+            let addr = dataset_addr(&engine);
+            let mut ab = AppendBuilder::new();
+            ab.append_i32(&(6..20).collect::<Vec<_>>());
+            engine.append_gathered(addr, &ab, 4).unwrap();
+            // Drop the engine without calling finalize_persist: models a true
+            // crash and releases the OS lock.
+        }
+        let got = crate::File::open(&p)
+            .unwrap()
+            .dataset("d")
+            .unwrap()
+            .read_i32()
+            .unwrap();
+        assert_eq!(got, (0..20).collect::<Vec<_>>());
     }
 }

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -2467,36 +2467,7 @@ impl WriteEngine {
         info: &FileSpaceInfo,
     ) -> Result<Vec<u8>, Error> {
         let region = Self::gather_oh_messages(&self.data, ext_addr, self.superblock.base_address)?;
-        let new_body = info.serialize();
-        // The message body is the fixed-size File Space Info record (≤ 125 bytes),
-        // so it always fits the u16 size field; `try_from` keeps this off the
-        // 32-bit narrowing-cast ledger.
-        let new_len = u16::try_from(new_body.len())
-            .map_err(|_| Error::EditUnsupported("File Space Info message too large"))?;
-        let mut out = Vec::with_capacity(region.len());
-        let mut p = 0;
-        let mut replaced = false;
-        while let Some((msg_type, _body, body_end)) = next_message(&region, p)? {
-            if msg_type == MessageType::FileSpaceInfo {
-                out.push(region[p]); // message type byte
-                out.extend_from_slice(&new_len.to_le_bytes());
-                out.push(region[p + 3]); // preserve the message flags (0x14)
-                out.extend_from_slice(&new_body);
-                replaced = true;
-            } else {
-                out.extend_from_slice(&region[p..body_end]);
-            }
-            p = body_end;
-        }
-        if !replaced {
-            // Persistence is armed only when the extension already carries a File
-            // Space Info message, so this is unreachable; refuse rather than
-            // silently restructure an extension we did not understand.
-            return Err(Error::EditUnsupported(
-                "a persisting file's superblock extension has no File Space Info message",
-            ));
-        }
-        Ok(out)
+        rewrite_extension_region_bytes(&region, info)
     }
 
     /// Repoint a version 0/1 superblock at the rebuilt (now v2) root group and
@@ -2528,7 +2499,7 @@ impl WriteEngine {
     /// `addr`, returning the `[start, end)` byte range of its message region.
     /// Rejects headers that are not OHDR v2 or that track message creation order
     /// (whose 6-byte message records this engine does not emit).
-    fn oh_region(d: &[u8], addr: usize) -> Result<(usize, usize), Error> {
+    pub(crate) fn oh_region(d: &[u8], addr: usize) -> Result<(usize, usize), Error> {
         if d.len() < addr + 6 || &d[addr..addr + 4] != b"OHDR" || d[addr + 4] != 2 {
             return Err(Error::EditUnsupported(
                 "an object does not use a version 2 object header",
@@ -6634,7 +6605,95 @@ fn is_prefix(a: &[String], b: &[String]) -> bool {
 /// record begins at `body end`. Returns `Ok(None)` once fewer than 4 bytes
 /// remain (a clean end of the region), and `Err` if a record's declared body
 /// runs past the region. Centralizes the bounds check shared by every walker.
-fn next_message(region: &[u8], p: usize) -> Result<Option<(MessageType, usize, usize)>, Error> {
+/// Rebuild a superblock-extension object header's message region (as collapsed by
+/// [`WriteEngine::gather_oh_messages`] or [`read_single_chunk_ext_region`]) with
+/// its File Space Info message replaced by `info`, preserving every other message
+/// verbatim. The persisting message is fixed-size, so the region length is stable.
+/// Shared by the whole-file mirror commit and the bounded finalize so both write
+/// the same extension bytes.
+pub(crate) fn rewrite_extension_region_bytes(
+    region: &[u8],
+    info: &FileSpaceInfo,
+) -> Result<Vec<u8>, Error> {
+    let new_body = info.serialize();
+    // The message body is the fixed-size File Space Info record (≤ 125 bytes),
+    // so it always fits the u16 size field; `try_from` keeps this off the
+    // 32-bit narrowing-cast ledger.
+    let new_len = u16::try_from(new_body.len())
+        .map_err(|_| Error::EditUnsupported("File Space Info message too large"))?;
+    let mut out = Vec::with_capacity(region.len());
+    let mut p = 0;
+    let mut replaced = false;
+    while let Some((msg_type, _body, body_end)) = next_message(region, p)? {
+        if msg_type == MessageType::FileSpaceInfo {
+            out.push(region[p]); // message type byte
+            out.extend_from_slice(&new_len.to_le_bytes());
+            out.push(region[p + 3]); // preserve the message flags (0x14)
+            out.extend_from_slice(&new_body);
+            replaced = true;
+        } else {
+            out.extend_from_slice(&region[p..body_end]);
+        }
+        p = body_end;
+    }
+    if !replaced {
+        // Persistence is armed only when the extension already carries a File
+        // Space Info message, so this is unreachable; refuse rather than
+        // silently restructure an extension we did not understand.
+        return Err(Error::EditUnsupported(
+            "a persisting file's superblock extension has no File Space Info message",
+        ));
+    }
+    Ok(out)
+}
+
+/// Read and collapse a **single-chunk** superblock-extension object header's
+/// message region from a random-access [`Source`], for the bounded backend which
+/// has no whole-file mirror to hand [`WriteEngine::gather_oh_messages`] a `&[u8]`.
+/// The extension every writer (this crate's and the C library's) emits for a
+/// persisting file is a single OHDR chunk; a multi-chunk extension (a
+/// `Continuation` message) is refused so the caller falls back to `File::open_rw`.
+/// Returns the collapsed message region and the full byte length of the
+/// single-chunk object header at `ext_addr` (`OHDR` prefix + region + 4-byte
+/// checksum), so the caller can both rewrite the extension and record its extent
+/// as reclaimable free space.
+pub(crate) fn read_single_chunk_ext_region<S: crate::source::Source>(
+    src: &S,
+    ext_addr: u64,
+) -> Result<(Vec<u8>, u64), Error> {
+    // The extension is tiny (a File Space Info message plus at most a few small
+    // messages); a bounded window covers its whole chunk. Reading past end-of-file
+    // is clamped so a near-EOF extension still reads.
+    const WINDOW: u64 = 4096;
+    let avail = src.len().saturating_sub(ext_addr);
+    let want = WINDOW.min(avail).to_usize()?;
+    let buf = src.read_exact_at(ext_addr, want).map_err(Error::Format)?;
+    let (rs, re) = WriteEngine::oh_region(&buf, 0).map_err(|_| {
+        Error::EditUnsupported(
+            "bounded read-write cannot read the superblock extension (not a single-chunk \
+             version 2 object header); use File::open_rw",
+        )
+    })?;
+    // Refuse a continuation: the bounded reader only understands a single chunk.
+    let mut p = rs;
+    while let Some((msg_type, _body, body_end)) = next_message(&buf[..re], p)? {
+        if msg_type == MessageType::ObjectHeaderContinuation {
+            return Err(Error::EditUnsupported(
+                "bounded read-write does not support a multi-chunk superblock extension; \
+                 use File::open_rw",
+            ));
+        }
+        p = body_end;
+    }
+    // `oh_region` validated `re + 4 <= buf.len()`, so the checksum is present and
+    // the full object-header length is `re + 4`.
+    Ok((buf[rs..re].to_vec(), (re + 4) as u64))
+}
+
+pub(crate) fn next_message(
+    region: &[u8],
+    p: usize,
+) -> Result<Option<(MessageType, usize, usize)>, Error> {
     if p + 4 > region.len() {
         return Ok(None);
     }
@@ -6763,7 +6822,7 @@ fn datatype_copies_foreign_address(dt: &crate::datatype::Datatype) -> bool {
 /// Wrap a chunk-0 message region in a fresh single-chunk version 2 object header
 /// (`OHDR` prefix + region + Jenkins checksum). Mirrors the encoding in
 /// [`crate::object_header_writer::ObjectHeaderWriter::serialize`].
-fn build_v2_object_header(region: &[u8]) -> Vec<u8> {
+pub(crate) fn build_v2_object_header(region: &[u8]) -> Vec<u8> {
     let total = region.len();
     let (flags, width) = if total <= 255 {
         (0u8, 1usize)

--- a/src/free_space_manager.rs
+++ b/src/free_space_manager.rs
@@ -324,6 +324,46 @@ pub(crate) fn read_persisted_sections(
     Ok(sections)
 }
 
+/// The free sections recovered from the on-disk managers, paired with the
+/// `(addr, len)` extents of every `FSHD`/`FSSE` block that was read (so a caller
+/// rewriting the managers can reclaim those blocks).
+pub(crate) type PersistedSections = (Vec<FreeSection>, Vec<(u64, u64)>);
+
+/// The bounded-memory counterpart of [`read_persisted_sections`]: read every
+/// persisted free section from the managers named in `manager_addrs` over a
+/// random-access [`Source`] instead of a whole-file `&[u8]`, so the bounded
+/// backend can seed its free list without a mirror. Only the small manager
+/// blocks are read; nothing scales with file size.
+pub(crate) fn read_persisted_sections_source<S: crate::source::Source>(
+    src: &S,
+    manager_addrs: &[u64],
+    base: u64,
+    offset_size: u8,
+) -> Result<PersistedSections, FormatError> {
+    let bad = || FormatError::InvalidFreeSpaceManager;
+    let mut sections = Vec::new();
+    let mut blocks = Vec::new();
+    let hdr_len = fshd_len(offset_size);
+    for &addr in manager_addrs {
+        if addr == u64::MAX {
+            continue;
+        }
+        let a = base.checked_add(addr).ok_or_else(bad)?;
+        let fshd = src.read_exact_at(a, hdr_len.to_usize()?)?;
+        let header = FsmHeader::parse(&fshd, offset_size)?;
+        blocks.push((a, hdr_len));
+        if header.fsse_addr == u64::MAX {
+            continue;
+        }
+        let fa = base.checked_add(header.fsse_addr).ok_or_else(bad)?;
+        let used = header.fsse_used;
+        let block = src.read_exact_at(fa, used.to_usize()?)?;
+        sections.extend(parse_fsse(&block, &header, offset_size)?);
+        blocks.push((fa, used));
+    }
+    Ok((sections, blocks))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -291,16 +291,33 @@ struct FileInner {
 }
 
 impl Drop for FileInner {
-    /// Best-effort clear of the SWMR-write flag for a writer dropped without an
-    /// explicit [`File::close`] (mirroring `SwmrWriter::drop`). Runs only when the
-    /// last `Arc<FileInner>` clone drops; a clean `close` already cleared the flag
-    /// and set `closed`, so this is idempotent and skipped in that case.
+    /// Best-effort cleanup for a writer dropped without an explicit
+    /// [`File::close`], running only when the last `Arc<FileInner>` clone drops;
+    /// a clean `close` already did this work and set `closed`, so this is
+    /// idempotent and skipped in that case.
+    ///
+    /// - A SWMR writer clears the superblock's SWMR-write flag (mirroring
+    ///   `SwmrWriter::drop`).
+    /// - A bounded read-write file that persists its free space rewrites its
+    ///   on-disk free-space managers into canonical shape (issue #173), so a
+    ///   dropped-without-`close` handle leaves the same file a clean `close`
+    ///   would (a no-op unless an append grew the file). A true crash (`SIGKILL`,
+    ///   power loss) skips `drop` entirely; the appended data is still durable.
     fn drop(&mut self) {
-        if self.swmr_write && !self.closed.load(Ordering::Acquire) {
-            if let Backend::Mirror(m) = &self.backend {
+        if self.closed.load(Ordering::Acquire) {
+            return;
+        }
+        match &self.backend {
+            Backend::Mirror(m) if self.swmr_write => {
                 let mut session = m.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
                 let _ = session.set_consistency_flags(0);
             }
+            Backend::Bounded(m) => {
+                let mut engine = m.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+                let _ = engine.finalize_persist();
+                let _ = engine.sync();
+            }
+            _ => {}
         }
     }
 }
@@ -1522,10 +1539,20 @@ impl File {
     /// [`Error::BoundedStagedUnsupported`](crate::Error::BoundedStagedUnsupported);
     /// open with [`open_rw`](Self::open_rw) for those.
     ///
+    /// A file that persists its free space
+    /// (`H5Pset_file_space_strategy(persist = true)`, non-paged) is supported:
+    /// its on-disk free-space managers are seeded at open and rewritten into
+    /// canonical shape when the file is closed — by an explicit
+    /// [`close`](Self::close) or, best-effort, when the last handle drops (issue
+    /// #173). Only a true crash (`SIGKILL`, power loss) skips that rewrite; the
+    /// appended data is still durable and reopens correctly, the managers merely
+    /// stay non-canonical until the next clean rewrite. The **paged** file-space
+    /// strategy (`H5F_FSPACE_STRATEGY_PAGE`) is not yet supported here and is
+    /// refused at open.
+    ///
     /// Requires a latest-format (v2/v3 superblock) file with 8-byte offsets and
-    /// lengths, no userblock, and no persisted free-space managers; other files
-    /// are refused at open with
-    /// [`Error::EditUnsupported`](crate::Error::EditUnsupported).
+    /// lengths and no userblock; other files (including paged ones) are refused
+    /// at open with [`Error::EditUnsupported`](crate::Error::EditUnsupported).
     pub fn open_rw_bounded<P: AsRef<std::path::Path>>(path: P) -> Result<Self, Error> {
         Self::open_rw_bounded_with_options(path, FileAccessOptions::new())
     }
@@ -1650,10 +1677,14 @@ impl File {
     /// reads still work.
     pub fn close(self) -> Result<(), Error> {
         if let Backend::Bounded(m) = &self.inner.backend {
-            // Every bounded append is already durable; issue a final barrier
-            // and seal the file. The exclusive lock releases when the last
-            // derived handle drops, as for a mirror file.
+            // Every bounded append is already durable. For a file that persists
+            // its free space, rewrite the on-disk free-space managers into their
+            // canonical (manager-at-tail) shape here — the one place a bounded
+            // session has to do it, since it has no staged commit (issue #173).
+            // Then issue a final barrier and seal the file. The exclusive lock
+            // releases when the last derived handle drops, as for a mirror file.
             let mut engine = m.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            engine.finalize_persist()?;
             engine.sync()?;
             drop(engine);
             self.inner.closed.store(true, Ordering::Release);

--- a/tests/bounded_append.rs
+++ b/tests/bounded_append.rs
@@ -214,20 +214,162 @@ fn userblock_file_is_refused_at_open() {
     assert!(matches!(err, Error::EditUnsupported(_)), "got: {err:?}");
 }
 
+/// A file that persists its free space (non-paged) is now supported by the
+/// bounded backend (issue #173): append in place, then `close` rewrites the
+/// on-disk free-space managers so a reopen recovers the data and the strategy.
 #[test]
-fn persisted_free_space_file_is_refused_at_open() {
+fn persisted_free_space_file_appends_and_finalizes() {
     let dir = tempdir().unwrap();
     let p = dir.path().join("persist.h5");
     let mut b = FileBuilder::new();
     b.with_file_space_strategy(FileSpaceStrategy::FsmAggr, true, 1);
     b.create_dataset("d")
-        .with_i32_data(&[1, 2, 3])
-        .with_shape(&[3])
+        .with_i32_data(&(0..10).collect::<Vec<i32>>())
+        .with_shape(&[10])
         .with_maxshape(&[u64::MAX])
-        .with_chunks(&[2]);
+        .with_chunks(&[4]);
     b.write(&p).unwrap();
-    let err = File::open_rw_bounded(&p).unwrap_err();
-    assert!(matches!(err, Error::EditUnsupported(_)), "got: {err:?}");
+
+    {
+        let file = File::open_rw_bounded(&p).unwrap();
+        let mut ds = file.dataset("d").unwrap();
+        ds.append(&(10..25).collect::<Vec<i32>>()).unwrap();
+        file.close().unwrap();
+    }
+
+    // The reopened file reads the full sequence and still records the persisting
+    // strategy, and hdf5-pure recovers free space the finalize wrote on disk.
+    let f = File::open(&p).unwrap();
+    assert_eq!(
+        f.dataset("d").unwrap().read_i32().unwrap(),
+        (0..25).collect::<Vec<_>>()
+    );
+    assert_eq!(f.file_space_strategy(), Some(FileSpaceStrategy::FsmAggr));
+    assert!(
+        f.file_space_info().unwrap().persist,
+        "the finalize keeps the persist flag set"
+    );
+    // The finalize freed the superseded extension + manager blocks, so the
+    // reopened file recovers at least one persisted free section.
+    assert!(
+        !f.persisted_free_space().is_empty(),
+        "expected persisted free sections after finalize"
+    );
+}
+
+/// Several bounded appends over one held-open persisting file, then one close:
+/// the finalize runs once and the reopened file reads the whole sequence.
+#[test]
+fn persisted_free_space_many_appends_one_finalize() {
+    let dir = tempdir().unwrap();
+    let p = dir.path().join("persist_many.h5");
+    let mut b = FileBuilder::new();
+    b.with_file_space_strategy(FileSpaceStrategy::FsmAggr, true, 3);
+    b.create_dataset("d")
+        .with_i32_data(&[0])
+        .with_shape(&[1])
+        .with_maxshape(&[u64::MAX])
+        .with_chunks(&[16]);
+    b.write(&p).unwrap();
+
+    {
+        let file = File::open_rw_bounded(&p).unwrap();
+        let mut ds = file.dataset("d").unwrap();
+        for start in (1..200).step_by(20) {
+            let end = (start + 20).min(200);
+            ds.append(&(start..end).collect::<Vec<i32>>()).unwrap();
+        }
+        file.close().unwrap();
+    }
+    assert_eq!(read_i32(&p), (0..200).collect::<Vec<_>>());
+}
+
+/// A dropped bounded persisting session (no `close`, i.e. an unclean exit) still
+/// leaves a file whose appended data is durable and readable — the finalize is
+/// on a persist file finalizes it (rewrites the managers into canonical shape),
+/// just like an explicit `close`.
+#[test]
+fn persisted_free_space_drop_finalizes() {
+    let dir = tempdir().unwrap();
+    let p = dir.path().join("persist_drop.h5");
+    let mut b = FileBuilder::new();
+    b.with_file_space_strategy(FileSpaceStrategy::FsmAggr, true, 1);
+    b.create_dataset("d")
+        .with_i32_data(&(0..8).collect::<Vec<i32>>())
+        .with_shape(&[8])
+        .with_maxshape(&[u64::MAX])
+        .with_chunks(&[4]);
+    b.write(&p).unwrap();
+
+    {
+        let file = File::open_rw_bounded(&p).unwrap();
+        let mut ds = file.dataset("d").unwrap();
+        ds.append(&(8..16).collect::<Vec<i32>>()).unwrap();
+        // Drop without close: the Drop guard runs the finalize best-effort.
+    }
+    assert_eq!(read_i32(&p), (0..16).collect::<Vec<_>>());
+    // The dropped-without-close file is finalized: managers are canonical, so a
+    // reopen recovers persisted free space, exactly as after an explicit close.
+    let f = File::open(&p).unwrap();
+    assert_eq!(f.file_space_strategy(), Some(FileSpaceStrategy::FsmAggr));
+    assert!(
+        !f.persisted_free_space().is_empty(),
+        "a dropped handle finalizes like close"
+    );
+}
+
+/// Opening a persist file and closing it without appending anything must not
+/// grow the file — the finalize is skipped when nothing was appended.
+#[test]
+fn persisted_free_space_noop_close_does_not_grow() {
+    let dir = tempdir().unwrap();
+    let p = dir.path().join("persist_noop.h5");
+    let mut b = FileBuilder::new();
+    b.with_file_space_strategy(FileSpaceStrategy::FsmAggr, true, 1);
+    b.create_dataset("d")
+        .with_i32_data(&(0..8).collect::<Vec<i32>>())
+        .with_shape(&[8])
+        .with_maxshape(&[u64::MAX])
+        .with_chunks(&[4]);
+    b.write(&p).unwrap();
+    let before = std::fs::metadata(&p).unwrap().len();
+
+    File::open_rw_bounded(&p).unwrap().close().unwrap();
+    assert_eq!(
+        std::fs::metadata(&p).unwrap().len(),
+        before,
+        "a no-append close must not grow the file"
+    );
+    // Repeated open/close cycles also leave the size fixed.
+    for _ in 0..3 {
+        File::open_rw_bounded(&p).unwrap().close().unwrap();
+    }
+    assert_eq!(std::fs::metadata(&p).unwrap().len(), before);
+}
+
+/// The paged file-space strategy is refused by the bounded backend (issue #173
+/// Phase 2), whether or not it persists free space: page-aligned allocation is
+/// not implemented yet.
+#[test]
+fn paged_file_is_refused_at_open() {
+    let dir = tempdir().unwrap();
+    for (name, persist) in [("paged_persist.h5", true), ("paged_plain.h5", false)] {
+        let p = dir.path().join(name);
+        let mut b = FileBuilder::new();
+        b.with_file_space_strategy(FileSpaceStrategy::Page, persist, 0)
+            .with_file_space_page_size(4096);
+        b.create_dataset("d")
+            .with_i32_data(&[1, 2, 3])
+            .with_shape(&[3])
+            .with_maxshape(&[u64::MAX])
+            .with_chunks(&[2]);
+        b.write(&p).unwrap();
+        let err = File::open_rw_bounded(&p).unwrap_err();
+        assert!(
+            matches!(err, Error::EditUnsupported(_)),
+            "{name} persist={persist} got: {err:?}"
+        );
+    }
 }
 
 #[test]

--- a/tests/bounded_append_crosscheck.rs
+++ b/tests/bounded_append_crosscheck.rs
@@ -9,8 +9,26 @@
 
 use hdf5::Extent;
 use hdf5::file::LibraryVersion;
-use hdf5_pure::{File, FileBuilder};
+use hdf5::plist::file_create::FileSpaceStrategy as CStrategy;
+use hdf5_pure::{File, FileBuilder, FileSpaceStrategy};
+use std::sync::{Mutex, MutexGuard};
 use tempfile::tempdir;
+
+// The reference free-space query, resolved at link time from the statically
+// linked libhdf5: a positive result proves the C library loaded and parsed the
+// on-disk free-space managers this crate's bounded finalize wrote.
+unsafe extern "C" {
+    fn H5Fget_freespace(file_id: i64) -> i64;
+}
+
+// Serialize the raw FFI call above (which bypasses `hdf5-metno`'s internal lock)
+// against every other C-library call in this file; libhdf5 is not built
+// thread-safe here. Poisoning is ignored so one test's panic does not cascade.
+static C_LIB: Mutex<()> = Mutex::new(());
+
+fn c_lib_guard() -> MutexGuard<'static, ()> {
+    C_LIB.lock().unwrap_or_else(|e| e.into_inner())
+}
 
 /// Create a rank-1 unlimited (Extensible-Array indexed) i32 dataset `name` with the
 /// C library under the latest format, seeded with `0..n`, chunk length `chunk`.
@@ -117,6 +135,101 @@ fn bounded_batched_large_append_reads_back_in_c() {
     assert_eq!(got.len(), total as usize);
     assert!(got.iter().enumerate().all(|(i, &v)| v == i as i32));
     assert_eq!(read_pure(&path, "d").len(), total as usize);
+}
+
+/// A persisting file (this crate's writer, `persist = true`, non-paged) grown
+/// through the bounded backend and finalized at `close` reads back byte-correct
+/// in the C library, which also loads the free-space managers the finalize wrote
+/// (issue #173).
+#[test]
+fn bounded_persist_finalize_reads_back_in_c() {
+    let _c = c_lib_guard();
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("pure_persist.h5");
+
+    let mut b = FileBuilder::new();
+    b.with_file_space_strategy(FileSpaceStrategy::FsmAggr, true, 1);
+    b.create_dataset("d")
+        .with_i32_data(&(0..10).collect::<Vec<i32>>())
+        .with_shape(&[10])
+        .with_maxshape(&[u64::MAX])
+        .with_chunks(&[4]);
+    b.write(&path).unwrap();
+
+    {
+        let file = File::open_rw_bounded(&path).unwrap();
+        let mut ds = file.dataset("d").unwrap();
+        ds.append(&(10..30).collect::<Vec<i32>>()).unwrap();
+        file.close().unwrap();
+    }
+
+    let expected: Vec<i32> = (0..30).collect();
+    assert_eq!(read_pure(&path, "d"), expected);
+
+    // The C library reads the data, recovers the persisting strategy, and its
+    // free-space query parses the managers the finalize wrote.
+    let f = hdf5::File::open(&path).unwrap();
+    assert_eq!(f.dataset("d").unwrap().read_raw::<i32>().unwrap(), expected);
+    let strat = f.create_plist().unwrap().get_file_space_strategy().unwrap();
+    assert!(
+        matches!(
+            strat,
+            CStrategy::FreeSpaceManager {
+                paged: false,
+                persist: true,
+                ..
+            }
+        ),
+        "C recovers our persisting FSM strategy, got {strat:?}"
+    );
+    let free = unsafe { H5Fget_freespace(f.id()) };
+    assert!(
+        free >= 0,
+        "C loads our free-space managers without error (got {free})"
+    );
+}
+
+/// The mirror of the above: the C library creates the persisting file, the
+/// bounded backend grows it and finalizes at `close`, and both libraries read
+/// the full sequence back.
+#[test]
+fn bounded_persist_on_c_created_file_reads_back() {
+    let _c = c_lib_guard();
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("c_persist.h5");
+
+    {
+        let file = hdf5::File::with_options()
+            .with_fapl(|p| p.libver_bounds(LibraryVersion::V110, LibraryVersion::latest()))
+            .with_fcpl(|fcpl| {
+                fcpl.file_space_strategy(CStrategy::FreeSpaceManager {
+                    paged: false,
+                    persist: true,
+                    threshold: 1,
+                })
+            })
+            .create(&path)
+            .unwrap();
+        let ds = file
+            .new_dataset::<i32>()
+            .chunk((4,))
+            .shape((Extent::resizable(8),))
+            .create("d")
+            .unwrap();
+        ds.write(&(0..8).collect::<Vec<_>>()).unwrap();
+        file.close().unwrap();
+    }
+
+    {
+        let file = File::open_rw_bounded(&path).unwrap();
+        let mut ds = file.dataset("d").unwrap();
+        ds.append(&(8..20).collect::<Vec<i32>>()).unwrap();
+        file.close().unwrap();
+    }
+
+    let expected: Vec<i32> = (0..20).collect();
+    assert_eq!(read_pure(&path, "d"), expected);
+    assert_eq!(read_c(&path, "d"), expected);
 }
 
 /// Variable-length string reads route through the file source; on read-write


### PR DESCRIPTION
## Summary

`File::open_rw_bounded` can now mutate a file created with `H5Pset_file_space_strategy(persist = true)` (non-paged) with memory bounded independent of file size. This is Phase 1 of #173; the **paged** strategy (`H5F_FSPACE_STRATEGY_PAGE`) is still refused at open and is left for Phase 2 (genuine page-aligned allocation).

Before this change, `open_rw_bounded` refused any persisting file at open, and the only way to mutate one was `open_rw` + `append_staged` + `commit`, which loads the whole file into memory.

## What it does

- At open, the bounded backend seeds an in-memory free list from the file's on-disk free-space managers using positioned reads of just the small `FSHD`/`FSSE` blocks (never the whole file), so peak memory stays bounded.
- Appends run the same crash-atomic Extensible-Array engine as before, in whole-chunk batches.
- At close (an explicit `File::close`, or best-effort when the last handle drops) the managers are rewritten into their canonical manager-at-tail shape and the superblock is repointed last as the crash-atomic linearization point. The result is byte-compatible with what the reference C library writes and reads back (crosschecked, including `H5Fget_freespace`).

## Design

The bounded engine is append-only at end-of-file (the `Store` trait has no free-hole-allocating primitive), so the seeded free holes are never written into and stay valid throughout a session — only the managers' on-disk position drifts. The finalize re-homes them past the appended data. It is skipped entirely when nothing was appended past the managers (`store.len()` unchanged), so an unchanged file never grows across open/close cycles. The whole-file mirror `commit_persisting` is untouched; both paths now share the extension-rewrite helper.

A true crash (no `close`, no `drop`) leaves every durable, crash-atomic append readable — verified against libhdf5 1.14.6, which reopens read-write and adds data without truncating the appended rows — and the managers stay non-canonical only until the next clean rewrite (this crate re-seeds them on the next open; a C-library reopen re-settles them).

## Testing

All gates green locally: `cargo fmt --check`, `clippy --all-targets --all-features -D warnings`, `cargo build --no-default-features` (no_std), and the full suite (`--all-features`, including the libhdf5 crosschecks).

New coverage:

- `tests/bounded_append.rs`: append + finalize round-trip, many-appends-one-finalize, drop-finalizes-like-close, no-op close does not grow the file, and paged files refused at open (both persisting and non-persisting).
- `tests/bounded_append_crosscheck.rs`: a pure-written persisting file grown and finalized by the bounded backend reads back in the C library and `H5Fget_freespace` parses our managers; and a C-created persisting file grown by the bounded backend reads back in both libraries.
- `src/bounded.rs` unit test for the true-crash path (drop the engine without finalizing, then reopen and read).

This branch was adversarially reviewed for crash-consistency and free-space correctness; the clean path was found sound, and the reviewer's findings (unclean-exit manager staleness, loader tolerance parity with `open_rw`, no-op-close growth, and a paged-refusal doc/code gap) are all addressed here.

## Known limitation

Space vacated by an in-place chunk relocation during an append is not yet added to the free list, so it reads as "unaccounted" in `h5stat`; free-hole reuse on the bounded path remains future work. Neither affects readability or crash-consistency.

Closes #173 is intentionally **not** used — Phase 2 (genuine paged allocation) tracks the rest of the issue.
