### PR TITLE
Fuzz fapl/fcpl against libhdf5 and fix persist=true eoa_pre_fsm (#178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- A fresh file written with `persist = true` and a non-paged file-space strategy (`FsmAggr`/`Aggr`/`None`) now records a defined end-of-allocation in its File Space Info message instead of the undefined sentinel, so an assertion-enabled build of the reference C library opens it instead of aborting; release builds already tolerated it ([#178](https://github.com/stephenberry/hdf5-pure/issues/178)).
 - The refusal when opening a *non-persisting* paged file with `File::open_rw_bounded` no longer points at `File::open_rw` (which also refuses a paged file); it now advises recreating the file with `persist = true`, the way to grow a paged file in place ([#178](https://github.com/stephenberry/hdf5-pure/issues/178)).
 
 ## [0.23.0] - 2026-07-22

--- a/src/file_space_info.rs
+++ b/src/file_space_info.rs
@@ -128,9 +128,12 @@ impl FileSpaceInfo {
 
     /// A persisting message for a file with no free space yet (the form
     /// [`FileBuilder`](crate::FileBuilder) emits for `persist = true`): the
-    /// persist flag is set but every manager slot is undefined and no FSM space
-    /// has been allocated, so `eoa_pre_fsm` is [`UNDEF`]. This matches what the C
-    /// library records when persistence is on but nothing is tracked.
+    /// persist flag is set and every manager slot is undefined because no FSM
+    /// space has been allocated. `eoa_pre_fsm` is left [`UNDEF`] here as a
+    /// placeholder; the writer overwrites it with the real end-of-allocation once
+    /// the layout is known, because libhdf5 requires a persisting file to record a
+    /// defined `eoa_fsm_fsalloc` (an assertion-enabled build aborts on the
+    /// sentinel — issue #178).
     pub(crate) fn persistent_empty(
         strategy: FileSpaceStrategy,
         threshold: u64,

--- a/src/file_writer.rs
+++ b/src/file_writer.rs
@@ -674,6 +674,23 @@ impl FileWriter {
         // is independent of the file layout, so build it up front and place it
         // after all other content below.
         let ext_oh = self.file_space_extension_oh();
+        // A persisting *non-paged* file's placeholder File Space Info message (built
+        // just above) records `eoa_pre_fsm` = UNDEF, because a fresh file has no
+        // free-space-manager blocks. libhdf5 requires `fs_persist => eoa_fsm_fsalloc
+        // != UNDEF`, and an assertion-enabled build aborts on the sentinel
+        // (H5Fsuper.c), so the non-paged tail below rewrites the message with a real
+        // end-of-allocation once the layout is known (issue #178). Capture the
+        // parameters here, while `self` is intact. (The paged path has its own
+        // manager-aware rewrite; a `Page` file never reaches the non-paged tail.)
+        let nonpaged_persist: Option<(FileSpaceStrategy, u64, u64)> = match self.file_space_strategy
+        {
+            Some((strategy, true, threshold)) if strategy != FileSpaceStrategy::Page => Some((
+                strategy,
+                threshold,
+                self.file_space_page_size.unwrap_or(DEFAULT_PAGE_SIZE),
+            )),
+            _ => None,
+        };
         struct DsFlat {
             name: String,
             dt: Datatype,
@@ -1983,7 +2000,27 @@ impl FileWriter {
         }
 
         // Superblock extension (File Space Info), at the address recorded above.
-        if let Some(bytes) = &ext_oh {
+        // For a persisting non-paged file, rebuild the message with a real
+        // end-of-allocation — the end of all content, since no FSM blocks follow —
+        // in place of the UNDEF placeholder (see the capture above; issue #178). The
+        // message length is unchanged (only the `eoa_pre_fsm` field differs), so the
+        // reserved layout still holds.
+        let real_ext_oh = match (&ext_oh, nonpaged_persist) {
+            (Some(_), Some((strategy, threshold, np_page_size))) => {
+                let mut info = FileSpaceInfo::persistent_empty(strategy, threshold, np_page_size);
+                info.eoa_pre_fsm = eof_addr2 - ub as u64;
+                let mut oh = ObjectHeaderWriter::new();
+                oh.add_message_with_flags(MessageType::FileSpaceInfo, info.serialize(), 0x14);
+                Some(oh.serialize())
+            }
+            (other, _) => other.clone(),
+        };
+        debug_assert_eq!(
+            real_ext_oh.as_ref().map_or(0, |b| b.len()),
+            ext_len,
+            "rebuilt extension header length must match the reserved length"
+        );
+        if let Some(bytes) = &real_ext_oh {
             debug_assert_eq!(
                 sink.position(),
                 ub as u64 + ext_addr.unwrap(),

--- a/tests/file_space_crosscheck.rs
+++ b/tests/file_space_crosscheck.rs
@@ -277,6 +277,52 @@ fn we_read_c_library_strategy() {
 }
 
 #[test]
+fn c_library_reads_our_fresh_persisting_file() {
+    let _c = c_lib_guard();
+    // Regression for issue #178: a fresh `persist = true` non-paged file must record
+    // a defined `eoa_fsm_fsalloc` in its File Space Info message. hdf5-pure once
+    // wrote the UNDEF sentinel, which an assertion-enabled libhdf5 rejects on open
+    // (H5Fsuper.c: `fs_persist => eoa_fsm_fsalloc != UNDEF`). No dataset is deleted,
+    // so the file genuinely tracks no free space — the corner the strategy
+    // crosschecks (persist = false, or persist = true only after a delete) missed.
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("ours_fresh_persist.h5");
+
+    let mut b = FileBuilder::new();
+    b.create_dataset("d").with_i32_data(&[1, 2, 3]);
+    b.with_file_space_strategy(FileSpaceStrategy::FsmAggr, true, 1);
+    b.write(&path).unwrap();
+
+    // Nothing is freed, so our own tracked free space is zero.
+    let total_ours: u64 = File::open(&path)
+        .unwrap()
+        .persisted_free_space()
+        .iter()
+        .map(|(_, l)| l)
+        .sum();
+    assert_eq!(total_ours, 0);
+
+    // The C library opens the persisting file (which would abort before the fix),
+    // recovers the persist flag, reads the data, and reports a matching (zero)
+    // free-space total.
+    let f = hdf5::File::open(&path).unwrap();
+    assert_eq!(
+        f.create_plist().unwrap().get_file_space_strategy().unwrap(),
+        CStrategy::FreeSpaceManager {
+            paged: false,
+            persist: true,
+            threshold: 1,
+        }
+    );
+    assert_eq!(
+        f.dataset("d").unwrap().read_raw::<i32>().unwrap(),
+        vec![1, 2, 3]
+    );
+    let free_c = unsafe { H5Fget_freespace(f.id()) };
+    assert_eq!(free_c as u64, total_ours);
+}
+
+#[test]
 fn c_library_reads_our_paged_file() {
     let _c = c_lib_guard();
     // hdf5-pure writes a genuine paged (H5F_FSPACE_STRATEGY_PAGE) persisting file

--- a/tests/file_space_fuzz_crosscheck.rs
+++ b/tests/file_space_fuzz_crosscheck.rs
@@ -1,0 +1,237 @@
+// Crosschecks link the reference HDF5 C library (the `hdf5-metno` dev-dependency),
+// gated to 64-bit-pointer targets.
+#![cfg(not(target_pointer_width = "32"))]
+//! Property-based cross-validation of the file-space (`fcpl`) and bounded-mutation
+//! (`fapl`) surface against the reference HDF5 C library (issue #178).
+//!
+//! The hand-written crosschecks in `file_space_crosscheck.rs` spot-check a few
+//! fixed configurations. These properties fuzz the same invariants across a
+//! generated space of **strategy**, **persist**, **page size**, **threshold**,
+//! and **append patterns**, diffing every generated file against libhdf5:
+//!
+//! 1. **Strategy round-trip.** For any strategy / persist / page size / threshold
+//!    and any set of datasets, a file hdf5-pure writes reads back byte-exact in
+//!    the C library, and the C library recovers the same strategy. For a
+//!    persisting *paged* file the strong invariant also holds: the C library's
+//!    `H5Fget_freespace` (which can only answer by parsing our on-disk
+//!    `FSHD`/`FSSE` managers) equals the sum of the free sections we wrote.
+//!
+//! 2. **Bounded paged mutation.** For any page size and any sequence of appends,
+//!    growing a genuine paged persisting file through `File::open_rw_bounded`
+//!    yields a file whose every row, recorded strategy, and manager free-space
+//!    total the C library reads back exactly.
+//!
+//! A failing case is shrunk to its minimal reproducer and recorded under
+//! `tests/proptest-regressions/`; commit that file so the reproducer travels
+//! with the fix.
+
+use hdf5::plist::file_create::FileSpaceStrategy as CStrategy;
+use hdf5_pure::{File, FileBuilder, FileSpaceStrategy};
+use proptest::prelude::*;
+use std::sync::{Mutex, MutexGuard};
+use tempfile::tempdir;
+
+// The reference free-space query, resolved at link time from the statically
+// linked libhdf5. Returns the total free space the C library tracks for the open
+// file, which it can only report by loading and parsing the on-disk
+// free-space-manager (`FSHD`/`FSSE`) blocks — so a match with our own tally
+// proves the C library accepts the managers hdf5-pure wrote, byte for byte.
+unsafe extern "C" {
+    fn H5Fget_freespace(file_id: i64) -> i64;
+}
+
+// `hdf5-metno` serializes its own C calls through an internal lock, but the raw
+// `H5Fget_freespace` FFI above bypasses it. Serialize every C-library call in
+// this file through one mutex so the raw call never races a concurrent libhdf5
+// call from the other property running in parallel (the C library is not built
+// thread-safe here). Poisoning is ignored: a panic in one case must not cascade.
+static C_LIB: Mutex<()> = Mutex::new(());
+
+fn c_lib_guard() -> MutexGuard<'static, ()> {
+    C_LIB.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// The four file-space strategies, each mapped to the name the C library reports.
+fn strategy() -> impl Strategy<Value = FileSpaceStrategy> {
+    prop_oneof![
+        Just(FileSpaceStrategy::FsmAggr),
+        Just(FileSpaceStrategy::Page),
+        Just(FileSpaceStrategy::Aggr),
+        Just(FileSpaceStrategy::None),
+    ]
+}
+
+/// Valid file-space page sizes: powers of two `>= 512`, the range the paged
+/// writer accepts. Under a non-paged strategy the value is only recorded.
+fn page_size() -> impl Strategy<Value = u64> {
+    prop_oneof![
+        Just(512u64),
+        Just(1024u64),
+        Just(2048u64),
+        Just(4096u64),
+        Just(8192u64),
+        Just(16384u64),
+    ]
+}
+
+/// What the C library's `get_file_space_strategy` reports for a file hdf5-pure
+/// wrote with `(strategy, persist, threshold)`.
+fn expected_c_strategy(strategy: FileSpaceStrategy, persist: bool, threshold: u64) -> CStrategy {
+    match strategy {
+        FileSpaceStrategy::FsmAggr => CStrategy::FreeSpaceManager {
+            paged: false,
+            persist,
+            threshold,
+        },
+        FileSpaceStrategy::Page => CStrategy::FreeSpaceManager {
+            paged: true,
+            persist,
+            threshold,
+        },
+        // The C library reports AGGR under its `PageAggregation` name and does not
+        // surface persist/threshold for it or for NONE.
+        FileSpaceStrategy::Aggr => CStrategy::PageAggregation,
+        FileSpaceStrategy::None => CStrategy::None,
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(48))]
+
+    /// A file hdf5-pure writes with any `(strategy, persist, page_size, threshold)`
+    /// and any datasets reads back byte-exact in the C library, which recovers the
+    /// same strategy; and a persisting paged file's manager total matches
+    /// `H5Fget_freespace` exactly.
+    #[test]
+    fn strategy_and_page_size_roundtrip_through_c(
+        strategy in strategy(),
+        persist in any::<bool>(),
+        threshold in 0u64..=8,
+        page_size in page_size(),
+        // A mix of small (< page) and large (>= page) datasets: i32 is 4 bytes, so
+        // up to 8000 elements spans several pages even at the largest page size.
+        lens in prop::collection::vec(1usize..=8000usize, 1..=3),
+    ) {
+        let _c = c_lib_guard();
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("fuzz_strategy.h5");
+
+        let datasets: Vec<Vec<i32>> =
+            lens.iter().map(|&n| (0..n as i32).collect()).collect();
+
+        let mut b = FileBuilder::new();
+        for (i, data) in datasets.iter().enumerate() {
+            b.create_dataset(&format!("d{i}")).with_i32_data(data);
+        }
+        b.with_file_space_strategy(strategy, persist, threshold)
+            .with_file_space_page_size(page_size);
+        b.write(&path).unwrap();
+
+        // hdf5-pure reads its own datasets back, and reports its tracked free space.
+        let total_ours: u64 = {
+            let ours = File::open(&path).unwrap();
+            for (i, data) in datasets.iter().enumerate() {
+                let got = ours.dataset(&format!("d{i}")).unwrap().read_i32().unwrap();
+                prop_assert_eq!(&got, data);
+            }
+            ours.persisted_free_space().iter().map(|(_, l)| l).sum()
+        };
+
+        // The reference C library recovers the strategy and reads every dataset.
+        // This includes a fresh `persist = true` non-paged file, which must record a
+        // defined `eoa_pre_fsm` (issue #178) or an assertion-enabled libhdf5 aborts
+        // on open (H5Fsuper.c: `fs_persist => eoa_fsm_fsalloc != UNDEF`).
+        let f = hdf5::File::open(&path).unwrap();
+        prop_assert_eq!(
+            f.create_plist().unwrap().get_file_space_strategy().unwrap(),
+            expected_c_strategy(strategy, persist, threshold)
+        );
+        for (i, data) in datasets.iter().enumerate() {
+            let got = f.dataset(&format!("d{i}")).unwrap().read_raw::<i32>().unwrap();
+            prop_assert_eq!(&got, data);
+        }
+        // Loading a persisting file's free-space managers requires parsing our
+        // on-disk records; the C library's total must equal our own tally exactly
+        // (a paged file tracks its page tails, a fresh non-paged file tracks none).
+        if persist {
+            let free_c = unsafe { H5Fget_freespace(f.id()) };
+            prop_assert_eq!(free_c as u64, total_ours);
+        }
+        drop(f);
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(32))]
+
+    /// Growing a genuine paged persisting file through the bounded backend, for any
+    /// page size and any append pattern, yields a file the C library reads back
+    /// row-for-row with a manager free-space total matching `H5Fget_freespace`.
+    #[test]
+    fn bounded_paged_append_roundtrips_through_c(
+        page_size in page_size(),
+        chunk_size in prop_oneof![Just(32usize), Just(64usize), Just(128usize), Just(256usize)],
+        // 1..=5 append calls of 1..=1500 unfiltered (so any-length) rows each.
+        appends in prop::collection::vec(1usize..=1500usize, 1..=5),
+    ) {
+        let _c = c_lib_guard();
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("fuzz_append.h5");
+
+        // Create a paged, persisting, unlimited chunked i32 dataset with one chunk.
+        {
+            let mut b = FileBuilder::new();
+            b.create_dataset("d")
+                .with_i32_data(&(0..chunk_size as i32).collect::<Vec<i32>>())
+                .with_shape(&[chunk_size as u64])
+                .with_maxshape(&[u64::MAX])
+                .with_chunks(&[chunk_size as u64]);
+            b.with_file_space_strategy(FileSpaceStrategy::Page, true, 0)
+                .with_file_space_page_size(page_size);
+            b.write(&path).unwrap();
+        }
+
+        // Grow it through the bounded backend with the generated append pattern.
+        // Scope the handles so the Dataset clone and File both drop (releasing the
+        // exclusive OS lock, which is mandatory on Windows) before the C open.
+        let mut next = chunk_size as i32;
+        {
+            let file = File::open_rw_bounded(&path).unwrap();
+            let mut ds = file.dataset("d").unwrap();
+            for &count in &appends {
+                let chunk: Vec<i32> = (next..next + count as i32).collect();
+                ds.append(&chunk).unwrap();
+                next += count as i32;
+            }
+            drop(ds);
+            file.close().unwrap();
+        }
+
+        let want: Vec<i32> = (0..next).collect();
+
+        // hdf5-pure reads the full sequence back and reports its tracked free space.
+        let total_ours: u64 = {
+            let ours = File::open(&path).unwrap();
+            let got = ours.dataset("d").unwrap().read_i32().unwrap();
+            prop_assert_eq!(&got, &want);
+            ours.persisted_free_space().iter().map(|(_, l)| l).sum()
+        };
+
+        // The C library recovers the paged strategy, reads every row, and its
+        // free-space total equals the sum of the managers we rewrote at close.
+        let f = hdf5::File::open(&path).unwrap();
+        prop_assert_eq!(
+            f.create_plist().unwrap().get_file_space_strategy().unwrap(),
+            CStrategy::FreeSpaceManager {
+                paged: true,
+                persist: true,
+                threshold: 0,
+            }
+        );
+        let got = f.dataset("d").unwrap().read_raw::<i32>().unwrap();
+        prop_assert_eq!(&got, &want);
+        let free_c = unsafe { H5Fget_freespace(f.id()) };
+        prop_assert_eq!(free_c as u64, total_ours);
+        drop(f);
+    }
+}


### PR DESCRIPTION
## Summary

Implements the property/fuzz testing suggested in #178: a proptest-based crosscheck that varies file-space **strategy**, **persist**, **page size**, **threshold**, and **append patterns**, diffing every generated file against the reference HDF5 C library (`hdf5-metno`).

The fuzzer found — and this PR fixes — a genuine conformance bug in the file-space writer.

## Fuzzer

`tests/file_space_fuzz_crosscheck.rs` (gated to 64-bit-pointer targets like the other crosschecks), two proptest properties:

- `strategy_and_page_size_roundtrip_through_c` — for any strategy / persist / page size / threshold / datasets: the C library recovers the strategy and reads every dataset byte-exact, and for a persisting file `H5Fget_freespace` equals our own tracked total exactly.
- `bounded_paged_append_roundtrips_through_c` — for any page size and append pattern grown through `File::open_rw_bounded`: full row round-trip plus exact `H5Fget_freespace` after the managers are rewritten at close.

## The bug it found

A fresh `persist = true` file with a **non-paged** strategy (`FsmAggr`/`Aggr`/`None`) recorded `eoa_pre_fsm = HADDR_UNDEF` in its File Space Info message. libhdf5 requires `fs_persist => eoa_fsm_fsalloc != UNDEF`; an **assertion-enabled** build aborts on open (`H5Fsuper.c`), while release builds (h5py wheels) tolerated it. The existing crosschecks missed it because they only tested `persist = false`, or `persist = true` after a delete (which writes real managers).

## The fix

`FileSpaceInfo::persistent_empty` keeps `eoa_pre_fsm` as a placeholder, and the non-paged writer tail now rewrites the File Space Info message with a real end-of-allocation once the layout is known — mirroring the paged path's existing manager-aware rewrite. The message length is unchanged (only the `eoa_pre_fsm` field differs), so the reserved layout still holds. A named regression test `c_library_reads_our_fresh_persisting_file` covers the exact case; the fuzzer covers it across strategies and page sizes.

## Validation

`cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`, and the test suite pass, including the strict (un-scoped) fuzzer and the new regression test.

Addresses #178.
