### PR TITLE
Delegate full-range row windows to whole reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- `Dataset::read_raw_rows` and the typed `read_*_rows` now delegate to a whole read when the window covers every row, so full-range windows on layouts whose windowed reads fall back to a whole read (inner-chunked storage, variable-length strings) no longer pay a full-size copy on top of it.
+
 ## [0.23.1] - 2026-07-23
 
 Two file-space fixes from documenting and fuzz-testing the paged and persisted surface ([#178](https://github.com/stephenberry/hdf5-pure/issues/178)): a fresh `persist = true` file with a non-paged strategy now records a defined end-of-allocation, so an assertion-enabled build of the reference C library opens it instead of aborting, and the `File::open_rw_bounded` refusal for a non-persisting paged file now advises the right recovery. Non-breaking patch.

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -3068,7 +3068,10 @@ impl Dataset {
     /// [`read_raw`](Self::read_raw) produces for those rows, so the typed
     /// `read_*_rows` helpers decode a window like their whole-dataset forms. The
     /// window is clamped to the first dimension: a read past the end returns only
-    /// the rows that exist, and a 0-D scalar is one row. Variable-length string
+    /// the rows that exist, and a 0-D scalar is one row. A window covering every
+    /// row delegates to [`read_raw`](Self::read_raw), so a full-range window never
+    /// costs more than a whole read — even on the layouts whose windowed reads
+    /// fall back to one internally. Variable-length string
     /// bytes are heap references, not text — use
     /// [`read_string_rows`](Self::read_string_rows).
     pub fn read_raw_rows(&self, start_row: u64, num_rows: u64) -> Result<Vec<u8>, Error> {
@@ -3079,6 +3082,20 @@ impl Dataset {
         let n0 = ds.dimensions.first().copied().unwrap_or(1);
         let start = start_row.min(n0);
         let count = num_rows.min(n0 - start);
+
+        // A window covering every row is exactly a whole read: delegate, so the
+        // layouts whose windowed reads fall back to a whole read (inner-chunked)
+        // don't pay a full-size copy on top of it.
+        if start == 0 && count == n0 {
+            let pipeline = self.filter_pipeline_parsed();
+            return Ok(self.file.read_dataset_raw(
+                &dl,
+                &ds,
+                &dt,
+                pipeline.as_ref(),
+                &self.chunk_cache,
+            )?);
+        }
 
         Ok(self.file.read_dataset_raw_rows(
             &dl,
@@ -3162,8 +3179,13 @@ impl Dataset {
     pub fn read_string_rows(&self, start_row: u64, num_rows: u64) -> Result<Vec<String>, Error> {
         let dt = self.datatype()?;
         if vl_data::is_vlen_string_datatype(&dt) {
-            let all = self.read_string()?;
             let n0 = self.dataspace()?.dimensions.first().copied().unwrap_or(1);
+            // A window covering every row is exactly `read_string` — skip the
+            // whole-read-then-clone fallback.
+            if start_row == 0 && num_rows >= n0 {
+                return self.read_string();
+            }
+            let all = self.read_string()?;
             let start = start_row.min(n0).to_usize()?;
             let end = start_row.saturating_add(num_rows).min(n0).to_usize()?;
             return Ok(all.get(start..end).unwrap_or_default().to_vec());

--- a/tests/partial_read.rs
+++ b/tests/partial_read.rs
@@ -291,6 +291,36 @@ fn read_raw_rows_matches_read_raw() {
 }
 
 #[test]
+fn full_range_window_delegates_to_whole_read() {
+    // A window covering every row (including one clamped down from over-long)
+    // delegates to the whole read, so it stays a single read even on the layouts
+    // whose windowed reads fall back to a whole read internally: inner-chunked
+    // storage and variable-length strings. The observable contract is equality
+    // with the whole read.
+    let data: Vec<f64> = (0..120).map(f64::from).collect();
+    let (buffered, streaming, _dir) = on_both_backends(|b| {
+        b.create_dataset("t")
+            .with_f64_data(&data)
+            .with_shape(&[20, 6])
+            .with_chunks(&[4, 2]); // inner dim chunked -> windowed reads fall back
+        b.create_dataset("labels")
+            .with_vlen_strings(&["idle", "reach", "grasp", "lift", "place"]);
+    });
+    for file in [&buffered, &streaming] {
+        let ds = file.dataset("t").unwrap();
+        let full = ds.read_raw().unwrap();
+        assert_eq!(ds.read_raw_rows(0, 20).unwrap(), full); // exact full range
+        assert_eq!(ds.read_raw_rows(0, 21).unwrap(), full); // over-long clamps to full range
+        assert_eq!(ds.read_f64_rows(0, 20).unwrap(), data);
+
+        let ds = file.dataset("labels").unwrap();
+        let full = ds.read_string().unwrap();
+        assert_eq!(ds.read_string_rows(0, 5).unwrap(), full);
+        assert_eq!(ds.read_string_rows(0, 99).unwrap(), full);
+    }
+}
+
+#[test]
 fn userblock_windows_go_through_base_framing() {
     // A userblock makes the superblock base non-zero, so reads route through the
     // base-framed source. Exercise that path for both contiguous and chunked


### PR DESCRIPTION
## What

`Dataset::read_raw_rows` (and through it the typed `read_*_rows` helpers) now early-outs to the whole read when the clamped window covers every row, and `read_string_rows` does the same for variable-length strings before touching the heap.

## Why

A window covering every row is exactly a whole read, but the windowed path didn't know that:

- On layouts whose windowed reads fall back to a whole read internally (storage chunks that split an inner dimension), a full-range window paid the whole read **plus** a full-size copy — 2× the dataset in peak memory. We measured this downstream in [rerun](https://github.com/rerun-io/rerun) while adopting the 0.23.0 windowed reads for streaming HDF5 ingestion: a 512 MiB inner-chunked dataset peaked at ~1 GiB RSS through `read_raw_rows(0, n0)` vs ~516 MiB through `read_raw()`.
- On variable-length strings, `read_string_rows(0, n0)` read the whole dataset and then cloned every row.

The early-out makes `read_*_rows` safe to call unconditionally with any window, which is exactly what a streaming caller wants — no need to special-case the full-range window on the caller side.

## Notes

- Observable behavior is unchanged; the existing `tests/partial_read.rs` window sweeps already check `(0, n0)` on every layout and both backends.
- Added `full_range_window_delegates_to_whole_read` to pin the equality contract on the two fallback layouts, including over-long windows that clamp down to the full range.
- Doc comment on `read_raw_rows` now states the guarantee; CHANGELOG entry under `[Unreleased]`.
- `cargo test` (1196 passed), `cargo clippy --all-targets`, `cargo fmt --check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)