### PR TITLE
Slice multi-dimensional VL string row windows by row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - `Dataset::read_raw_rows` and the typed `read_*_rows` now delegate to a whole read when the window covers every row, so full-range windows on layouts whose windowed reads fall back to a whole read (inner-chunked storage, variable-length strings) no longer pay a full-size copy on top of it.
+- `Dataset::read_string_rows` on a multi-dimensional variable-length string dataset now slices by row — each row spanning its inner dimensions — instead of treating the flat element array as one string per row, so a windowed read returns the same rows as `read_raw_rows` ([#182](https://github.com/stephenberry/hdf5-pure/pull/182)).
 
 ## [0.23.1] - 2026-07-23
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -3179,15 +3179,41 @@ impl Dataset {
     pub fn read_string_rows(&self, start_row: u64, num_rows: u64) -> Result<Vec<String>, Error> {
         let dt = self.datatype()?;
         if vl_data::is_vlen_string_datatype(&dt) {
-            let n0 = self.dataspace()?.dimensions.first().copied().unwrap_or(1);
+            let dims = self.dataspace()?.dimensions;
+            let n0 = dims.first().copied().unwrap_or(1);
             // A window covering every row is exactly `read_string` — skip the
             // whole-read-then-clone fallback.
             if start_row == 0 && num_rows >= n0 {
                 return self.read_string();
             }
+            // `read_string` returns one entry per *element* (the product of all
+            // dimensions), so the row window is scaled by the inner-dimension
+            // element count to slice whole rows — matching `read_raw_rows`
+            // rather than treating each element as its own row. Checked so a
+            // crafted dataspace whose inner dims overflow `usize` errors instead
+            // of wrapping.
+            let row_elems: usize = dims.iter().skip(1).try_fold(1usize, |acc, &d| {
+                acc.checked_mul(d.to_usize()?)
+                    .ok_or(FormatError::OffsetOverflow {
+                        offset: acc as u64,
+                        length: d,
+                    })
+            })?;
             let all = self.read_string()?;
-            let start = start_row.min(n0).to_usize()?;
-            let end = start_row.saturating_add(num_rows).min(n0).to_usize()?;
+            let start_row_idx = start_row.min(n0);
+            let end_row_idx = start_row.saturating_add(num_rows).min(n0);
+            let start = start_row_idx.to_usize()?.checked_mul(row_elems).ok_or(
+                FormatError::OffsetOverflow {
+                    offset: start_row_idx,
+                    length: row_elems as u64,
+                },
+            )?;
+            let end = end_row_idx.to_usize()?.checked_mul(row_elems).ok_or(
+                FormatError::OffsetOverflow {
+                    offset: end_row_idx,
+                    length: row_elems as u64,
+                },
+            )?;
             return Ok(all.get(start..end).unwrap_or_default().to_vec());
         }
         let raw = self.read_raw_rows(start_row, num_rows)?;

--- a/tests/partial_read.rs
+++ b/tests/partial_read.rs
@@ -235,6 +235,47 @@ fn vlen_strings_window_falls_back_to_slice() {
 }
 
 #[test]
+fn vlen_strings_multidim_window_slices_by_row() {
+    // On a multi-dimensional VL string dataset a row spans its inner dimensions,
+    // so `read_string_rows` must slice by row — the same rows `read_raw_rows`
+    // returns — not treat the flat per-element array as one string per row.
+    let (buffered, streaming, _dir) = on_both_backends(|b| {
+        b.create_dataset("grid")
+            .with_vlen_strings(&["a", "bb", "ccc", "dddd", "e", "ff"])
+            .with_shape(&[3, 2]); // 3 rows x 2 columns -> each row is 2 elements
+    });
+    for file in [&buffered, &streaming] {
+        let ds = file.dataset("grid").unwrap();
+        let all = ds.read_string().unwrap();
+        assert_eq!(all.len(), 6);
+
+        // Each row is the pair of inner-dimension elements, not a single string.
+        assert_eq!(ds.read_string_rows(0, 1).unwrap(), vec!["a", "bb"]);
+        assert_eq!(ds.read_string_rows(1, 1).unwrap(), vec!["ccc", "dddd"]);
+        assert_eq!(ds.read_string_rows(2, 1).unwrap(), vec!["e", "ff"]);
+        assert_eq!(
+            ds.read_string_rows(1, 2).unwrap(),
+            vec!["ccc", "dddd", "e", "ff"]
+        );
+
+        // Full-range and over-long windows return every element.
+        assert_eq!(ds.read_string_rows(0, 3).unwrap(), all);
+        assert_eq!(ds.read_string_rows(0, 99).unwrap(), all);
+        // A window starting past the last row is empty.
+        assert!(ds.read_string_rows(3, 1).unwrap().is_empty());
+
+        // Lockstep with the raw path: the string count of a window equals the
+        // number of elements `read_raw_rows` reads for the same window.
+        let elem = ds.datatype().unwrap().type_size() as usize;
+        for (start, count) in [(0u64, 1u64), (1, 1), (2, 1), (0, 2), (1, 2), (0, 3)] {
+            let n_strings = ds.read_string_rows(start, count).unwrap().len();
+            let n_raw_elems = ds.read_raw_rows(start, count).unwrap().len() / elem;
+            assert_eq!(n_strings, n_raw_elems, "window ({start}, {count})");
+        }
+    }
+}
+
+#[test]
 fn typed_readers_match_whole_dataset() {
     // Spot-check several dtypes go through the same window path and decode right.
     let (buffered, streaming, _dir) = on_both_backends(|b| {


### PR DESCRIPTION
## What

`Dataset::read_string_rows` now slices a multi-dimensional variable-length string dataset by row — each row spanning its inner dimensions — instead of treating the flat per-element array as one string per row.

## Why

VL strings live in a shared heap, so `read_string_rows` reads the whole dataset (`read_string`) and slices it. But `read_string` returns one entry per *element* (the product of all dimensions), while the slice bounds were leading-dimension row indices. For a 1-D dataset the two coincide; for a multi-dimensional one they diverge, so a window returned at most `num_rows` strings total rather than `num_rows` rows.

On a `[3, 2]` grid `["a", "bb", "ccc", "dddd", "e", "ff"]`:

| call | before | after |
|---|---|---|
| `read_string_rows(0, 1)` | `["a"]` | `["a", "bb"]` |
| `read_string_rows(1, 1)` | `["bb"]` | `["ccc", "dddd"]` |
| `read_string_rows(1, 2)` | `["bb", "ccc"]` | `["ccc", "dddd", "e", "ff"]` |

The `after` column matches the `read_raw_rows` element contract (row 0 of a `[3, 2]` dataset is two elements). Surfaced while reviewing #181, which made the full-range multi-D case consistent with that contract; this is the remaining partial-window half.

## How

Scale the slice bounds by the inner-dimension element count — the same `row_elems` product `read_raw_rows` computes — with checked multiplication so a crafted dataspace errors instead of wrapping. One-dimensional datasets are unchanged (the inner product is 1); fixed-length strings and the numeric `read_*_rows` were already correct (they decode through `read_raw_rows`).

## Notes

- New `vlen_strings_multidim_window_slices_by_row` in `tests/partial_read.rs` pins per-row slicing on a `[3, 2]` grid across both backends, including full-range, over-long, and past-the-end windows, and cross-checks the string count against `read_raw_rows` for each window.
- `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo check --no-default-features` (no_std) all clean.
