### PR TITLE
Stream row windows of inner-chunked datasets without a whole read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
-- `Dataset::read_raw_rows` and the typed `read_*_rows` now stream a row window of a dataset whose storage chunks split inner dimensions by decoding only the overlapping chunks and scattering each into the window, instead of falling back to a whole read — peak memory for inner-chunked layouts now scales with the window plus one chunk, not the dataset.
+- `Dataset::read_raw_rows` and the typed `read_*_rows` now stream a row window of an inner-chunked dataset by decoding only the chunks the window overlaps, instead of falling back to a whole read, so peak memory scales with the window plus one chunk rather than the dataset ([#183](https://github.com/stephenberry/hdf5-pure/pull/183)).
 
 ## [0.23.2] - 2026-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- `Dataset::read_raw_rows` and the typed `read_*_rows` now stream a row window of a dataset whose storage chunks split inner dimensions by decoding only the overlapping chunks and scattering each into the window, instead of falling back to a whole read — peak memory for inner-chunked layouts now scales with the window plus one chunk, not the dataset.
+
 ## [0.23.2] - 2026-07-23
 
 Two fixes to the windowed row-read API introduced in 0.23.0: a full-range `Dataset::read_raw_rows` / `read_*_rows` window now delegates to the whole read instead of paying a full-size copy on top of it on layouts whose windowed reads fall back to one (inner-chunked storage, variable-length strings), and `Dataset::read_string_rows` now slices a multi-dimensional variable-length string dataset by row rather than by first-dimension index. Non-breaking patch.

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ let values = ds.read_f64().unwrap();  // only this dataset's chunks are read
 
 The reading API is identical to `File::open`; only the backing store differs. Dataset reads are fully supported: contiguous, compact, and every chunk-index layout (B-tree v1, fixed array, and extensible array). Two limits apply to the streaming backend that in-memory reading does not have: only latest-format (v2) groups resolve along a path (a v1 symbol-table group is rejected), and reading attributes is not yet supported. `open_streaming` requires the `std` filesystem.
 
-To read a single dataset that is itself too large to hold decompressed, read it in **row windows** rather than whole: `read_raw_rows(start, count)` and the typed `read_f64_rows` … `read_string_rows` decode only the leading-dimension rows `[start, start + count)`, touching only the chunks that window overlaps, so peak memory scales with the window rather than the dataset.
+To read a single dataset that is itself too large to hold decompressed, read it in **row windows** rather than whole: `read_raw_rows(start, count)` and the typed `read_f64_rows` … `read_string_rows` decode only the leading-dimension rows `[start, start + count)`, touching only the chunks that window overlaps, so peak memory scales with the window rather than the dataset. The exception is `read_string_rows` on variable-length strings, which still reads the whole dataset and slices out the window.
 
 ```rust
 use hdf5_pure::File;

--- a/docs/guide/reading.md
+++ b/docs/guide/reading.md
@@ -160,7 +160,7 @@ let ds = file.dataset("frames").unwrap();
 let window = ds.read_f64_rows(100, 50).unwrap(); // rows 100..150 only
 ```
 
-Only the storage the window touches is read: a single bounded sub-read for compact and contiguous layouts, and just the chunks whose first-dimension span overlaps the window for chunked layouts, so peak memory scales with the window (plus one chunk) rather than the dataset. The window is clamped to the leading dimension, so a read past the end returns only the rows that exist and a zero-row request returns an empty `Vec`. Datasets chunked along an inner dimension, and variable-length string datasets, transparently fall back to a whole read sliced to the window.
+Only the storage the window touches is read: a single bounded sub-read for compact and contiguous layouts, and just the chunks whose first-dimension span overlaps the window for chunked layouts, so peak memory scales with the window (plus one chunk) rather than the dataset. The window is clamped to the leading dimension, so a read past the end returns only the rows that exist and a zero-row request returns an empty `Vec`. Variable-length string datasets transparently fall back to a whole read sliced to the window.
 
 Combined with a [streaming open](streaming.md#reading-a-large-dataset-a-window-at-a-time), this reads a dataset too large to hold in memory a fixed number of rows at a time.
 

--- a/docs/guide/reading.md
+++ b/docs/guide/reading.md
@@ -160,7 +160,7 @@ let ds = file.dataset("frames").unwrap();
 let window = ds.read_f64_rows(100, 50).unwrap(); // rows 100..150 only
 ```
 
-Only the storage the window touches is read: a single bounded sub-read for compact and contiguous layouts, and just the chunks whose first-dimension span overlaps the window for chunked layouts, so peak memory scales with the window (plus one chunk) rather than the dataset. The window is clamped to the leading dimension, so a read past the end returns only the rows that exist and a zero-row request returns an empty `Vec`. Variable-length string datasets transparently fall back to a whole read sliced to the window.
+Only the storage the window touches is read: a single bounded sub-read for compact and contiguous layouts, and just the chunks whose first-dimension span overlaps the window for chunked layouts, so peak memory scales with the window (plus one chunk) rather than the dataset. The window is clamped to the leading dimension, so a read past the end returns only the rows that exist and a zero-row request returns an empty `Vec`. For variable-length strings, `read_string_rows` transparently falls back to a whole read sliced to the window; `read_raw_rows` streams their fixed-size heap references with the normal bound.
 
 Combined with a [streaming open](streaming.md#reading-a-large-dataset-a-window-at-a-time), this reads a dataset too large to hold in memory a fixed number of rows at a time.
 

--- a/docs/guide/streaming.md
+++ b/docs/guide/streaming.md
@@ -62,7 +62,7 @@ for start in (0..rows).step_by(1_000_000) {
 }
 ```
 
-The window is clamped to the dataset, so the final short window needs no special-casing. See [Reading a row window](reading.md#reading-a-row-window) for the full method list and the fallback for variable-length string datasets.
+The window is clamped to the dataset, so the final short window needs no special-casing. See [Reading a row window](reading.md#reading-a-row-window) for the full method list and the `read_string_rows` fallback for variable-length strings.
 
 ## Tuning retained memory
 

--- a/docs/guide/streaming.md
+++ b/docs/guide/streaming.md
@@ -62,7 +62,7 @@ for start in (0..rows).step_by(1_000_000) {
 }
 ```
 
-The window is clamped to the dataset, so the final short window needs no special-casing. See [Reading a row window](reading.md#reading-a-row-window) for the full method list and the fallback for inner-chunked and variable-length datasets.
+The window is clamped to the dataset, so the final short window needs no special-casing. See [Reading a row window](reading.md#reading-a-row-window) for the full method list and the fallback for variable-length string datasets.
 
 ## Tuning retained memory
 

--- a/src/chunked_read.rs
+++ b/src/chunked_read.rs
@@ -975,8 +975,8 @@ pub(crate) fn read_chunked_rows_from_source<S: Source + ?Sized>(
         // Inner-split scatter parameters. `place_chunk` takes non-negative
         // offsets, so a chunk straddling the window start is instead entered
         // `skip` leading slabs in (dim 0 is outermost, so one slab is
-        // `chunk_strides[0]` elements) with its leading dim shrunk to match;
-        // the kernel's own bound check against `win_dims[0]` clips a chunk
+        // `chunk_strides[0]` elements), and its leading dim becomes exactly
+        // the `hi - lo` slabs the window keeps, which also clips a chunk
         // straddling the window end. A saturated `advance` (crafted dims) makes
         // `bytes.get(advance..)` come up empty and the chunk copies nothing —
         // the kernel's clamping discipline for short chunks.
@@ -990,7 +990,7 @@ pub(crate) fn read_chunked_rows_from_source<S: Source + ?Sized>(
             let skip = lo - c0;
             offsets[0] = lo - row_lo;
             let mut dims = chunk_dims.clone();
-            dims[0] = cd0 - skip;
+            dims[0] = hi - lo;
             let advance = skip
                 .saturating_mul(chunk_strides[0])
                 .saturating_mul(elem_size);

--- a/src/chunked_read.rs
+++ b/src/chunked_read.rs
@@ -826,12 +826,15 @@ pub fn read_chunked_data_from_source<S: Source + ?Sized>(
 /// and decompressed chunks, so successive windows on the same handle walk the index
 /// once and reuse boundary chunks.
 ///
-/// Handles only chunks that span the full inner extent (`chunk_dims[i] == ds_dims[i]`
-/// for `i >= 1`), where each row is contiguous in the chunk and the copy is a plain
-/// row band — true for every frame-per-chunk dataset. Returns `Ok(None)` when an
-/// inner dimension is chunked, so the caller falls back to a whole read. Otherwise
-/// returns `num_rows * row_elems` elements. The caller clamps the window to the
-/// dataset.
+/// A chunk that spans the dataset's full inner extent (`chunk_dims[i] == ds_dims[i]`
+/// for `i >= 1` — every 1-D and frame-per-chunk layout) holds each row contiguously,
+/// so its contribution is a plain row band copied in one move. A chunk of an
+/// inner-split grid scatters into the window through the same N-D kernel the whole
+/// read uses ([`place_chunk`]), aimed at a window-shaped output. Either way only the
+/// chunks overlapping the window are decoded, and `num_rows * row_elems` elements
+/// are returned. Returns `Ok(None)` only for a rank-0 (scalar) chunked layout — a
+/// crafted-file corner with no leading dimension to window — so the caller falls
+/// back to a whole read. The caller clamps the window to the dataset.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn read_chunked_rows_from_source<S: Source + ?Sized>(
     source: &S,
@@ -862,13 +865,18 @@ pub(crate) fn read_chunked_rows_from_source<S: Source + ?Sized>(
     let elem_size = datatype.type_size() as usize;
     let (rank, chunk_dims, ds_dims) = chunked_dims(chunk_dimensions, dataspace)?;
 
-    // A rank-0 (scalar) chunked layout has no leading dimension to window, and a
-    // row is contiguous in the chunk only when the chunk spans the full inner
-    // extent; both cases fall back to the whole-dataset reader (which handles
-    // rank 0 and inner chunking) rather than the row-band fast path.
-    if rank == 0 || (1..rank).any(|i| chunk_dims[i] != ds_dims[i]) {
+    // A rank-0 (scalar) chunked layout has no leading dimension to window; fall
+    // back to the whole-dataset reader, which handles rank 0. Only a crafted
+    // file reaches this (valid chunked layouts are rank >= 1), but the reader
+    // parses untrusted input.
+    if rank == 0 {
         return Ok(None);
     }
+
+    // When every chunk spans the dataset's full inner extent, each row is
+    // contiguous in its chunk and a window is one row band per chunk; an
+    // inner-split chunk grid instead scatters each chunk through the N-D kernel.
+    let full_inner = (1..rank).all(|i| chunk_dims[i] == ds_dims[i]);
 
     // Elements per row (product of the inner dims; 1 when 1-D). Checked so a
     // crafted dataspace whose inner dims overflow `usize` errors instead of
@@ -897,6 +905,16 @@ pub(crate) fn read_chunked_rows_from_source<S: Source + ?Sized>(
     if total_bytes == 0 {
         return Ok(Some(output));
     }
+
+    // Scatter geometry for the inner-split path: the output is a dataset whose
+    // leading dimension is the window (`[out_rows, inner dims…]`), row-major.
+    // Checked before any I/O: crafted chunk dimensions (u32 each) can overflow
+    // the stride product where a real chunk's byte size cannot. For a full-inner
+    // chunk the product equals `row_elems`, already checked above.
+    let mut win_dims = ds_dims.clone();
+    win_dims[0] = out_rows;
+    let win_strides = row_major_strides(&win_dims)?;
+    let chunk_strides = row_major_strides(&chunk_dims)?;
 
     // Unallocated chunk index: a non-empty window has no storage to read. Match
     // the whole-dataset reader, which errors here, so `read_raw_rows` stays
@@ -950,17 +968,57 @@ pub(crate) fn read_chunked_rows_from_source<S: Source + ?Sized>(
             continue; // no overlap with the window
         }
 
-        // Rows of this chunk that fall in the window, as byte offsets.
+        // Rows of this chunk that fall in the window.
         let lo = c0.max(row_lo);
         let hi = c_end.min(row_hi);
+
+        // Inner-split scatter parameters. `place_chunk` takes non-negative
+        // offsets, so a chunk straddling the window start is instead entered
+        // `skip` leading slabs in (dim 0 is outermost, so one slab is
+        // `chunk_strides[0]` elements) with its leading dim shrunk to match;
+        // the kernel's own bound check against `win_dims[0]` clips a chunk
+        // straddling the window end. A saturated `advance` (crafted dims) makes
+        // `bytes.get(advance..)` come up empty and the chunk copies nothing —
+        // the kernel's clamping discipline for short chunks.
+        let scatter: Option<(Vec<usize>, Vec<usize>, usize)> = if full_inner {
+            None
+        } else {
+            let mut offsets = Vec::with_capacity(rank);
+            for &o in chunk.offsets.iter().take(rank) {
+                offsets.push(o.to_usize()?);
+            }
+            let skip = lo - c0;
+            offsets[0] = lo - row_lo;
+            let mut dims = chunk_dims.clone();
+            dims[0] = cd0 - skip;
+            let advance = skip
+                .saturating_mul(chunk_strides[0])
+                .saturating_mul(elem_size);
+            Some((offsets, dims, advance))
+        };
+
+        // Byte offsets of the contiguous row band (full-inner path).
         let src = (lo - c0).saturating_mul(row_bytes);
         let dst = (lo - row_lo) * row_bytes;
         let band = (hi - lo) * row_bytes;
 
+        let copy = |output: &mut [u8], bytes: &[u8]| match &scatter {
+            None => row_band_copy(output, dst, bytes, src, band, elem_size),
+            Some((offsets, dims, advance)) => place_chunk(
+                bytes.get(*advance..).unwrap_or(&[]),
+                output,
+                offsets,
+                dims,
+                &win_dims,
+                &win_strides,
+                &chunk_strides,
+                elem_size,
+                rank,
+            ),
+        };
+
         let coord: Vec<u64> = chunk.offsets.iter().take(rank).copied().collect();
-        let hit = cache.with_decompressed(&coord, |bytes| {
-            row_band_copy(&mut output, dst, bytes, src, band, elem_size);
-        });
+        let hit = cache.with_decompressed(&coord, |bytes| copy(&mut output, bytes));
         if hit.is_some() {
             continue;
         }
@@ -969,11 +1027,11 @@ pub(crate) fn read_chunked_rows_from_source<S: Source + ?Sized>(
         match pipeline {
             Some(pl) => {
                 let dec = decompress_chunk(&raw, pl, ctx, chunk.filter_mask)?;
-                row_band_copy(&mut output, dst, &dec, src, band, elem_size);
+                copy(&mut output, &dec);
                 cache.put_decompressed(coord, dec);
             }
             None => {
-                row_band_copy(&mut output, dst, &raw, src, band, elem_size);
+                copy(&mut output, &raw);
                 cache.put_decompressed_slice(coord, &raw);
             }
         }
@@ -1001,6 +1059,22 @@ fn row_band_copy(
     if len > 0 {
         output[dst..dst + len].copy_from_slice(&chunk[src..src + len]);
     }
+}
+
+/// Row-major strides for `dims` (innermost stride 1), checked so crafted
+/// dimensions error instead of panicking (debug) or wrapping (release).
+fn row_major_strides(dims: &[usize]) -> Result<Vec<usize>, FormatError> {
+    let mut strides = vec![1usize; dims.len()];
+    for i in (0..dims.len().saturating_sub(1)).rev() {
+        strides[i] =
+            strides[i + 1]
+                .checked_mul(dims[i + 1])
+                .ok_or(FormatError::OffsetOverflow {
+                    offset: strides[i + 1] as u64,
+                    length: dims[i + 1] as u64,
+                })?;
+    }
+    Ok(strides)
 }
 
 /// Read a chunked dataset from a [`Source`] with parsed-index and
@@ -2795,6 +2869,49 @@ mod tests {
             1,
         )
         .expect_err("overflowing inner-dim product must error");
+        assert!(
+            matches!(err, FormatError::OffsetOverflow { .. }),
+            "expected OffsetOverflow, got {err:?}"
+        );
+    }
+
+    /// An inner-split chunk grid whose *chunk* dimensions overflow the stride
+    /// product must error rather than panic (debug) or wrap (release) — the
+    /// dataset itself is small, so the `row_elems` guard doesn't catch it; the
+    /// checked stride construction must. `(2^22)^3` overflows 64-bit `usize`;
+    /// `(2^22)^2` already overflows 32-bit, so this holds on both. Checked
+    /// before any I/O: the empty source would otherwise EOF first.
+    #[test]
+    fn windowed_rows_chunk_stride_overflow_errors() {
+        let big: u32 = 1 << 22;
+        let layout = DataLayout::Chunked {
+            chunk_dimensions: vec![2, big, big, big, 8],
+            btree_address: Some(0),
+            version: 3,
+            chunk_index_type: None,
+            single_chunk_filtered_size: None,
+            single_chunk_filter_mask: None,
+        };
+        let dataspace = Dataspace {
+            space_type: DataspaceType::Simple,
+            rank: 4,
+            dimensions: vec![4, 2, 2, 2],
+            max_dimensions: None,
+        };
+        let cache = ChunkCache::new();
+        let err = read_chunked_rows_from_source(
+            &BytesSource::new(b""),
+            &layout,
+            &dataspace,
+            &make_f64_type(),
+            None,
+            8,
+            8,
+            &cache,
+            0,
+            1,
+        )
+        .expect_err("overflowing chunk-dim stride product must error");
         assert!(
             matches!(err, FormatError::OffsetOverflow { .. }),
             "expected OffsetOverflow, got {err:?}"

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1253,8 +1253,8 @@ impl FileInner {
 
 /// Read a row window through an already base-framed `Source`. Contiguous
 /// layouts are one bounded sub-read; chunked layouts use the windowed chunk
-/// reader, or fall back to a whole read plus slice when an inner dimension is
-/// chunked.
+/// reader (only the rank-0 crafted-file corner falls back to a whole read
+/// plus slice).
 #[allow(clippy::too_many_arguments)]
 fn read_rows_framed<S: Source + ?Sized>(
     source: &S,

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1316,7 +1316,8 @@ fn read_rows_framed<S: Source + ?Sized>(
                 source, dl, ds, dt, pipeline, os, ls, cache, start_row, num_rows,
             )? {
                 Some(bytes) => Ok(bytes),
-                // Inner-chunked: fall back to a whole read, then slice.
+                // Rank-0 chunked (a crafted-file corner): fall back to a whole
+                // read, then slice.
                 None => {
                     let full = data_read::read_raw_data_cached_from_source(
                         source, dl, ds, dt, pipeline, os, ls, cache,
@@ -3070,8 +3071,7 @@ impl Dataset {
     /// window is clamped to the first dimension: a read past the end returns only
     /// the rows that exist, and a 0-D scalar is one row. A window covering every
     /// row delegates to [`read_raw`](Self::read_raw), so a full-range window never
-    /// costs more than a whole read — even on the layouts whose windowed reads
-    /// fall back to one internally. Variable-length string
+    /// costs more than a whole read. Variable-length string
     /// bytes are heap references, not text — use
     /// [`read_string_rows`](Self::read_string_rows).
     pub fn read_raw_rows(&self, start_row: u64, num_rows: u64) -> Result<Vec<u8>, Error> {
@@ -3083,9 +3083,9 @@ impl Dataset {
         let start = start_row.min(n0);
         let count = num_rows.min(n0 - start);
 
-        // A window covering every row is exactly a whole read: delegate, so the
-        // layouts whose windowed reads fall back to a whole read (inner-chunked)
-        // don't pay a full-size copy on top of it.
+        // A window covering every row is exactly a whole read: delegate, so it
+        // never costs a window-shaped copy on top of one (and vlen-string reads,
+        // which still fall back to a whole read, don't pay it twice).
         if start == 0 && count == n0 {
             let pipeline = self.filter_pipeline_parsed();
             return Ok(self.file.read_dataset_raw(

--- a/tests/partial_read.rs
+++ b/tests/partial_read.rs
@@ -4,7 +4,7 @@
 //!
 //! The invariant under test everywhere: a row window must be byte-for-byte the
 //! same as the whole-dataset read sliced to that row range — for every layout
-//! (contiguous, chunked, inner-chunked fallback), on both the in-memory and the
+//! (contiguous, chunked, inner-chunked grids), on both the in-memory and the
 //! streaming backend, and across edge windows (empty, past-the-end, straddling
 //! chunk boundaries).
 
@@ -161,10 +161,10 @@ fn chunked_multi_row_chunk_partial_edges() {
 }
 
 #[test]
-fn inner_chunked_falls_back_to_whole_read() {
-    // shape [20, 6], chunks [4, 2]: the inner dim is chunked, so the windowed chunk
-    // reader returns None and the caller falls back to a sliced whole-read. The
-    // result must still be correct.
+fn inner_chunked_2d_grid_windows() {
+    // shape [20, 6], chunks [4, 2]: the inner dim is chunked, so each window
+    // scatters the overlapping chunks of a 2-D chunk grid into a window-shaped
+    // output (no whole-read fallback).
     let data: Vec<f64> = (0..120).map(f64::from).collect();
     let (buffered, streaming, _dir) = on_both_backends(|b| {
         b.create_dataset("t")
@@ -175,6 +175,43 @@ fn inner_chunked_falls_back_to_whole_read() {
     let extra = &[(3, 5), (0, 20), (10, 1)];
     check_f64(&buffered, "t", 6, extra);
     check_f64(&streaming, "t", 6, extra);
+}
+
+#[test]
+fn inner_chunked_edge_overhang_deflate() {
+    // shape [23, 10], chunks [4, 3], deflated: neither dimension is a multiple of
+    // its chunk extent, so the grid's last chunk row and column overhang the
+    // dataset — the scatter must clip them in both the leading and inner dims,
+    // and windows straddling chunk boundaries must trim inside a chunk.
+    let data: Vec<f64> = (0..230).map(|i| f64::from(i) * 0.5 - 3.0).collect();
+    let (buffered, streaming, _dir) = on_both_backends(|b| {
+        b.create_dataset("e")
+            .with_f64_data(&data)
+            .with_shape(&[23, 10])
+            .with_chunks(&[4, 3])
+            .with_deflate(4);
+    });
+    let extra = &[(3, 2), (4, 4), (7, 9), (19, 4), (22, 1), (0, 23)];
+    check_f64(&buffered, "e", 10, extra);
+    check_f64(&streaming, "e", 10, extra);
+}
+
+#[test]
+fn inner_chunked_4d_image_grid() {
+    // The image-tile case: shape [13, 5, 7, 3] u8 with chunks [4, 2, 3, 2] — an
+    // inner-split grid in every dimension, with overhanging edge chunks in every
+    // dimension. Windows must assemble each row from the full inner chunk grid.
+    let data: Vec<u8> = (0..13 * 5 * 7 * 3).map(|i| (i % 251) as u8).collect();
+    let (buffered, streaming, _dir) = on_both_backends(|b| {
+        b.create_dataset("img")
+            .with_u8_data(&data)
+            .with_shape(&[13, 5, 7, 3])
+            .with_chunks(&[4, 2, 3, 2])
+            .with_deflate(2);
+    });
+    let extra = &[(3, 2), (4, 4), (11, 2), (12, 1), (0, 13)];
+    check_u8(&buffered, "img", 5 * 7 * 3, extra);
+    check_u8(&streaming, "img", 5 * 7 * 3, extra);
 }
 
 #[test]
@@ -334,16 +371,16 @@ fn read_raw_rows_matches_read_raw() {
 #[test]
 fn full_range_window_delegates_to_whole_read() {
     // A window covering every row (including one clamped down from over-long)
-    // delegates to the whole read, so it stays a single read even on the layouts
-    // whose windowed reads fall back to a whole read internally: inner-chunked
-    // storage and variable-length strings. The observable contract is equality
-    // with the whole read.
+    // delegates to the whole read, so it never costs a window-shaped copy on top
+    // of one — checked here on an inner-chunked grid and on variable-length
+    // strings (whose windowed reads still fall back to a whole read internally).
+    // The observable contract is equality with the whole read.
     let data: Vec<f64> = (0..120).map(f64::from).collect();
     let (buffered, streaming, _dir) = on_both_backends(|b| {
         b.create_dataset("t")
             .with_f64_data(&data)
             .with_shape(&[20, 6])
-            .with_chunks(&[4, 2]); // inner dim chunked -> windowed reads fall back
+            .with_chunks(&[4, 2]); // inner dim chunked
         b.create_dataset("labels")
             .with_vlen_strings(&["idle", "reach", "grasp", "lift", "place"]);
     });

--- a/tests/windowed_read_memory.rs
+++ b/tests/windowed_read_memory.rs
@@ -1,0 +1,108 @@
+//! Peak-allocation regression test for the windowed row-read API: a small row
+//! window of a large inner-chunked dataset must allocate on the order of the
+//! window (plus a few decompressed chunks), not the dataset. A whole-read
+//! fallback peaks above the full dataset size and fails the assertion.
+//!
+//! The counting allocator applies to this whole test binary, so this file must
+//! hold exactly one `#[test]`: a second test running in parallel would pollute
+//! the counter.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use hdf5_pure::{File, FileBuilder};
+
+/// Bytes currently allocated and the high-water mark, maintained by the
+/// counting allocator below. Relaxed ordering is fine: the test is effectively
+/// single-threaded during the measured section, and the assertion bound has a
+/// 4x margin — exactness is not required, only the order of magnitude.
+static LIVE: AtomicUsize = AtomicUsize::new(0);
+static PEAK: AtomicUsize = AtomicUsize::new(0);
+
+struct CountingAlloc;
+
+unsafe impl GlobalAlloc for CountingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = unsafe { System.alloc(layout) };
+        if !ptr.is_null() {
+            let live = LIVE.fetch_add(layout.size(), Ordering::Relaxed) + layout.size();
+            PEAK.fetch_max(live, Ordering::Relaxed);
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) };
+        LIVE.fetch_sub(layout.size(), Ordering::Relaxed);
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let new_ptr = unsafe { System.realloc(ptr, layout, new_size) };
+        if !new_ptr.is_null() {
+            if new_size >= layout.size() {
+                let grow = new_size - layout.size();
+                let live = LIVE.fetch_add(grow, Ordering::Relaxed) + grow;
+                PEAK.fetch_max(live, Ordering::Relaxed);
+            } else {
+                LIVE.fetch_sub(layout.size() - new_size, Ordering::Relaxed);
+            }
+        }
+        new_ptr
+    }
+}
+
+#[global_allocator]
+static ALLOC: CountingAlloc = CountingAlloc;
+
+#[test]
+fn inner_chunked_window_read_is_memory_bounded() {
+    // 4 MiB of f64 rows with inner-split storage chunks: [2048, 32, 8] in
+    // [64, 16, 4] chunks — a 2x2 inner chunk grid per 64-row band, deflated so
+    // chunks really decode (32 KiB decompressed each).
+    const N0: usize = 2048;
+    const ROW_ELEMS: usize = 32 * 8;
+    const DATASET_BYTES: usize = N0 * ROW_ELEMS * 8;
+
+    let data: Vec<f64> = (0..N0 * ROW_ELEMS).map(|i| i as f64).collect();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("test.h5");
+    let mut builder = FileBuilder::new();
+    builder
+        .create_dataset("t")
+        .with_f64_data(&data)
+        .with_shape(&[N0 as u64, 32, 8])
+        .with_chunks(&[64, 16, 4])
+        .with_deflate(3);
+    builder.write(&path).unwrap();
+    drop(data);
+
+    // The streaming backend reads from disk on demand; the buffered backend
+    // would hold the whole file in memory by design and drown the signal.
+    let file = File::open_streaming(&path).unwrap();
+    let ds = file.dataset("t").unwrap();
+
+    // Measure only the windowed read: a 64-row window straddling a chunk-band
+    // boundary mid-file, so it decodes chunks from two leading bands.
+    let base = LIVE.load(Ordering::Relaxed);
+    PEAK.store(base, Ordering::Relaxed);
+
+    let window = ds.read_f64_rows(992, 64).unwrap();
+
+    let peak = PEAK.load(Ordering::Relaxed) - base;
+    eprintln!("peak allocation during the windowed read: {peak} bytes (dataset: {DATASET_BYTES})");
+
+    // Window + raw/typed conversion + a few decompressed 32 KiB chunks lands
+    // well under 1 MiB; a whole-read fallback peaks above the full dataset
+    // (the assembled whole read plus cached chunks and the sliced window).
+    assert!(
+        peak < DATASET_BYTES / 4,
+        "peak allocation during the windowed read must be bounded by the window, \
+         not the {DATASET_BYTES}-byte dataset; measured {peak} bytes"
+    );
+
+    // The window must still be the right bytes.
+    let expected: Vec<f64> = (992 * ROW_ELEMS..(992 + 64) * ROW_ELEMS)
+        .map(|i| i as f64)
+        .collect();
+    assert_eq!(window, expected);
+}


### PR DESCRIPTION
## What

`read_chunked_rows_from_source` now handles datasets whose storage chunks split inner dimensions: only the chunks overlapping the window's leading-dimension range are decoded (one at a time, through the existing `ChunkCache`), and each is scattered into a window-shaped output. The `Ok(None)` whole-read fallback remains only for the rank-0 crafted-file corner.

## Why

The windowed row-read API's promise is "peak memory scales with the window, not the dataset", but an inner-split chunk grid fell back to whole-read-then-slice — so streaming such a dataset window by window cost its full size in peak memory and re-read everything per window. This was the last layout for which [rerun](https://github.com/rerun-io/rerun)'s streaming HDF5 ingestion couldn't stay memory-bounded: a 512 MiB inner-chunked dataset peaked at ~516 MiB RSS where every other layout streams at ~10 MiB. With this change it streams at ~14 MiB (window + decompressed-chunk cache), with unchanged load time.

## How

The two pieces already existed and compose:

- The window loop (from the row-band path) contributes leading-dim chunk-overlap filtering and one-chunk-at-a-time decode through the cache.
- The N-D scatter kernel the whole read uses (`place_chunk` / `copy_chunk_to_output`) contributes inner-dim placement, edge-chunk clipping, and short-buffer clamping. It is called verbatim — no changes to the kernel — aimed at a window-shaped virtual dataset (`[num_rows, inner dims…]`).

The one wrinkle is a chunk straddling the window *start*, which would need a negative leading offset. Since dim 0 is outermost in a row-major chunk, skipping its first `skip` slabs is just a source-buffer offset (`skip × chunk_strides[0] × elem_size`) plus a shrunken leading dim, keeping kernel offsets non-negative; the kernel's own bound check against the window dims clips chunks straddling the window *end*.

Full-inner chunks keep the existing single-`memcpy` row-band fast path, so the common frame-per-chunk case is untouched.

## Notes

- Stride products are computed checked and before any I/O: crafted chunk dimensions (u32 each) can overflow the product where a real chunk's byte size cannot, and the dataset-side `row_elems` guard doesn't see chunk dims. New guard test alongside the existing windowed-read guards.
- A saturated source offset degrades to an empty slice and copies nothing — the same discipline as the kernel's short-chunk clamps.
- Tests: the former `inner_chunked_falls_back_to_whole_read` becomes `inner_chunked_2d_grid_windows` (same equality contract, now exercising the scatter path); new `inner_chunked_edge_overhang_deflate` ([23, 10] with [4, 3] chunks — overhanging edge chunks in both dims, deflated) and `inner_chunked_4d_image_grid` ([13, 5, 7, 3] u8 with [4, 2, 3, 2] chunks — a grid split in every dimension) run the full window sweeps on both backends.
- `tests/windowed_read_memory.rs` demonstrates the memory bound: a counting `#[global_allocator]` (its own test binary, so it scopes to exactly this test) measures a 64-row window read from a 4 MiB deflated inner-split dataset on the streaming backend and asserts peak allocation stays under a quarter of the dataset. The scatter path peaks at **547,336 bytes** (window + raw/typed conversion + a few decompressed 32 KiB chunks); the whole-read fallback peaks at **4,873,004 bytes** (1.16× the dataset) and fails the assertion. The ≥4× margin on both sides keeps allocator slack and cache admission from ever flaking it.
- `cargo test` (1204 passed), `cargo clippy --all-targets`, `cargo fmt --check` all clean.
- Follow-up candidate from the same review: windowed reads of variable-length strings still fall back to a whole read (`read_string` + slice); bounding those would need windowed global-heap access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
