### PR TITLE
Resolve only a row window's heap references in read_string_rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - `Dataset::read_raw_rows` and the typed `read_*_rows` now stream a row window of an inner-chunked dataset by decoding only the chunks the window overlaps, instead of falling back to a whole read, so peak memory scales with the window plus one chunk rather than the dataset ([#183](https://github.com/stephenberry/hdf5-pure/pull/183)).
+- `Dataset::read_string_rows` on variable-length strings now resolves only the window's heap references instead of reading and resolving the whole dataset before slicing, so the row-window memory bound holds for every windowed read: peak allocation is the window's references, its text, and the metadata of the heap collections it touches.
 
 ## [0.23.2] - 2026-07-23
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ let values = ds.read_f64().unwrap();  // only this dataset's chunks are read
 
 The reading API is identical to `File::open`; only the backing store differs. Dataset reads are fully supported: contiguous, compact, and every chunk-index layout (B-tree v1, fixed array, and extensible array). Both group forms (v2 and v1 symbol-table) resolve along a path and attributes read the same as `File::open`; the differences are that `File::as_bytes` returns an empty slice, a streaming file cannot be the source of a cross-file copy, and chunk decompression is sequential. `open_streaming` requires the `std` filesystem.
 
-To read a single dataset that is itself too large to hold decompressed, read it in **row windows** rather than whole: `read_raw_rows(start, count)` and the typed `read_f64_rows` … `read_string_rows` decode only the leading-dimension rows `[start, start + count)`, touching only the chunks that window overlaps, so peak memory scales with the window rather than the dataset. The exception is `read_string_rows` on variable-length strings, which still reads the whole dataset and slices out the window.
+To read a single dataset that is itself too large to hold decompressed, read it in **row windows** rather than whole: `read_raw_rows(start, count)` and the typed `read_f64_rows` … `read_string_rows` decode only the leading-dimension rows `[start, start + count)`, touching only the chunks that window overlaps, so peak memory scales with the window rather than the dataset — for variable-length strings included, whose window resolves only its own heap references.
 
 ```rust
 use hdf5_pure::File;

--- a/docs/guide/reading.md
+++ b/docs/guide/reading.md
@@ -160,7 +160,7 @@ let ds = file.dataset("frames").unwrap();
 let window = ds.read_f64_rows(100, 50).unwrap(); // rows 100..150 only
 ```
 
-Only the storage the window touches is read: a single bounded sub-read for compact and contiguous layouts, and just the chunks whose first-dimension span overlaps the window for chunked layouts, so peak memory scales with the window (plus one chunk) rather than the dataset. The window is clamped to the leading dimension, so a read past the end returns only the rows that exist and a zero-row request returns an empty `Vec`. For variable-length strings, `read_string_rows` transparently falls back to a whole read sliced to the window; `read_raw_rows` streams their fixed-size heap references with the normal bound.
+Only the storage the window touches is read: a single bounded sub-read for compact and contiguous layouts, and just the chunks whose first-dimension span overlaps the window for chunked layouts, so peak memory scales with the window (plus one chunk) rather than the dataset. The window is clamped to the leading dimension, so a read past the end returns only the rows that exist and a zero-row request returns an empty `Vec`. Variable-length strings keep the bound too: `read_string_rows` resolves only the window's heap references, and `read_raw_rows` streams those fixed-size references like any other element.
 
 Combined with a [streaming open](streaming.md#reading-a-large-dataset-a-window-at-a-time), this reads a dataset too large to hold in memory a fixed number of rows at a time.
 

--- a/docs/guide/streaming.md
+++ b/docs/guide/streaming.md
@@ -61,7 +61,7 @@ for start in (0..rows).step_by(1_000_000) {
 }
 ```
 
-The window is clamped to the dataset, so the final short window needs no special-casing. See [Reading a row window](reading.md#reading-a-row-window) for the full method list and the `read_string_rows` fallback for variable-length strings.
+The window is clamped to the dataset, so the final short window needs no special-casing. See [Reading a row window](reading.md#reading-a-row-window) for the full method list.
 
 ## Tuning retained memory
 

--- a/src/global_heap.rs
+++ b/src/global_heap.rs
@@ -79,6 +79,22 @@ impl GlobalHeapIndex {
         offset: u64,
         length_size: u8,
     ) -> Result<Self, FormatError> {
+        Self::parse_filtered(source, offset, length_size, |_| true)
+    }
+
+    /// [`parse`](Self::parse), retaining only the objects `keep` accepts.
+    ///
+    /// The walk still visits every object header — each object's size chains
+    /// the position of the next — but the directory holds just the accepted
+    /// entries, so a caller resolving a few objects of a large collection
+    /// (e.g. a row window of a variable-length string dataset) is not charged
+    /// the whole collection's directory.
+    pub(crate) fn parse_filtered<S: Source + ?Sized>(
+        source: &S,
+        offset: u64,
+        length_size: u8,
+        keep: impl Fn(u16) -> bool,
+    ) -> Result<Self, FormatError> {
         let header_size = 8 + length_size as usize;
         let header = source.read_metadata_at(offset, header_size)?;
 
@@ -159,11 +175,13 @@ impl GlobalHeapIndex {
                 });
             }
 
-            objects.push(GlobalHeapObjectInfo {
-                index: object_index,
-                data_address,
-                size: object_size,
-            });
+            if keep(object_index) {
+                objects.push(GlobalHeapObjectInfo {
+                    index: object_index,
+                    data_address,
+                    size: object_size,
+                });
+            }
 
             let padded_size = pad8_u64(object_size)?;
             pos = data_address

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -3089,8 +3089,7 @@ impl Dataset {
         let count = num_rows.min(n0 - start);
 
         // A window covering every row is exactly a whole read: delegate, so it
-        // never costs a window-shaped copy on top of one (and vlen-string reads,
-        // which still fall back to a whole read, don't pay it twice).
+        // never costs a window-shaped copy on top of one.
         if start == 0 && count == n0 {
             let pipeline = self.filter_pipeline_parsed();
             return Ok(self.file.read_dataset_raw(
@@ -3179,47 +3178,34 @@ impl Dataset {
     /// Windowed [`read_string`](Self::read_string).
     ///
     /// Fixed-length strings decode straight from the window. Variable-length
-    /// strings live in a shared heap, so the whole dataset is read and then
-    /// sliced — the memory bound does not apply there.
+    /// strings resolve only the window's heap references, so the window memory
+    /// bound holds for them too: peak allocation is the window's references,
+    /// its text, and the metadata of the heap collections it touches.
     pub fn read_string_rows(&self, start_row: u64, num_rows: u64) -> Result<Vec<String>, Error> {
         let dt = self.datatype()?;
         if vl_data::is_vlen_string_datatype(&dt) {
-            let dims = self.dataspace()?.dimensions;
-            let n0 = dims.first().copied().unwrap_or(1);
-            // A window covering every row is exactly `read_string` — skip the
-            // whole-read-then-clone fallback.
-            if start_row == 0 && num_rows >= n0 {
-                return self.read_string();
-            }
-            // `read_string` returns one entry per *element* (the product of all
-            // dimensions), so the row window is scaled by the inner-dimension
-            // element count to slice whole rows — matching `read_raw_rows`
-            // rather than treating each element as its own row. Checked so a
-            // crafted dataspace whose inner dims overflow `usize` errors instead
-            // of wrapping.
-            let row_elems: usize = dims.iter().skip(1).try_fold(1usize, |acc, &d| {
-                acc.checked_mul(d.to_usize()?)
-                    .ok_or(FormatError::OffsetOverflow {
-                        offset: acc as u64,
-                        length: d,
-                    })
+            // The window's heap references, read memory-bounded like any other
+            // fixed-size element (4-byte length + collection address + 4-byte
+            // object index), one row spanning its inner dimensions. Resolving
+            // only those against the global heap keeps the bound — the same
+            // resolution `read_string` runs over the whole dataset's references.
+            let raw = self.read_raw_rows(start_row, num_rows)?;
+            let ref_size = 4 + self.file.offset_size() as usize + 4;
+            let num_elements = (raw.len() / ref_size) as u64;
+            let mut strings = Vec::new();
+            self.file.with_source(|source| -> Result<(), Error> {
+                Ok(vl_data::visit_vl_strings_from_source(
+                    source,
+                    &raw,
+                    num_elements,
+                    self.file.offset_size(),
+                    self.file.length_size(),
+                    self.file.addr_offset,
+                    VlenStringReadOptions::default(),
+                    |string| strings.push(String::from(string)),
+                )?)
             })?;
-            let all = self.read_string()?;
-            let start_row_idx = start_row.min(n0);
-            let end_row_idx = start_row.saturating_add(num_rows).min(n0);
-            let start = start_row_idx.to_usize()?.checked_mul(row_elems).ok_or(
-                FormatError::OffsetOverflow {
-                    offset: start_row_idx,
-                    length: row_elems as u64,
-                },
-            )?;
-            let end = end_row_idx.to_usize()?.checked_mul(row_elems).ok_or(
-                FormatError::OffsetOverflow {
-                    offset: end_row_idx,
-                    length: row_elems as u64,
-                },
-            )?;
-            return Ok(all.get(start..end).unwrap_or_default().to_vec());
+            return Ok(strings);
         }
         let raw = self.read_raw_rows(start_row, num_rows)?;
         Ok(data_read::read_as_strings(&raw, &dt)?)

--- a/src/vl_data.rs
+++ b/src/vl_data.rs
@@ -235,6 +235,35 @@ where
     let refs = parse_vl_references(raw_data, num_elements, offset_size)?;
     payload_size(&refs, options)?;
 
+    // This call's object indices per (base-adjusted) collection address, so
+    // each collection's directory walk retains only the entries the call
+    // resolves — a row window of a large dataset would otherwise be charged
+    // the full directory of every touched collection (a writer may pack every
+    // string into one collection). Grouping collects only references the
+    // resolve loop below will look up; invalid ones surface their errors
+    // there, in element order.
+    let mut wanted: Vec<(u64, Vec<u16>)> = Vec::new();
+    for element in &refs {
+        if is_undefined_addr(element.collection_address, offset_size)
+            || (element.length == 0 && element.collection_address == 0)
+        {
+            continue;
+        }
+        let Some(address) = element.collection_address.checked_add(base_address) else {
+            continue;
+        };
+        let Ok(index) = u16::try_from(element.object_index) else {
+            continue;
+        };
+        match wanted.binary_search_by_key(&address, |&(a, _)| a) {
+            Ok(pos) => wanted[pos].1.push(index),
+            Err(pos) => wanted.insert(pos, (address, Vec::from([index]))),
+        }
+    }
+    for (_, indices) in &mut wanted {
+        indices.sort_unstable();
+    }
+
     let mut collections: Vec<(u64, GlobalHeapIndex)> = Vec::new();
     for element in &refs {
         if element.length == 0
@@ -262,7 +291,16 @@ where
         {
             Some(pos) => pos,
             None => {
-                let collection = GlobalHeapIndex::parse(source, collection_address, length_size)?;
+                let keep = wanted
+                    .binary_search_by_key(&collection_address, |&(a, _)| a)
+                    .map(|pos| wanted[pos].1.as_slice())
+                    .unwrap_or(&[]);
+                let collection = GlobalHeapIndex::parse_filtered(
+                    source,
+                    collection_address,
+                    length_size,
+                    |i| keep.binary_search(&i).is_ok(),
+                )?;
                 collections.push((collection_address, collection));
                 collections.len() - 1
             }

--- a/tests/partial_read.rs
+++ b/tests/partial_read.rs
@@ -254,9 +254,10 @@ fn fixed_length_strings_window() {
 }
 
 #[test]
-fn vlen_strings_window_falls_back_to_slice() {
-    // Variable-length strings are heap-backed, so `read_string_rows` reads the whole
-    // dataset and slices; the window must still match.
+fn vlen_strings_window() {
+    // Variable-length strings are heap-backed; `read_string_rows` resolves only
+    // the window's heap references, and the window must match the whole read
+    // sliced to the same rows.
     let (buffered, streaming, _dir) = on_both_backends(|b| {
         b.create_dataset("labels")
             .with_vlen_strings(&["idle", "reach", "grasp", "lift", "place"]);
@@ -371,10 +372,10 @@ fn read_raw_rows_matches_read_raw() {
 #[test]
 fn full_range_window_delegates_to_whole_read() {
     // A window covering every row (including one clamped down from over-long)
-    // delegates to the whole read, so it never costs a window-shaped copy on top
-    // of one — checked here on an inner-chunked grid and on variable-length
-    // strings (whose windowed reads still fall back to a whole read internally).
-    // The observable contract is equality with the whole read.
+    // must cost and return exactly the whole read: `read_raw_rows` delegates to
+    // it, and a vlen-string window resolves the same full set of heap
+    // references. Checked on an inner-chunked grid and on variable-length
+    // strings; the observable contract is equality with the whole read.
     let data: Vec<f64> = (0..120).map(f64::from).collect();
     let (buffered, streaming, _dir) = on_both_backends(|b| {
         b.create_dataset("t")

--- a/tests/windowed_read_memory.rs
+++ b/tests/windowed_read_memory.rs
@@ -1,23 +1,29 @@
-//! Peak-allocation regression test for the windowed row-read API: a small row
-//! window of a large inner-chunked dataset must allocate on the order of the
-//! window (plus a few decompressed chunks), not the dataset. A whole-read
-//! fallback peaks above the full dataset size and fails the assertion.
+//! Peak-allocation regression tests for the windowed row-read API: a small row
+//! window of a large dataset must allocate on the order of the window (plus a
+//! few decompressed chunks or heap-collection directories), not the dataset. A
+//! whole-read fallback peaks above the full dataset size and fails the
+//! assertion.
 //!
-//! The counting allocator applies to this whole test binary, so this file must
-//! hold exactly one `#[test]`: a second test running in parallel would pollute
-//! the counter.
+//! The counting allocator applies to this whole test binary, so every test
+//! serializes on [`LOCK`] and resets the peak inside the critical section — a
+//! test measuring outside the lock would attribute other tests' allocations to
+//! itself.
 
 use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use hdf5_pure::{File, FileBuilder};
 
 /// Bytes currently allocated and the high-water mark, maintained by the
-/// counting allocator below. Relaxed ordering is fine: the test is effectively
-/// single-threaded during the measured section, and the assertion bound has a
-/// 4x margin — exactness is not required, only the order of magnitude.
+/// counting allocator below. Relaxed ordering is fine: the measured section is
+/// single-threaded (under [`LOCK`]), and the assertion bounds have a 4x margin
+/// — exactness is not required, only the order of magnitude.
 static LIVE: AtomicUsize = AtomicUsize::new(0);
 static PEAK: AtomicUsize = AtomicUsize::new(0);
+
+/// Serializes the tests in this binary so [`PEAK`] measures one at a time.
+static LOCK: Mutex<()> = Mutex::new(());
 
 struct CountingAlloc;
 
@@ -56,6 +62,10 @@ static ALLOC: CountingAlloc = CountingAlloc;
 
 #[test]
 fn inner_chunked_window_read_is_memory_bounded() {
+    let _guard = LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+
     // 4 MiB of f64 rows with inner-split storage chunks: [2048, 32, 8] in
     // [64, 16, 4] chunks — a 2x2 inner chunk grid per 64-row band, deflated so
     // chunks really decode (32 KiB decompressed each).
@@ -103,6 +113,67 @@ fn inner_chunked_window_read_is_memory_bounded() {
     // The window must still be the right bytes.
     let expected: Vec<f64> = (992 * ROW_ELEMS..(992 + 64) * ROW_ELEMS)
         .map(|i| i as f64)
+        .collect();
+    assert_eq!(window, expected);
+}
+
+#[test]
+fn vlen_string_window_read_is_memory_bounded() {
+    let _guard = LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+    // ~4 MiB of variable-length string payload: 32k rows of 128-byte strings,
+    // plus ~512 KiB of heap references in the dataset itself. The writer packs
+    // the strings into one giant heap collection — the degenerate case for a
+    // windowed read, whose directory alone rivals the window if parsed whole.
+    const N0: usize = 32 * 1024;
+    const STR_LEN: usize = 128;
+    const PAYLOAD_BYTES: usize = N0 * STR_LEN;
+
+    let strings: Vec<String> = (0..N0)
+        .map(|i| format!("{i:0>width$}", width = STR_LEN))
+        .collect();
+    let refs: Vec<&str> = strings.iter().map(String::as_str).collect();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("test.h5");
+    let mut builder = FileBuilder::new();
+    builder.create_dataset("labels").with_vlen_strings(&refs);
+    builder.write(&path).unwrap();
+    drop(refs);
+    drop(strings);
+
+    let file = File::open_streaming(&path).unwrap();
+    let ds = file.dataset("labels").unwrap();
+
+    // Measure only the windowed read: 256 mid-file rows — ~32 KiB of text plus
+    // ~4 KiB of references, resolved against a window-filtered slice of the
+    // collection's directory.
+    let base = LIVE.load(Ordering::Relaxed);
+    PEAK.store(base, Ordering::Relaxed);
+
+    let window = ds.read_string_rows(15_000, 256).unwrap();
+
+    let peak = PEAK.load(Ordering::Relaxed) - base;
+    eprintln!(
+        "peak allocation during the windowed vlen read: {peak} bytes (payload: {PAYLOAD_BYTES})"
+    );
+
+    // Window references + text + touched heap-collection directories land far
+    // under 1 MiB; resolving every reference first peaks above the full payload
+    // (all references plus a Vec<String> of every row). This also catches a
+    // collection parse that starts buffering whole collections instead of
+    // walking their metadata.
+    assert!(
+        peak < PAYLOAD_BYTES / 4,
+        "peak allocation during the windowed vlen read must be bounded by the window, \
+         not the {PAYLOAD_BYTES}-byte payload; measured {peak} bytes"
+    );
+
+    // The window must still be the right strings.
+    assert_eq!(window.len(), 256);
+    let expected: Vec<String> = (15_000..15_000 + 256)
+        .map(|i| format!("{i:0>width$}", width = STR_LEN))
         .collect();
     assert_eq!(window, expected);
 }


### PR DESCRIPTION
## What

The variable-length branch of `Dataset::read_string_rows` now reads just the window's heap references (via `read_raw_rows`, bounded like any other fixed-size element) and resolves only those, instead of reading and resolving the whole dataset before slicing. With #181 and #183 in, this was the last windowed read whose peak memory scaled with the dataset; the row-window memory bound now holds for every `read_*_rows`.

## Why

Downstream in [rerun](https://github.com/rerun-io/rerun)'s streaming HDF5 ingestion, vlen-string datasets were the one layout we still had to materialize up front instead of streaming window by window. Through our stack, streaming a 128 MiB vlen-string dataset (2M × 64 B, h5py-written) peaked at ~425 MiB RSS before this change and ~56 MiB after, with unchanged load time.

## How

The resolution machinery was already bounded — `visit_vl_strings_from_source` resolves element by element straight from the source — so the core change is small: feed it the window's references instead of all of them. Multi-dimensional row semantics (#182) fall out for free, since `read_raw_rows` returns whole rows. The full-range early-out is gone: the unified path costs exactly `read_string` there (same reference read, same resolution).

One term remained dataset-scaled after that: `GlobalHeapIndex::parse` retains the directory of *every* object in a touched collection, and the writer packs all of a dataset's strings into one giant collection — for short strings that directory (~24 B per string) rivals the payload. The resolver now pre-groups the call's object indices per collection and `GlobalHeapIndex::parse_filtered` retains only those entries. The walk still visits every object header (each object's size chains the position of the next), but the directory is window-sized. Whole reads are unchanged — their filter accepts everything.

## Numbers

From the new `vlen_string_window_read_is_memory_bounded` (4 MiB payload, 32k × 128 B strings, 256-row mid-file window, streaming backend), peak allocation during the read:

| | peak |
|---|---|
| whole-read + slice (before) | 6,816,136 bytes — 1.6× the payload, fails the bound |
| windowed references, unfiltered directory | 833,832 bytes — mostly the giant collection's directory |
| windowed references + filtered directory (this PR) | **54,184 bytes** |

## Notes

- `tests/windowed_read_memory.rs` now holds two tests serialized on a mutex (the counting allocator is binary-wide, so measurements must not overlap); the new one pins the vlen bound at < payload/4 and doubles as a guard against a collection parse that starts buffering whole directories.
- `vlen_strings_window_falls_back_to_slice` becomes `vlen_strings_window` (same equality contract, now on the bounded path); the #182 multi-dimensional sweep is untouched and passes unchanged, including its lockstep-with-`read_raw_rows` count checks.
- Docs re-swept: README, `docs/guide/reading.md`, `docs/guide/streaming.md` (the caveat #183's follow-up scoped to `read_string_rows` now disappears entirely), plus the `read_raw_rows` early-out comment.
- `cargo test` (1205 passed), `cargo clippy --all-targets`, `cargo fmt --check`, `cargo check --no-default-features` (no_std) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)