### PR TITLE
Bump the version in the PR that breaks the API, not at release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,12 @@ jobs:
   # removing a `pub fn`) fails the job unless the version in Cargo.toml is
   # bumped accordingly (under 0.x, breaking changes require a minor bump).
   #
+  # So a PR that breaks the public API on purpose bumps Cargo.toml to the next
+  # minor as part of the PR, which is this repo's convention regardless (the
+  # manifest carries the version being developed — see "Versioning" in
+  # CLAUDE.md). Red here means the break is either unintended or undeclared;
+  # it is not the expected state of a breaking PR.
+  #
   # `parallel_read`/`lane_partition` are gated behind `parallel`, so the feature
   # set below must enable the public-API-bearing features to see their surface.
   # `fast-deflate` is omitted (a flate2 backend swap, no API delta) along with

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,3 +7,11 @@ Keep `CHANGELOG.md` entries concise and reader-facing. Each entry is one or two 
 Drop the things that bloat it: bit/byte-level internals and root-cause mechanics, "validated/verified against the reference C library" narration, "byte-for-byte" boilerplate, exhaustive enumerations of every refused case, and development cross-references like "addressed below". Commit `d5a966b` (#61, "Trim the changelog to concise, reader-facing entries") is the canonical example of the before/after; match its `before -> after` for any new entry, and don't let the `[Unreleased]` section regrow into PR-description-length paragraphs.
 
 `docs/reference/changelog.md` is a generated include of `CHANGELOG.md`, so edit only the root file.
+
+## Versioning
+
+The version in `Cargo.toml` is the version being *developed*, not the one last published. **A PR that breaks the public API bumps it to the next minor (`0.24.0` -> `0.25.0`) in that same PR**, alongside its `CHANGELOG.md` entry. If it already reads the next minor, leave it: one bump covers every breaking change in the cycle. Additive-only PRs need no bump, and the release takes care of theirs.
+
+This is what keeps the `SemVer (cargo-semver-checks)` job green. That job compares the branch against the latest crates.io release and fails a breaking change unless the manifest already declares a bump large enough to carry it. Deferring the bump to release time makes every breaking PR red by construction, and a check that is expected to be red stops being read at all, including when it flags an *unintended* break.
+
+`scripts/release.sh` reads the previous version from the latest `v*` tag, so it accepts an already-bumped manifest and skips the bump.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,8 +10,10 @@ Drop the things that bloat it: bit/byte-level internals and root-cause mechanics
 
 ## Versioning
 
-The version in `Cargo.toml` is the version being *developed*, not the one last published. **A PR that breaks the public API bumps it to the next minor (`0.24.0` -> `0.25.0`) in that same PR**, alongside its `CHANGELOG.md` entry. If it already reads the next minor, leave it: one bump covers every breaking change in the cycle. Additive-only PRs need no bump, and the release takes care of theirs.
+The version in `Cargo.toml` is the version being *developed*, not the one last published. **A PR that breaks the public API bumps it to the next minor (`0.24.0` -> `0.25.0`), and `Cargo.lock` with it, in that same PR**, alongside its `CHANGELOG.md` entry. If it already reads the next minor, leave it: one bump covers every breaking change in the cycle. Additive-only PRs need no bump, and the release takes care of theirs.
 
 This is what keeps the `SemVer (cargo-semver-checks)` job green. That job compares the branch against the latest crates.io release and fails a breaking change unless the manifest already declares a bump large enough to carry it. Deferring the bump to release time makes every breaking PR red by construction, and a check that is expected to be red stops being read at all, including when it flags an *unintended* break.
 
-`scripts/release.sh` reads the previous version from the latest `v*` tag, so it accepts an already-bumped manifest and skips the bump.
+Know the cost: once the manifest declares the bump, `cargo-semver-checks` reports "no semver update required" and **skips every check** for the rest of the cycle, so it catches an unintended break only in the first breaking PR of a cycle (and throughout an additive-only one). `scripts/release.sh` compensates by running the full check once at release time with `--release-type minor`, which overrides that derivation; read its output against the `[Unreleased]` section you are about to promote. An empty report on a cycle whose changelog claims a breaking change is the signal worth chasing.
+
+`scripts/release.sh` reads the previous version from the latest `vX.Y.Z` tag, so it accepts an already-bumped manifest. It refuses a version that does not come after the last release, a manifest outside `last-release .. version-being-cut`, and a changelog a previous run already promoted.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -31,6 +31,11 @@
 #
 set -euo pipefail
 
+# Every mktemp lands here so an abort part-way through leaves nothing behind.
+TMP_FILES=""
+cleanup() { [ -z "$TMP_FILES" ] || rm -f $TMP_FILES; }
+trap cleanup EXIT
+
 # ---------------------------------------------------------------------------
 # Argument parsing
 # ---------------------------------------------------------------------------
@@ -96,24 +101,59 @@ REPO_URL="$(awk -F'"' '/^repository = /{print $2; exit}' "$CARGO_TOML")"
 # Cargo.toml. Under this repo's convention (see "Versioning" in CLAUDE.md) the
 # manifest carries the version being *developed*, so once a breaking PR has
 # merged it already reads $NEW_VERSION and is no longer the previous release.
-PREV_VERSION="$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -1 | sed 's/^v//')"
-[ -n "$PREV_VERSION" ] || PREV_VERSION="$CUR_VERSION"
+#
+# Exact `vX.Y.Z` only: the shell glob's `*` matches dots, so a looser pattern
+# would admit `v0.24.0.1`, and `--sort=-v:refname` ranks `v0.25.0-rc1` above
+# `v0.25.0` unless `versionsort.suffix` is configured. `sort -V | tail -1` reads
+# its whole input, where `head -1` would SIGPIPE (silently, under `set -o
+# pipefail`) on a repo with enough tags to fill the pipe buffer.
+# `|| true`: with no matching tag `grep` exits 1, and under `set -o pipefail`
+# that would abort the script here — before the check below can say why.
+PREV_VERSION="$(git tag --list 'v*' \
+  | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+  | sed 's/^v//' \
+  | sort -V \
+  | tail -1 || true)"
+
+# Compare dotted versions. `sort -V` orders them; equal values sort to the same
+# line, so `_ge` is "not strictly less".
+version_ge() {
+  [ "$1" = "$2" ] || [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -1)" = "$1" ]
+}
 
 # ---------------------------------------------------------------------------
 # Preflight
 # ---------------------------------------------------------------------------
-note "Releasing ${PREV_VERSION} -> ${NEW_VERSION}"
-
 printf '%s\n' "$NEW_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' \
   || die "version must be X.Y.Z (got '$NEW_VERSION')"
 
-# Cargo.toml may legitimately read either the last release (nothing breaking has
-# merged this cycle) or the version being released (something has). Anything
-# else means the manifest and the requested version disagree about what is
-# being cut, which is a mistake worth stopping on rather than overwriting.
-if [ "$CUR_VERSION" != "$NEW_VERSION" ] && [ "$CUR_VERSION" != "$PREV_VERSION" ]; then
-  die "$CARGO_TOML reads $CUR_VERSION, which is neither the last release ($PREV_VERSION) nor $NEW_VERSION"
-fi
+# No tag means no compare base. Falling back to Cargo.toml would be wrong under
+# this repo's convention — the manifest is the version being developed, not the
+# previous release — and would silently emit a `vX...vX` self-comparison link.
+# A shallow or tag-pruned clone lands here; fetch the tags rather than guess.
+[ -n "$PREV_VERSION" ] || die "no vX.Y.Z tag found; run \`git fetch --tags\` (a shallow clone has none)"
+
+note "Releasing ${PREV_VERSION} -> ${NEW_VERSION}"
+
+# Releases move forward. Without this a typo like `0.2.5` for `0.25.0` passes
+# every other check and, with --publish, is permanent: crates.io versions can be
+# yanked but never deleted or reused.
+version_ge "$NEW_VERSION" "$PREV_VERSION" && [ "$NEW_VERSION" != "$PREV_VERSION" ] \
+  || die "$NEW_VERSION does not come after the last release ($PREV_VERSION)"
+
+# Cargo.toml may legitimately read the last release (nothing breaking has merged
+# this cycle) or anything up to the version being cut (something has, possibly in
+# a smaller step than this release). Outside that range the manifest and the
+# requested version disagree about what is being cut, which is worth stopping on
+# rather than overwriting.
+version_ge "$CUR_VERSION" "$PREV_VERSION" && version_ge "$NEW_VERSION" "$CUR_VERSION" \
+  || die "$CARGO_TOML reads $CUR_VERSION, outside the last release ($PREV_VERSION) .. $NEW_VERSION"
+
+# A `## [X.Y.Z]` section for this version means a previous run already promoted
+# the changelog. Re-running would emit a second one; the local tag check below
+# misses this when the tag was deleted to retry a failed publish.
+grep -q "^## \[${NEW_VERSION}\]" "$CHANGELOG" \
+  && die "$CHANGELOG already has a [$NEW_VERSION] section; a previous run promoted it"
 
 BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 [ "$BRANCH" = "main" ] || die "not on main (on '$BRANCH'); release from main"
@@ -154,27 +194,32 @@ TODAY="$(date +%Y-%m-%d)"
 # ([[package]] hdf5-pure).
 bump_version() {
   local file="$1" tmp
-  tmp="$(mktemp)"
+  tmp="$(mktemp)"; TMP_FILES="$TMP_FILES $tmp"
   awk -v new="$NEW_VERSION" '
     /^name = "hdf5-pure"/ { pkg=1 }
     pkg && /^version = / { sub(/"[^"]*"/, "\"" new "\""); pkg=0 }
     { print }
   ' "$file" > "$tmp"
-  mv "$tmp" "$file"
+  # Copy through the existing file rather than renaming the temp over it, so the
+  # original inode and its 0644 mode survive (mktemp creates 0600).
+  cat "$tmp" > "$file"
 }
+# Idempotent, and applied to each file independently: skipping both because
+# Cargo.toml already reads $NEW_VERSION would leave a Cargo.lock still declaring
+# the previous version in the release commit and tag.
 if [ "$CUR_VERSION" = "$NEW_VERSION" ]; then
   note "Version already reads $NEW_VERSION (bumped by the PR that required it)"
 else
   note "Bumping version in $CARGO_TOML and $CARGO_LOCK"
-  bump_version "$CARGO_TOML"
-  bump_version "$CARGO_LOCK"
 fi
+bump_version "$CARGO_TOML"
+bump_version "$CARGO_LOCK"
 
 # ---------------------------------------------------------------------------
 # 2. Promote [Unreleased] into a dated section and refresh the compare links
 # ---------------------------------------------------------------------------
 note "Updating $CHANGELOG"
-CL_TMP="$(mktemp)"
+CL_TMP="$(mktemp)"; TMP_FILES="$TMP_FILES $CL_TMP"
 SUMMARY="$SUMMARY" awk \
   -v new="$NEW_VERSION" -v prev="$PREV_VERSION" -v date="$TODAY" -v repo="$REPO_URL" '
   # Insert the new version header + summary as the first content under
@@ -195,16 +240,44 @@ SUMMARY="$SUMMARY" awk \
   }
   { print }
 ' "$CHANGELOG" > "$CL_TMP"
-mv "$CL_TMP" "$CHANGELOG"
+cat "$CL_TMP" > "$CHANGELOG"
+
+# The `[X.Y.Z]:` compare link is emitted only as a side effect of matching the
+# `[Unreleased]:` line, so a missing or renamed anchor would drop both links
+# silently and still produce a plausible-looking release.
+grep -q "^\[${NEW_VERSION}\]: " "$CHANGELOG" \
+  || die "$CHANGELOG has no [Unreleased]: link line to anchor the compare links to"
+grep -q "^## \[${NEW_VERSION}\] - ${TODAY}\$" "$CHANGELOG" \
+  || die "failed to promote [Unreleased] into a [$NEW_VERSION] section"
 
 # ---------------------------------------------------------------------------
-# 3. Verify the crate still packages cleanly with the new version
+# 3. Report the cycle's public-API delta
+# ---------------------------------------------------------------------------
+# CI's semver-checks job derives what to check from the version already in the
+# manifest, so once a breaking PR has bumped it the job reports "no semver update
+# required" and skips every check for the rest of the cycle. `--release-type
+# minor` overrides that derivation and forces the full run, which is worth having
+# exactly once, here, where the accumulated delta can be read against the
+# [Unreleased] section about to be promoted.
+#
+# Informational: a listed break is expected under a 0.x minor bump, and an empty
+# report on a cycle whose changelog claims a breaking change is the real signal.
+if command -v cargo-semver-checks >/dev/null 2>&1; then
+  note "Public API delta since ${PREV_VERSION} (informational)"
+  cargo semver-checks --baseline-version "$PREV_VERSION" --release-type minor \
+    --default-features --features serde,zfp,provenance,parallel,ndarray || true
+else
+  note "Skipping the API delta report (cargo-semver-checks not installed)"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Verify the crate still packages cleanly with the new version
 # ---------------------------------------------------------------------------
 note "Verifying with cargo publish --dry-run"
 cargo publish --dry-run --allow-dirty
 
 # ---------------------------------------------------------------------------
-# 4. Commit + tag (opt-in)
+# 5. Commit + tag (opt-in)
 # ---------------------------------------------------------------------------
 if [ "$DO_COMMIT" -eq 0 ]; then
   note "Prepared release files (not committed)."
@@ -234,7 +307,7 @@ git commit -m "Release $TAG"
 git tag -a "$TAG" -m "Release $TAG"
 
 # ---------------------------------------------------------------------------
-# 5. Push (opt-in)
+# 6. Push (opt-in)
 # ---------------------------------------------------------------------------
 if [ "$DO_PUSH" -eq 1 ]; then
   note "Pushing main and $TAG"
@@ -243,11 +316,11 @@ if [ "$DO_PUSH" -eq 1 ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# 6. GitHub release (opt-in) — notes are the changelog section for this version
+# 7. GitHub release (opt-in) — notes are the changelog section for this version
 # ---------------------------------------------------------------------------
 if [ "$DO_GH" -eq 1 ]; then
   note "Creating GitHub release $TAG"
-  NOTES_TMP="$(mktemp)"
+  NOTES_TMP="$(mktemp)"; TMP_FILES="$TMP_FILES $NOTES_TMP"
   awk -v ver="$NEW_VERSION" '
     index($0, "## [" ver "]") == 1 { grab=1; next }  # start after this version header
     grab && /^## \[/ { exit }                        # stop at the next version header
@@ -259,7 +332,7 @@ if [ "$DO_GH" -eq 1 ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# 7. crates.io publish (opt-in)
+# 8. crates.io publish (opt-in)
 # ---------------------------------------------------------------------------
 if [ "$DO_PUBLISH" -eq 1 ]; then
   note "Publishing to crates.io"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -4,7 +4,8 @@
 #
 # Automates the mechanical, easy-to-botch parts of a release so they come out
 # identical every time:
-#   * bump the version in Cargo.toml and Cargo.lock
+#   * bump the version in Cargo.toml and Cargo.lock, or accept one a breaking
+#     PR already bumped (see "Versioning" in CLAUDE.md)
 #   * promote the CHANGELOG's [Unreleased] section into a dated `## [X.Y.Z]`
 #     section and refresh the two compare links at the bottom
 #   * verify the crate still packages (`cargo publish --dry-run`)
@@ -45,7 +46,9 @@ die() { printf 'error: %s\n' "$*" >&2; exit 1; }
 note() { printf '\033[1m==>\033[0m %s\n' "$*"; }
 
 usage() {
-  sed -n '2,45p' "$0" | sed 's/^# \{0,1\}//'
+  # The leading comment block, minus the shebang and the `#` markers. Ends at
+  # the first line that is not a comment, so it stays correct as the block grows.
+  awk 'NR > 1 && !/^#/ { exit } NR > 1 { sub(/^# ?/, ""); print }' "$0"
   exit "${1:-0}"
 }
 
@@ -89,14 +92,28 @@ REPO_URL="$(awk -F'"' '/^repository = /{print $2; exit}' "$CARGO_TOML")"
 [ -n "$CUR_VERSION" ] || die "could not read current version from $CARGO_TOML"
 [ -n "$REPO_URL" ] || die "could not read repository URL from $CARGO_TOML"
 
+# The version this release follows comes from the latest version tag, not from
+# Cargo.toml. Under this repo's convention (see "Versioning" in CLAUDE.md) the
+# manifest carries the version being *developed*, so once a breaking PR has
+# merged it already reads $NEW_VERSION and is no longer the previous release.
+PREV_VERSION="$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -1 | sed 's/^v//')"
+[ -n "$PREV_VERSION" ] || PREV_VERSION="$CUR_VERSION"
+
 # ---------------------------------------------------------------------------
 # Preflight
 # ---------------------------------------------------------------------------
-note "Releasing ${CUR_VERSION} -> ${NEW_VERSION}"
+note "Releasing ${PREV_VERSION} -> ${NEW_VERSION}"
 
 printf '%s\n' "$NEW_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' \
   || die "version must be X.Y.Z (got '$NEW_VERSION')"
-[ "$NEW_VERSION" != "$CUR_VERSION" ] || die "version is already $NEW_VERSION"
+
+# Cargo.toml may legitimately read either the last release (nothing breaking has
+# merged this cycle) or the version being released (something has). Anything
+# else means the manifest and the requested version disagree about what is
+# being cut, which is a mistake worth stopping on rather than overwriting.
+if [ "$CUR_VERSION" != "$NEW_VERSION" ] && [ "$CUR_VERSION" != "$PREV_VERSION" ]; then
+  die "$CARGO_TOML reads $CUR_VERSION, which is neither the last release ($PREV_VERSION) nor $NEW_VERSION"
+fi
 
 BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 [ "$BRANCH" = "main" ] || die "not on main (on '$BRANCH'); release from main"
@@ -145,9 +162,13 @@ bump_version() {
   ' "$file" > "$tmp"
   mv "$tmp" "$file"
 }
-note "Bumping version in $CARGO_TOML and $CARGO_LOCK"
-bump_version "$CARGO_TOML"
-bump_version "$CARGO_LOCK"
+if [ "$CUR_VERSION" = "$NEW_VERSION" ]; then
+  note "Version already reads $NEW_VERSION (bumped by the PR that required it)"
+else
+  note "Bumping version in $CARGO_TOML and $CARGO_LOCK"
+  bump_version "$CARGO_TOML"
+  bump_version "$CARGO_LOCK"
+fi
 
 # ---------------------------------------------------------------------------
 # 2. Promote [Unreleased] into a dated section and refresh the compare links
@@ -155,7 +176,7 @@ bump_version "$CARGO_LOCK"
 note "Updating $CHANGELOG"
 CL_TMP="$(mktemp)"
 SUMMARY="$SUMMARY" awk \
-  -v new="$NEW_VERSION" -v prev="$CUR_VERSION" -v date="$TODAY" -v repo="$REPO_URL" '
+  -v new="$NEW_VERSION" -v prev="$PREV_VERSION" -v date="$TODAY" -v repo="$REPO_URL" '
   # Insert the new version header + summary as the first content under
   # [Unreleased] (i.e. before the first non-blank line that follows it).
   /^## \[Unreleased\]/ { print; seen=1; next }
@@ -232,7 +253,7 @@ if [ "$DO_GH" -eq 1 ]; then
     grab && /^## \[/ { exit }                        # stop at the next version header
     grab { print }
   ' "$CHANGELOG" > "$NOTES_TMP"
-  printf '\n**Full changelog:** %s/compare/v%s...v%s\n' "$REPO_URL" "$CUR_VERSION" "$NEW_VERSION" >> "$NOTES_TMP"
+  printf '\n**Full changelog:** %s/compare/v%s...v%s\n' "$REPO_URL" "$PREV_VERSION" "$NEW_VERSION" >> "$NOTES_TMP"
   gh release create "$TAG" --title "$TAG" --notes-file "$NOTES_TMP"
   rm -f "$NOTES_TMP"
 fi


### PR DESCRIPTION
Every deliberately breaking PR fails `SemVer (cargo-semver-checks)`, and has for several releases. That is not the tool being wrong: it compares the branch against the latest crates.io release and passes a breaking change only when `Cargo.toml` already declares a bump large enough to carry it. Because the bump lived in the release commit, the manifest read the *published* version for the entire development cycle, so the job could not go green on a breaking PR no matter how correct the change was.

The cost is not the red mark. It is that a check everyone expects to be red stops being read, including on the day it flags a break nobody meant to make. That is the only thing this job exists to catch.

## The convention

**The version in `Cargo.toml` is the version being developed.** A PR that breaks the public API bumps it to the next minor as part of that PR, next to its changelog entry. If it already reads the next minor, leave it: one bump covers every breaking change in the cycle. Additive PRs need no bump, and `cargo-semver-checks` does not ask for one.

Verified locally against the two open breaking PRs: with the bump in place the job reports `no semver update required` instead of listing the intended removals.

Written down in `CLAUDE.md` and in the comment above the job, since the failure mode is a process one and will otherwise come back.

## What this needed from `release.sh`

- The previous version now comes from the latest `vX.Y.Z` tag, not from `Cargo.toml` — which stops being the previous release the moment a breaking PR merges. Without this the new compare link would have read `v0.25.0...v0.25.0`.
- It accepts an already-bumped manifest instead of refusing outright, and refuses one outside `last-release .. version-being-cut`.

Exercised in a throwaway clone: monotonicity, re-cutting the last release, a manifest ahead of the request, zero tags, 1.0.0 from a 0.25.0 manifest, the already-bumped skip, and a re-run over an already-promoted changelog. Compare links and file modes checked on the paths that complete.

Also ends `--help` at the first non-comment line; its hardcoded `sed -n '2,45p'` range had drifted and was printing shell code.

## Review found two ways this could do damage

Both in the block this PR rewrites, both fixed here:

- **No monotonicity check.** `release.sh 0.2.5` — a plausible slip for `0.25.0`, and this convention makes typing a version routine — passed every check and would have cut a *lower* version. With `--publish` that is permanent. The release must now come after the last tag.
- **The no-tag fallback reintroduced the bug this PR fixes.** `PREV_VERSION="$CUR_VERSION"` is unsound by construction here, since the manifest is never the previous release, so both compare links became `vX...vX`. A `git clone --depth 1` has zero tags and lands there. It now refuses. Testing that refusal found it exited *silently* — `grep` returns 1 with no match, and under `pipefail` that aborted the script before the check could report why.

Also: the guard admitted only two exact versions, which blocked the eventual 1.0.0 release; the bump is now idempotent and per-file (skipping both on `Cargo.toml` alone would ship a stale `Cargo.lock` in the release commit); tag selection takes exact `vX.Y.Z` only, since the glob's `*` matches dots and `--sort=-v:refname` ranks `v0.25.0-rc1` above `v0.25.0`; a re-run over an already-promoted changelog is refused; the compare-link rewrite is verified rather than assumed; and temp files no longer silently reset tracked files to 0600.

## The cost, now stated rather than implied

Once the manifest declares the bump, `cargo-semver-checks` reports "no semver update required" and **skips all 253 checks** until the next release — so it catches an unintended break only in the first breaking PR of a cycle, and throughout an additive-only one. That is a real reduction, and the first draft did not mention it.

`--release-type minor` overrides the derivation and forces the full run even with the bump in place (verified: 196 checks, naming the intended break). `release.sh` now does exactly that once at release time, informationally, where the accumulated delta can be read against the `[Unreleased]` section about to be promoted. `CLAUDE.md` says so and says what to look for.

## Merge order

Worth merging before #196 and #197, since both carry the 0.25.0 bump this convention asks for and `release.sh` would otherwise refuse the release with `version is already 0.25.0`.
