### PR TITLE
Fix embedded-reference repack corruption and the builder-closure deadlock, restore crash-consistency tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - Reading the same `File` from inside a builder closure (`Group::create_dataset`, `create_group_with`, `Dataset::write_staged`, `append_staged`) no longer hangs the process. The closures now configure a builder off the session lock, so a staged dataset may depend on data already in the file; it sees the file as it was before the call, since staged edits resolve only on `commit` ([#200](https://github.com/stephenberry/hdf5-pure/issues/200)).
-- `repack` no longer corrupts a dataset whose datatype *contains* a variable-length or object-reference member, such as a compound with a variable-length string field. The embedded references were copied verbatim and left pointing into the source file, producing a destination this crate read back without complaint and the reference C library could not read at all; they are now rewritten like top-level ones ([#201](https://github.com/stephenberry/hdf5-pure/issues/201)).
+- `repack` no longer corrupts a dataset whose datatype *contains* a variable-length member, an object-reference member, or both — such as a compound with a variable-length string field. The embedded addresses were copied verbatim and left pointing into the source file, producing a destination this crate read back without complaint and the reference C library could not read at all; they are now rewritten like top-level ones ([#201](https://github.com/stephenberry/hdf5-pure/issues/201)).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `Dataset::write_staged` overwrites a dataset through its full `DatasetBuilder`, the builder-level counterpart of `Dataset::write` for element kinds that are not `H5Element` ([#148](https://github.com/stephenberry/hdf5-pure/issues/148)).
 - `Group::create_group_with` stages a new group configured through a `StagedGroup` closure, so a group's attributes and children land with its creation (`set_attr` cannot reach it, since it needs a group that already resolves). `create_group(name)` is unchanged ([#148](https://github.com/stephenberry/hdf5-pure/issues/148)).
 
+### Fixed
+
+- `repack` no longer corrupts a dataset whose datatype *contains* a variable-length or object-reference member, such as a compound with a variable-length string field. The embedded references were copied verbatim and left pointing into the source file, producing a destination this crate read back without complaint and the reference C library could not read at all; they are now rewritten like top-level ones ([#201](https://github.com/stephenberry/hdf5-pure/issues/201)).
+
 ### Changed
 
 - **Breaking:** three refusals on the owned write path now report a more specific error: an unaligned SWMR append gives `SwmrAppendUnsupported` instead of a `ChunkedReadError`, an ineligible immediate append gives `AppendInPlaceUnsupported` instead of `AppendUnsupported`, and a missing edit target gives `PathNotFound` when the handle is resolved instead of `AppendUnsupported`/`EditUnsupported` at commit ([#148](https://github.com/stephenberry/hdf5-pure/issues/148)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- Reading the same `File` from inside a builder closure (`Group::create_dataset`, `create_group_with`, `Dataset::write_staged`, `append_staged`) no longer hangs the process. The closures now configure a builder off the session lock, so a staged dataset may depend on data already in the file; it sees the file as it was before the call, since staged edits resolve only on `commit` ([#200](https://github.com/stephenberry/hdf5-pure/issues/200)).
 - `repack` no longer corrupts a dataset whose datatype *contains* a variable-length or object-reference member, such as a compound with a variable-length string field. The embedded references were copied verbatim and left pointing into the source file, producing a destination this crate read back without complaint and the reference C library could not read at all; they are now rewritten like top-level ones ([#201](https://github.com/stephenberry/hdf5-pure/issues/201)).
 
 ### Changed

--- a/docs/guide/editing.md
+++ b/docs/guide/editing.md
@@ -97,7 +97,7 @@ root.create_dataset("run2/signal", |b| {
 
 `set_attr` needs a group that already resolves, so a group staged in this same batch is not reachable through it — stage those attributes with `create_group_with` instead. A staged object is not resolvable by name until `commit`, so `File::group`/`File::dataset` will not find it before then.
 
-The `create_group_with`/`create_dataset`/`write_staged` closures run while the file's writable session is locked, so a closure must not call back into the same `File`.
+The `create_group_with`/`create_dataset`/`write_staged`/`append_staged` closures configure a builder rather than the file itself, so a closure may read the same `File` — staging a dataset whose contents depend on one already there works. What it reads is the file as it was before the call, since nothing staged resolves until `commit`.
 
 `set_attr` takes an `AttrValue`, fixed-size or variable-length (`AttrValue::VarLenAsciiArray`). `File::root()` names the root group. Attributes are stored compactly in the rebuilt group header; an edit that would exceed the compact-attribute limit, or a group using dense (fractal-heap) attribute storage, is refused before any file bytes change.
 

--- a/docs/guide/repack.md
+++ b/docs/guide/repack.md
@@ -56,7 +56,7 @@ The operation is all-or-nothing: the entire source is validated and staged in me
 | Aspect | Supported |
 | --- | --- |
 | Datatypes | fixed-point, floating-point, fixed-length string, time, bit-field, opaque, compound, enumeration, array; variable-length strings and sequences, and 8-byte object references (rewritten to their targets' new addresses) |
-| Embedded references | a compound with a variable-length or object-reference member, an array of such compounds, and nesting of either: the embedded references are rewritten, the surrounding bytes carried through untouched |
+| Embedded addresses | a compound with a variable-length member, an object-reference member, or both; an array of such compounds; and nesting of either. The embedded addresses are rewritten, the surrounding bytes carried through untouched |
 | Layout | contiguous / compact or chunked |
 | Filters | deflate, shuffle, fletcher32, and/or lossless integer scale-offset |
 | Structure | group hierarchy of arbitrary depth |

--- a/docs/guide/repack.md
+++ b/docs/guide/repack.md
@@ -55,7 +55,8 @@ The operation is all-or-nothing: the entire source is validated and staged in me
 
 | Aspect | Supported |
 | --- | --- |
-| Datatypes | fixed-point, floating-point, fixed-length string, time, bit-field, opaque, compound, enumeration, array; contiguous variable-length strings and sequences, and 8-byte object references (rewritten to their targets' new addresses) |
+| Datatypes | fixed-point, floating-point, fixed-length string, time, bit-field, opaque, compound, enumeration, array; variable-length strings and sequences, and 8-byte object references (rewritten to their targets' new addresses) |
+| Embedded references | a compound with a variable-length or object-reference member, an array of such compounds, and nesting of either: the embedded references are rewritten, the surrounding bytes carried through untouched |
 | Layout | contiguous / compact or chunked |
 | Filters | deflate, shuffle, fletcher32, and/or lossless integer scale-offset |
 | Structure | group hierarchy of arbitrary depth |
@@ -73,7 +74,7 @@ These are reported as `Error::RepackUnsupported` naming the object, never silent
 
 | Refused | Reason |
 | --- | --- |
-| chunked, filtered, or resizable **object-reference** datasets | their object addresses are assigned as elements are re-staged, which a compressed chunk would need rewritten in place |
+| chunked, filtered, or resizable datasets whose datatype **is or contains an object reference** | their object addresses are assigned as elements are re-staged, which a compressed chunk would need rewritten in place |
 | variable-length sequences whose base type is itself variable-length, or a reference | the copied element bytes would carry addresses that go stale on rewrite |
 | region references, and object references other than 8 bytes wide | their stored selections and addresses are not rewritten yet |
 | object references in a file with a userblock, or to an object being dropped | the new target address cannot be resolved safely, or will not exist |

--- a/src/chunk_index_inplace.rs
+++ b/src/chunk_index_inplace.rs
@@ -1,8 +1,9 @@
-//! In-place Extensible-Array chunk-index growth, shared by the SWMR append
-//! writer ([`crate::swmr_writer`]) and the general append writer
-//! ([`crate::append_writer`]).
+//! In-place Extensible-Array chunk-index growth, shared by the mirror-backed
+//! edit engine ([`crate::edit`]) and the bounded engine ([`crate::bounded`]) —
+//! the two owners behind [`Dataset::append`](crate::Dataset::append) and
+//! [`File::open_swmr_writer`](crate::File::open_swmr_writer).
 //!
-//! Both writers grow a one-dimensional, unlimited, Extensible-Array-indexed
+//! Both owners grow a one-dimensional, unlimited, Extensible-Array-indexed
 //! dataset *in place*: an appended chunk is written at end-of-file, its record is
 //! stored into an element slot of the chunk index, the index grows by appending
 //! new blocks only when a block boundary is crossed (never relocating existing
@@ -87,7 +88,7 @@ impl ElemRecord {
 /// bounded backend adds a store with no mirror at all, which is why every engine
 /// *read* goes through [`Source`] (bounded, random-access) rather than a
 /// whole-file `&[u8]`. Genericizing the engine over this trait lets a long-lived
-/// the in-place edit engine drive an O(1) in-place append against its *own* single mirror and
+/// edit engine drive an O(1) in-place append against its *own* single mirror and
 /// exclusive lock rather than constructing a second `InPlaceFile` (which would
 /// take a second exclusive lock and keep a divergent mirror). Each owner keeps its
 /// own crash-safety discipline for the primitives — `InPlaceFile` mirrors before

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -792,12 +792,19 @@ impl WriteEngine {
         FileSpaceInfo::parse(&msg.data, os, ls).ok()
     }
 
-    /// Stage a new dataset, added on the next [`commit`](Self::commit). The
-    /// argument is the full path of the dataset; everything before the last
-    /// component names the parent group, which must exist (or be created in this
-    /// session). Returns the [`DatasetBuilder`] — the same builder used by
-    /// [`FileBuilder`](crate::FileBuilder) — to configure data, shape, and
-    /// attributes.
+    /// Stage a new dataset, added on the next [`commit`](Self::commit).
+    ///
+    /// `path` is the dataset's full path; everything before the last component
+    /// names the parent group, which must exist (or be created in this session).
+    /// `builder` is the same [`DatasetBuilder`] [`FileBuilder`](crate::FileBuilder)
+    /// uses, configured by the caller; its name is taken from `path`, so the two
+    /// cannot disagree.
+    ///
+    /// The builder is passed in finished rather than handed out as a `&mut` into
+    /// this engine. That is deliberate: a borrow into the engine forces the
+    /// caller to hold it — and, above this layer, its lock — for as long as the
+    /// builder is being configured, which is what let a user closure deadlock
+    /// against the same file it was reading (issue #200).
     ///
     /// The dataset may be contiguous or chunked, and chunked datasets may be
     /// filtered (`with_deflate`, `with_shuffle`, `with_fletcher32`,
@@ -808,19 +815,19 @@ impl WriteEngine {
     /// variable-length-string payload (`with_vlen_strings`), or path-resolved
     /// object-reference elements (`with_path_references`; chunking any of
     /// these is not supported, and dense attributes remain unsupported).
-    pub fn create_dataset(&mut self, path: &str) -> &mut DatasetBuilder {
+    pub(crate) fn stage_created_dataset(&mut self, path: &str, mut builder: DatasetBuilder) {
         let mut comps = split_path(path);
-        let leaf = comps.pop().unwrap_or_default();
-        self.pending_datasets
-            .push((comps, DatasetBuilder::new(&leaf)));
-        &mut self.pending_datasets.last_mut().unwrap().1
+        builder.name = comps.pop().unwrap_or_default();
+        self.pending_datasets.push((comps, builder));
     }
 
     /// Stage an in-place overwrite of an **existing** dataset's values (the HDF5
     /// `H5Dwrite` whole-dataset write), applied on the next
-    /// [`commit`](Self::commit). `path` is the full path of a dataset that must
-    /// already exist; the returned [`DatasetBuilder`] — the same builder used by
-    /// [`create_dataset`](Self::create_dataset) — supplies the replacement data.
+    /// [`commit`](Self::commit).
+    ///
+    /// `path` is the full path of a dataset that must already exist; `builder`
+    /// supplies the replacement data and is named from `path`, as in
+    /// [`stage_created_dataset`](Self::stage_created_dataset).
     ///
     /// This is a *value* overwrite, not a reshape or retype: the new data's
     /// datatype and shape must match the on-disk dataset's exactly (byte-for-byte
@@ -848,25 +855,24 @@ impl WriteEngine {
     /// patched — exactly like an addition relocates the path up to the root. A
     /// relocating overwrite moves the object header, so it is refused unless the
     /// dataset has a single hard link.
-    pub fn write_dataset(&mut self, path: &str) -> &mut DatasetBuilder {
+    pub(crate) fn stage_dataset_write(&mut self, path: &str, mut builder: DatasetBuilder) {
         let comps = split_path(path);
-        let leaf = comps.last().cloned().unwrap_or_default();
-        self.pending_writes
-            .push((comps, DatasetBuilder::new(&leaf)));
-        &mut self.pending_writes.last_mut().unwrap().1
+        builder.name = comps.last().cloned().unwrap_or_default();
+        self.pending_writes.push((comps, builder));
     }
 
     /// Stage an append of new elements to an **existing** chunked, unlimited
-    /// dataset, applied on the next [`commit`](Self::commit). `path` names a
-    /// dataset that must already exist; the returned [`AppendBuilder`] supplies
-    /// the elements to add via its typed / generic / raw `append_*` methods.
+    /// dataset, applied on the next [`commit`](Self::commit).
     ///
-    /// Unlike [`write_dataset`](Self::write_dataset) (a value overwrite that
-    /// forbids any shape change) this **grows** the dataset along its first
-    /// (axis-0) dimension. It works on **filtered** datasets: the appended chunks
-    /// are compressed through the dataset's own on-disk filter pipeline
-    /// (deflate / shuffle / fletcher32 / scale-offset, and ZFP with the `zfp`
-    /// feature), and the pipeline, datatype, fill value, and attributes are
+    /// `path` names a dataset that must already exist; `builder` supplies the
+    /// elements to add via its typed / generic / raw `append_*` methods.
+    ///
+    /// Unlike [`stage_dataset_write`](Self::stage_dataset_write) (a value
+    /// overwrite that forbids any shape change) this **grows** the dataset along
+    /// its first (axis-0) dimension. It works on **filtered** datasets: the
+    /// appended chunks are compressed through the dataset's own on-disk filter
+    /// pipeline (deflate / shuffle / fletcher32 / scale-offset, and ZFP with the
+    /// `zfp` feature), and the pipeline, datatype, fill value, and attributes are
     /// preserved verbatim. Appends of any length are supported — when the
     /// dataset's current length is not a whole multiple of the chunk length, the
     /// single trailing partial chunk is read, extended, and re-encoded; every
@@ -890,10 +896,8 @@ impl WriteEngine {
     /// [`Error::AppendUnsupported`]. Use [`Dataset::is_chunked`](crate::Dataset::is_chunked),
     /// [`maxshape`](crate::Dataset::maxshape), and [`filters`](crate::Dataset::filters)
     /// to check eligibility up front.
-    pub fn append_dataset(&mut self, path: &str) -> &mut AppendBuilder {
-        self.pending_appends
-            .push((split_path(path), AppendBuilder::new()));
-        &mut self.pending_appends.last_mut().unwrap().1
+    pub(crate) fn stage_dataset_append(&mut self, path: &str, builder: AppendBuilder) {
+        self.pending_appends.push((split_path(path), builder));
     }
 
     /// Immediately append rows to an **existing** chunked, unlimited,
@@ -6924,7 +6928,9 @@ mod tests {
         // A clean edit-and-commit cycle heals it.
         {
             let mut s = WriteEngine::open(&path).unwrap();
-            s.create_dataset("e").with_i32_data(&[4, 5]);
+            let mut b = DatasetBuilder::new("e");
+            b.with_i32_data(&[4, 5]);
+            s.stage_created_dataset("e", b);
             s.commit().unwrap();
         }
 
@@ -6967,9 +6973,9 @@ mod tests {
 
         {
             let mut s = WriteEngine::open(&path).unwrap();
-            s.create_dataset("labels")
-                .with_vlen_string_elements(datatype, &elements)
-                .unwrap();
+            let mut b = DatasetBuilder::new("labels");
+            b.with_vlen_string_elements(datatype, &elements).unwrap();
+            s.stage_created_dataset("labels", b);
             s.commit().unwrap();
         }
 

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -6705,6 +6705,231 @@ mod tests {
         }
     }
 
+    /// Build a one-element-per-chunk unlimited `d` holding `0..n`, the shape the
+    /// crash-consistency harnesses below grow.
+    fn build_unit_chunked(path: &std::path::Path, n: i32) {
+        use crate::writer::FileBuilder;
+        let data: Vec<i32> = (0..n).collect();
+        let mut b = FileBuilder::new();
+        b.create_dataset("d")
+            .with_i32_data(&data)
+            .with_shape(&[n as u64])
+            .with_maxshape(&[u64::MAX])
+            .with_chunks(&[1]);
+        b.write(path).unwrap();
+    }
+
+    /// Stop an append after `max_phase` durability phases and hand back the
+    /// resulting file. Dropping the engine inside is the simulated crash: no
+    /// further phases run and no close barrier is written.
+    fn append_stopped_at(
+        base: &std::path::Path,
+        out: &std::path::Path,
+        values: std::ops::Range<i32>,
+        max_phase: u8,
+    ) {
+        std::fs::copy(base, out).unwrap();
+        let mut s = WriteEngine::open(out).unwrap();
+        s.append_inplace_i32_phased("d", &values.collect::<Vec<_>>(), max_phase)
+            .unwrap();
+    }
+
+    /// Growing an Extensible-Array index across its inline -> direct-block ->
+    /// super-block boundaries touches far more index structure than the
+    /// partial-tail case above. Stopping at any phase boundary must still read
+    /// back as a consistent prefix.
+    ///
+    /// Restores coverage lost with the deprecated `SwmrWriter` (issue #202); the
+    /// owned path drives the same `apply_ea_append` engine.
+    #[test]
+    fn append_inplace_crash_consistency_across_ea_boundaries() {
+        use crate::reader::File as PureFile;
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        let base = dir.path().join("base.h5");
+        let (n, target) = (50i32, 250i32);
+        build_unit_chunked(&base, n);
+
+        for max_phase in 1u8..=4 {
+            let p = dir.path().join(format!("crash_ea_{max_phase}.h5"));
+            append_stopped_at(&base, &p, n..target, max_phase);
+            let expected_len = if max_phase == 4 { target } else { n };
+            let f = PureFile::from_bytes(std::fs::read(&p).unwrap()).unwrap();
+            assert_eq!(
+                f.dataset("d").unwrap().read_i32().unwrap(),
+                (0..expected_len).collect::<Vec<_>>(),
+                "inconsistent view after crash at phase {max_phase}"
+            );
+        }
+    }
+
+    /// The same guarantee for an append that crosses the paged-data-block
+    /// boundary (~131,060 chunks), where phase 1 allocates a paged super block,
+    /// paged data blocks, the per-page checksums, and the page-init bitmap. This
+    /// is the most intricate in-place growth the engine performs, and truncating
+    /// it partway is exactly what a power loss does.
+    ///
+    /// Restores coverage lost with the deprecated `SwmrWriter` (issue #202).
+    #[test]
+    fn append_inplace_crash_consistency_paged_prefix() {
+        use crate::reader::File as PureFile;
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        let base = dir.path().join("base.h5");
+        let (start, target) = (131_000i32, 132_000i32);
+        build_unit_chunked(&base, start);
+
+        for max_phase in 1u8..=4 {
+            let p = dir.path().join(format!("crash_paged_{max_phase}.h5"));
+            append_stopped_at(&base, &p, start..target, max_phase);
+            let expected_len = if max_phase == 4 { target } else { start };
+            let f = PureFile::from_bytes(std::fs::read(&p).unwrap()).unwrap();
+            assert_eq!(
+                f.dataset("d").unwrap().read_i32().unwrap(),
+                (0..expected_len).collect::<Vec<_>>(),
+                "inconsistent paged view after crash at phase {max_phase}"
+            );
+        }
+    }
+
+    /// The consistent-prefix guarantee must hold for the *reference C library*,
+    /// not only this crate's reader — and this crate's reader is the more lenient
+    /// of the two, so it cannot stand in for it.
+    ///
+    /// The pure reader bounds chunk reads by `min(EA count, dimension)`, which
+    /// makes it tolerate a phase-3 state where the element count has advanced
+    /// past the dimension. The C library instead walks strictly by the dataspace
+    /// dimension and re-validates block checksums, so a stale end-of-file, a
+    /// half-grown index, or a mis-checksummed block could satisfy the reader here
+    /// and still break C or h5py. That gap is the whole point of the test:
+    /// crash-safety for the append path is an interop guarantee.
+    ///
+    /// Both starting layouts are covered — a partial trailing chunk and the
+    /// EA-boundary growth above — since they exercise different index writes.
+    ///
+    /// Restores coverage lost with the deprecated `SwmrWriter` and `AppendWriter`
+    /// (issue #202).
+    #[test]
+    // Reads back with the reference HDF5 C library (`hdf5-metno`), a
+    // 64-bit-only dev-dependency; skip on 32-bit so the lib tests run there.
+    #[cfg(not(target_pointer_width = "32"))]
+    fn append_inplace_crash_consistency_c_library_reads_prefix() {
+        use tempfile::tempdir;
+
+        // (initial length, chunk length, appended length): a partial trailing
+        // chunk, a chunk-aligned start, and the EA-boundary crossing.
+        for (n, chunk, add) in [(6i32, 4u64, 5i32), (8, 2, 6), (50, 1, 200)] {
+            let dir = tempdir().unwrap();
+            let base = dir.path().join("base.h5");
+            {
+                use crate::writer::FileBuilder;
+                let mut b = FileBuilder::new();
+                b.create_dataset("d")
+                    .with_i32_data(&(0..n).collect::<Vec<i32>>())
+                    .with_shape(&[n as u64])
+                    .with_maxshape(&[u64::MAX])
+                    .with_chunks(&[chunk]);
+                b.write(&base).unwrap();
+            }
+
+            for max_phase in 1u8..=4 {
+                let p = dir
+                    .path()
+                    .join(format!("crash_c_{n}_{chunk}_{max_phase}.h5"));
+                append_stopped_at(&base, &p, n..n + add, max_phase);
+                let expected_len = if max_phase == 4 { n + add } else { n };
+                let f = hdf5::File::open(&p).unwrap();
+                assert_eq!(
+                    f.dataset("d").unwrap().read_raw::<i32>().unwrap(),
+                    (0..expected_len).collect::<Vec<_>>(),
+                    "C library saw an inconsistent view after crash at phase {max_phase} \
+                     (n={n}, chunk={chunk})"
+                );
+                f.close().unwrap();
+            }
+        }
+    }
+
+    /// Crash recovery across the phase-3/phase-4 gap.
+    ///
+    /// A writer that crashes after publishing the Extensible-Array element count
+    /// (phase 3) but before publishing the dataspace dimension (phase 4) leaves
+    /// the on-disk count ahead of the committed dimension. A fresh writer must
+    /// roll forward from the *committed dimension*, overwriting the uncommitted
+    /// slots, rather than appending past them and leaving a gap.
+    ///
+    /// The crashed and recovering appends deliberately write different values at
+    /// the overlapping positions, so a regression that seeds the chunk count from
+    /// the stale EA header surfaces the crashed writer's values rather than
+    /// merely producing plausible-looking data.
+    ///
+    /// Restores coverage lost with the deprecated `SwmrWriter` (issue #202); the
+    /// surviving `recover_and_reappend_after_clean_phase4` covers only the clean
+    /// case.
+    #[test]
+    // Reads back with the reference HDF5 C library (`hdf5-metno`), a
+    // 64-bit-only dev-dependency; skip on 32-bit so the lib tests run there.
+    #[cfg(not(target_pointer_width = "32"))]
+    fn append_inplace_recover_and_reappend_after_phase3_crash() {
+        use crate::reader::File as PureFile;
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("phase3_recover.h5");
+        let n = 50i32;
+        build_unit_chunked(&path, n);
+
+        // Writer 1 crashes after phase 3: the element count advances but the
+        // dimension stays at `n`. Its values are far from the correct
+        // continuation, so a leak is unmistakable.
+        {
+            let mut s = WriteEngine::open(&path).unwrap();
+            s.append_inplace_i32_phased("d", &(1000..1200).collect::<Vec<_>>(), 3)
+                .unwrap();
+        }
+        let committed: Vec<i32> = (0..n).collect();
+        let pf = PureFile::from_bytes(std::fs::read(&path).unwrap()).unwrap();
+        assert_eq!(
+            pf.dataset("d").unwrap().read_i32().unwrap(),
+            committed,
+            "phase-3 crash exposed uncommitted data to the pure reader"
+        );
+        {
+            let f = hdf5::File::open(&path).unwrap();
+            assert_eq!(
+                f.dataset("d").unwrap().read_raw::<i32>().unwrap(),
+                committed,
+                "phase-3 crash exposed uncommitted data to the C library"
+            );
+            f.close().unwrap();
+        }
+
+        // Writer 2 recovers: roll forward from the committed dimension,
+        // overwriting the uncommitted slots with the real continuation.
+        {
+            let mut s = WriteEngine::open(&path).unwrap();
+            s.append_inplace_i32_phased("d", &(n..150).collect::<Vec<_>>(), 4)
+                .unwrap();
+        }
+
+        let expected: Vec<i32> = (0..150).collect();
+        let pf = PureFile::from_bytes(std::fs::read(&path).unwrap()).unwrap();
+        assert_eq!(
+            pf.dataset("d").unwrap().read_i32().unwrap(),
+            expected,
+            "recovery did not roll forward correctly (pure reader)"
+        );
+        let f = hdf5::File::open(&path).unwrap();
+        assert_eq!(
+            f.dataset("d").unwrap().read_raw::<i32>().unwrap(),
+            expected,
+            "recovery did not roll forward correctly (C library)"
+        );
+        f.close().unwrap();
+    }
+
     #[test]
     fn raw_appendable_recurses_into_aggregates() {
         use crate::datatype::{CompoundMember, DatatypeByteOrder};

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -194,10 +194,10 @@ use crate::object_header::ObjectHeader;
 use crate::signature;
 use crate::superblock::Superblock;
 use crate::type_builders::{
-    AttrValue, DatasetBuilder, ObjectRefTarget, VlStringStaging, build_attr_message,
-    build_global_heap_collections, make_f32_type, make_f64_type, make_i8_type, make_i16_type,
-    make_i32_type, make_i64_type, make_u8_type, make_u16_type, make_u32_type, make_u64_type,
-    patch_vl_refs, patch_vl_refs_masked,
+    AttrValue, DatasetBuilder, ObjectRefPatch, ObjectRefTarget, VlStringStaging,
+    build_attr_message, build_global_heap_collections, make_f32_type, make_f64_type, make_i8_type,
+    make_i16_type, make_i32_type, make_i64_type, make_u8_type, make_u16_type, make_u32_type,
+    make_u64_type, patch_vl_refs, patch_vl_refs_masked, write_reference_address,
 };
 
 /// An undefined on-disk address (all bits set), HDF5's "no address" sentinel.
@@ -2157,11 +2157,10 @@ impl WriteEngine {
                 // that every earlier-placed object in this commit is in
                 // `path_addr` (chunked datasets never carry these —
                 // `flatten_dataset` refuses that combination).
-                if let Some(targets) = fd.reference_targets.take() {
-                    let mut patched = Vec::with_capacity(targets.len() * 8);
-                    for target in &targets {
+                if let Some(patches) = fd.reference_targets.take() {
+                    for patch in &patches {
                         let addr = Self::resolve_reference_target(
-                            target,
+                            &patch.target,
                             &path_addr,
                             &nodes,
                             &add_targets,
@@ -2170,9 +2169,8 @@ impl WriteEngine {
                             &self.data,
                             &self.superblock,
                         )?;
-                        patched.extend_from_slice(&addr.to_le_bytes());
+                        write_reference_address(&mut fd.raw, patch.byte_offset, addr);
                     }
-                    fd.raw = patched;
                 }
                 let oh = if fd.chunk_options.is_chunked() || fd.maxshape.is_some() {
                     self.build_chunked_dataset(&fd)?
@@ -2184,7 +2182,7 @@ impl WriteEngine {
                     if let Some(staging) = fd.vl_string_staging.take() {
                         if !staging.collections.is_empty() {
                             let addrs = self.place_vl_collections(&staging.collections)?;
-                            patch_vl_refs_masked(&mut fd.raw, &staging.patch_mask, &addrs);
+                            patch_vl_refs_masked(&mut fd.raw, &staging.patch_offsets, &addrs);
                         }
                     }
                     // A zero-element dataset has no data block to allocate; its
@@ -4353,10 +4351,10 @@ impl WriteEngine {
                 let mut ordered: Vec<&FlatDataset> = datasets.iter().collect();
                 ordered.sort_by_key(|fd| fd.reference_targets.is_some());
                 for fd in ordered {
-                    if let Some(targets) = &fd.reference_targets {
-                        for target in targets {
+                    if let Some(patches) = &fd.reference_targets {
+                        for patch in patches {
                             Self::resolve_reference_target(
-                                target,
+                                &patch.target,
                                 &sim_addr,
                                 nodes,
                                 add_targets,
@@ -5077,7 +5075,7 @@ struct FlatDataset {
     /// Resolved (see [`WriteEngine::resolve_reference_target`]) and patched
     /// into `raw` in the apply loop, once every object this commit places has
     /// a known address. `None` for an ordinary dataset.
-    reference_targets: Option<Vec<ObjectRefTarget>>,
+    reference_targets: Option<Vec<ObjectRefPatch>>,
     /// A user-defined fill value, encoded in the dataset's datatype, or `None`
     /// for the library default. Validated against the datatype element size in
     /// [`flatten_dataset`].
@@ -6946,7 +6944,7 @@ mod tests {
         // without ever writing its global heap collection or patching its
         // placeholder references, so the dataset failed to read back. A null
         // element (no heap object at all, distinct from an empty string) must
-        // stay untouched by the patch — only `patch_mask`-flagged elements'
+        // stay untouched by the patch — only heap-backed elements'
         // placeholder addresses are resolved; exercising both keeps the mask
         // itself, not just the common all-`Bytes` case, under test.
         use crate::type_builders::VlStringElement;

--- a/src/file_writer.rs
+++ b/src/file_writer.rs
@@ -35,7 +35,7 @@ use crate::object_header_writer::ObjectHeaderWriter;
 use crate::superblock::Superblock;
 use crate::type_builders::{
     DatasetBuilder, FinishedGroup, GroupBuilder, VlStringStaging, build_attr_message,
-    build_global_heap_collections, patch_vl_refs, patch_vl_refs_masked,
+    build_global_heap_collections, patch_vl_refs, patch_vl_refs_masked, write_reference_address,
 };
 
 // `AttrValue` lives in `type_builders`; `types` and `mat` reference it through
@@ -866,7 +866,7 @@ impl FileWriter {
             /// Repack's verbatim chunk payload, when this dataset's chunks are
             /// copied compressed-as-is rather than encoded from `raw`.
             raw_chunks: Option<crate::type_builders::RawChunkPayload>,
-            reference_targets: Option<Vec<crate::type_builders::ObjectRefTarget>>,
+            reference_targets: Option<Vec<crate::type_builders::ObjectRefPatch>>,
             /// Staged global heap collections + patch mask for a VL-string
             /// dataset, whose element references in `raw` need their heap
             /// addresses patched once the post-data cursor is known.
@@ -1311,7 +1311,7 @@ impl FileWriter {
                     continue;
                 };
                 let addrs = place_collections(&staging.collections, &mut cursor);
-                patch_vl_refs_masked(&mut all_ds[i].raw, &staging.patch_mask, &addrs);
+                patch_vl_refs_masked(&mut all_ds[i].raw, &staging.patch_offsets, &addrs);
                 all_ds[i].vl_string_staging = Some(staging);
                 early_gcol.push(i);
             }
@@ -1548,18 +1548,17 @@ impl FileWriter {
             // destination address (an unknown path falls back to the undefined
             // address); a raw target is written verbatim (null / undefined).
             for d in all_ds.iter_mut() {
-                if let Some(ref targets) = d.reference_targets {
-                    let mut patched = Vec::with_capacity(targets.len() * 8);
-                    for target in targets {
-                        let addr = match target {
-                            crate::type_builders::ObjectRefTarget::Path(path) => {
-                                path_map.get(path).copied().unwrap_or(u64::MAX)
-                            }
-                            crate::type_builders::ObjectRefTarget::Raw(addr) => *addr,
-                        };
-                        patched.extend_from_slice(&addr.to_le_bytes());
-                    }
-                    d.raw = patched;
+                let Some(ref patches) = d.reference_targets else {
+                    continue;
+                };
+                for patch in patches {
+                    let addr = match &patch.target {
+                        crate::type_builders::ObjectRefTarget::Path(path) => {
+                            path_map.get(path).copied().unwrap_or(u64::MAX)
+                        }
+                        crate::type_builders::ObjectRefTarget::Raw(addr) => *addr,
+                    };
+                    write_reference_address(&mut d.raw, patch.byte_offset, addr);
                 }
             }
         }
@@ -1832,7 +1831,7 @@ impl FileWriter {
                         "a staged VL-string dataset is non-chunked, so its data is in memory"
                     )
                 };
-                patch_vl_refs_masked(bytes, &staging.patch_mask, gaddrs);
+                patch_vl_refs_masked(bytes, &staging.patch_offsets, gaddrs);
             }
 
             let ds_layouts: Vec<DsLayout> = layouts
@@ -2136,7 +2135,7 @@ impl FileWriter {
                         );
                     };
                     let addrs = place_collections(&staging.collections, &mut gcol_cursor);
-                    patch_vl_refs_masked(bytes, &staging.patch_mask, &addrs);
+                    patch_vl_refs_masked(bytes, &staging.patch_offsets, &addrs);
                 }
             }
             #[expect(

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -2523,7 +2523,7 @@ impl Dataset {
     pub fn write<T: H5Element>(&mut self, data: &[T]) -> Result<(), Error> {
         // Build off the lock — `H5Element` is user-implementable, so
         // `write_into` is potentially user code (see `write_staged`).
-        self.file.check_staged_writable()?;
+        self.check_staged_edit()?;
         let mut builder = DatasetBuilder::new("");
         T::write_into(&mut builder, data);
         self.with_session_mut(true, |session, path| {
@@ -2558,10 +2558,10 @@ impl Dataset {
     /// The closure configures a standalone builder, not the file, so it may read
     /// the same [`File`]; nothing it stages resolves until [`File::commit`].
     pub fn write_staged(&mut self, build: impl FnOnce(&mut DatasetBuilder)) -> Result<(), Error> {
-        // Report a read-only or sealed file before running the closure, then run
-        // it with no lock held; `stage_dataset_write` names the builder from the
-        // dataset's path (issue #200).
-        self.file.check_staged_writable()?;
+        // Report a read-only, sealed, or unaddressable dataset before running the
+        // closure, then run it with no lock held; `stage_dataset_write` names the
+        // builder from the dataset's path (issue #200).
+        self.check_staged_edit()?;
         let mut builder = DatasetBuilder::new("");
         build(&mut builder);
         self.with_session_mut(true, |session, path| {
@@ -2590,7 +2590,7 @@ impl Dataset {
     /// The closure configures a standalone builder, not the file, so it may read
     /// the same [`File`]; nothing it stages resolves until [`File::commit`].
     pub fn append_staged(&mut self, build: impl FnOnce(&mut AppendBuilder)) -> Result<(), Error> {
-        self.file.check_staged_writable()?;
+        self.check_staged_edit()?;
         let mut builder = AppendBuilder::new();
         build(&mut builder);
         self.with_session_mut(true, |session, path| {
@@ -2618,6 +2618,23 @@ impl Dataset {
             session.remove_dataset_attr(path, name);
             Ok(())
         })
+    }
+
+    /// Gate a staged edit on this dataset *without* taking the session lock:
+    /// the file must accept staged edits, and this handle must have a resolvable
+    /// path.
+    ///
+    /// The path check belongs here rather than only in
+    /// [`with_session_mut`](Self::with_session_mut) so that every reason to
+    /// refuse is reported *before* a user closure runs, not after. A handle
+    /// reached by object reference ([`dereference`](Self::dereference)) has no
+    /// path, and would otherwise have its closure run and its result discarded.
+    fn check_staged_edit(&self) -> Result<(), Error> {
+        self.file.check_staged_writable()?;
+        if self.path.is_none() {
+            return Err(Error::ReadOnly);
+        }
+        Ok(())
     }
 
     /// Run `f` with the writable session and this dataset's path, then refresh
@@ -3218,7 +3235,10 @@ impl Dataset {
             );
         }
 
-        let raw = self.read_raw()?;
+        // A zero-element dataset owns no element bytes, and the C library leaves
+        // such a dataset's storage unallocated — reading it would fail for a
+        // missing chunk address rather than yield an empty buffer.
+        let raw = if n == 0 { Vec::new() } else { self.read_raw()? };
         let n_usize = n.to_usize()?;
         let needed = n_usize
             .checked_mul(stride)

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, Mutex};
 use crate::bounded::BoundedEngine;
 use crate::edit::{AppendBuilder, SpaceAccounting, WriteEngine};
 use crate::element::H5Element;
-use crate::type_builders::DatasetBuilder;
+use crate::type_builders::{DatasetBuilder, VL_REF_SIZE};
 
 use crate::attribute::{extract_attributes_full, extract_attributes_full_from_source};
 use crate::chunk_cache::{ChunkCache, ChunkCacheConfig, ChunkCacheStats};
@@ -3070,6 +3070,84 @@ impl Dataset {
             )
         })?;
         Ok((objects, element_size))
+    }
+
+    /// Read a dataset whose datatype *contains* variable-length references
+    /// without being variable-length itself — a compound with a VL member, or an
+    /// array of them (issue #201).
+    ///
+    /// Returns everything a rewrite needs: the element bytes, where each embedded
+    /// reference sits within them, and the heap payload each one names. That lets
+    /// the writer re-stage the payloads into a new file's global heap and rewrite
+    /// the references in place, which is what keeps a rewrite from carrying the
+    /// source file's heap addresses into the destination.
+    ///
+    /// The references are resolved one slot at a time, so `options`' limits apply
+    /// per slot rather than across the whole dataset.
+    pub(crate) fn read_embedded_vlen_bytes(
+        &self,
+        slots: &[vl_data::EmbeddedVlSlot],
+        options: VlenStringReadOptions,
+    ) -> Result<vl_data::EmbeddedVlData, Error> {
+        let stride = self.datatype()?.type_size() as usize;
+        let dataspace = self.dataspace()?;
+        let n = dataspace.num_elements();
+        if let Some(limit) = options.max_elements()
+            && n > limit as u64
+        {
+            return Err(
+                FormatError::VariableLengthElementLimitExceeded { limit, actual: n }.into(),
+            );
+        }
+
+        let raw = self.read_raw()?;
+        let n_usize = n.to_usize()?;
+        let needed = n_usize
+            .checked_mul(stride)
+            .ok_or(FormatError::OffsetOverflow {
+                offset: n,
+                length: stride as u64,
+            })?;
+        if raw.len() < needed {
+            return Err(FormatError::UnexpectedEof {
+                expected: needed,
+                available: raw.len(),
+            }
+            .into());
+        }
+
+        let mut offsets = Vec::with_capacity(n_usize * slots.len());
+        let mut objects = Vec::with_capacity(n_usize * slots.len());
+        for slot in slots {
+            // Gather this slot's reference from every element into a dense buffer,
+            // which is the shape the shared VL reader consumes. Each slot has its
+            // own base-type width, so they are resolved a slot at a time rather
+            // than in one pass.
+            let mut dense = Vec::with_capacity(n_usize * VL_REF_SIZE);
+            for e in 0..n_usize {
+                let at = e * stride + slot.byte_offset;
+                dense.extend_from_slice(&raw[at..at + VL_REF_SIZE]);
+                offsets.push(at);
+            }
+            let resolved = self.file.with_source(|source| {
+                vl_data::read_vl_byte_objects_from_source(
+                    source,
+                    &dense,
+                    n,
+                    self.file.offset_size(),
+                    self.file.length_size(),
+                    self.file.addr_offset,
+                    slot.element_size,
+                    options,
+                )
+            })?;
+            objects.extend(resolved);
+        }
+        Ok(vl_data::EmbeddedVlData {
+            raw,
+            offsets,
+            objects,
+        })
     }
 
     /// Read all attributes of this dataset.

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -510,6 +510,23 @@ impl FileInner {
         Ok(())
     }
 
+    /// Gate a staged edit *without* taking the session lock: the backend must
+    /// offer the staged surface, and the file must still be mutable.
+    ///
+    /// This is the same gate the locking helpers apply before locking, split out
+    /// so a public method taking a user closure can report a read-only or sealed
+    /// file up front, run the closure with no lock held, and take the lock only
+    /// to record the result (issue #200).
+    fn check_staged_writable(&self) -> Result<(), Error> {
+        match &self.backend {
+            Backend::Mirror(_) => self.check_mutable(true),
+            // A bounded file is writable but has no staged surface; everything
+            // else is read-only.
+            Backend::Bounded(_) => Err(Error::BoundedStagedUnsupported),
+            _ => Err(Error::ReadOnly),
+        }
+    }
+
     /// A `Source` view over the backend, for the streaming-capable paths.
     pub(crate) fn source(&self) -> SourceView<'_> {
         match &self.backend {
@@ -1921,12 +1938,12 @@ impl std::fmt::Debug for Object {
 /// Every method stages; nothing is written until [`File::commit`], and a staged
 /// object is not resolvable by name until then.
 ///
-/// The closure holding this runs while the file's writable session is locked, so
-/// it must not call back into the same [`File`] (including through a [`Group`] or
-/// [`Dataset`] handle) — that would deadlock. Everything a staged group needs is
-/// on this type.
+/// The closure holding this records into a buffer rather than into the file's
+/// writable session, so nothing is locked while it runs. The recorded operations
+/// are applied together when it returns, which is also why a staged object is not
+/// resolvable until [`File::commit`].
 pub struct StagedGroup<'a> {
-    session: &'a mut WriteEngine,
+    ops: &'a mut Vec<StagedOp>,
     path: String,
 }
 
@@ -1934,7 +1951,11 @@ impl StagedGroup<'_> {
     /// Stage an attribute on this group, applied with its creation on
     /// [`File::commit`].
     pub fn set_attr(&mut self, name: &str, value: AttrValue) -> &mut Self {
-        self.session.set_group_attr(&self.path, name, value);
+        self.ops.push(StagedOp::SetGroupAttr {
+            path: self.path.clone(),
+            name: name.to_string(),
+            value,
+        });
         self
     }
 
@@ -1953,9 +1974,9 @@ impl StagedGroup<'_> {
         build: impl FnOnce(&mut StagedGroup<'_>),
     ) -> &mut Self {
         let child = format!("{}/{}", self.path, name);
-        self.session.create_group(&child);
+        self.ops.push(StagedOp::CreateGroup(child.clone()));
         let mut staged = StagedGroup {
-            session: self.session,
+            ops: &mut *self.ops,
             path: child,
         };
         build(&mut staged);
@@ -1968,9 +1989,51 @@ impl StagedGroup<'_> {
         name: &str,
         build: impl FnOnce(&mut DatasetBuilder),
     ) -> &mut Self {
-        let child = format!("{}/{}", self.path, name);
-        build(self.session.create_dataset(&child));
+        let mut builder = DatasetBuilder::new(name);
+        build(&mut builder);
+        self.ops.push(StagedOp::CreateDataset {
+            path: format!("{}/{}", self.path, name),
+            builder: Box::new(builder),
+        });
         self
+    }
+}
+
+/// One edit recorded by a [`StagedGroup`] closure, replayed onto the writable
+/// session after the closure returns.
+///
+/// The indirection is what keeps user code off the session lock: the closure
+/// touches only this buffer, so calling back into the same [`File`] from inside
+/// it is at worst wrongly ordered rather than a deadlock (issue #200).
+enum StagedOp {
+    CreateGroup(String),
+    SetGroupAttr {
+        path: String,
+        name: String,
+        value: AttrValue,
+    },
+    CreateDataset {
+        path: String,
+        /// Boxed because a `DatasetBuilder` dwarfs the other variants, and a
+        /// closure staging many groups would otherwise pay its size per entry.
+        builder: Box<DatasetBuilder>,
+    },
+}
+
+impl StagedOp {
+    /// Record this edit on the session. Applied in the order the closure made
+    /// the calls, so a group is always staged before its own attributes and
+    /// children.
+    fn apply(self, session: &mut WriteEngine) {
+        match self {
+            StagedOp::CreateGroup(path) => session.create_group(&path),
+            StagedOp::SetGroupAttr { path, name, value } => {
+                session.set_group_attr(&path, &name, value);
+            }
+            StagedOp::CreateDataset { path, builder } => {
+                session.stage_created_dataset(&path, *builder);
+            }
+        }
     }
 }
 
@@ -2126,8 +2189,9 @@ impl Group {
     /// staged; this can, and the creation and its attributes land in one commit.
     /// For a plain empty group use [`create_group`](Self::create_group).
     ///
-    /// The closure runs while this file's writable session is locked, so it must
-    /// not call back into the same [`File`] (see [`StagedGroup`]).
+    /// The closure records into a buffer rather than into the file itself, and
+    /// nothing it stages resolves until [`File::commit`], so reading the same
+    /// [`File`] from inside it sees the file as it was before this call.
     ///
     /// Requires a read-write file ([`File::open_rw`]), else
     /// [`Error::ReadOnly`](crate::Error::ReadOnly).
@@ -2149,19 +2213,21 @@ impl Group {
         name: &str,
         build: impl FnOnce(&mut StagedGroup<'_>),
     ) -> Result<(), Error> {
-        self.with_child_session(name, |session, child| {
-            session.create_group(child);
-            let mut staged = StagedGroup {
-                session,
-                path: child.to_string(),
-            };
-            build(&mut staged);
-            Ok(())
-        })
+        let child = self.child_edit_path(name)?;
+        let mut ops = vec![StagedOp::CreateGroup(child.clone())];
+        build(&mut StagedGroup {
+            ops: &mut ops,
+            path: child,
+        });
+        self.apply_staged(ops)
     }
 
     /// Create a dataset `name` within this group, configuring it through `build`
     /// (shape, data, chunks, filters, …), staged until [`File::commit`].
+    ///
+    /// As with [`create_group_with`](Self::create_group_with), the closure
+    /// configures a builder rather than the file, so it may read the same
+    /// [`File`] — it will see the file as it was before this call.
     ///
     /// Requires a read-write file ([`File::open_rw`]), else
     /// [`Error::ReadOnly`](crate::Error::ReadOnly).
@@ -2170,10 +2236,13 @@ impl Group {
         name: &str,
         build: impl FnOnce(&mut DatasetBuilder),
     ) -> Result<(), Error> {
-        self.with_child_session(name, |session, child| {
-            build(session.create_dataset(child));
-            Ok(())
-        })
+        let child = self.child_edit_path(name)?;
+        let mut builder = DatasetBuilder::new(name);
+        build(&mut builder);
+        self.apply_staged(vec![StagedOp::CreateDataset {
+            path: child,
+            builder: Box::new(builder),
+        }])
     }
 
     /// Delete the object named `name` from this group, staged until
@@ -2228,6 +2297,38 @@ impl Group {
         let child = self.child_path(name).ok_or(Error::ReadOnly)?;
         let mut session = m.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         f(&mut session, &child)
+    }
+
+    /// Validate that this group can stage an edit to child `name` and return the
+    /// child's root-relative path, *without* taking the session lock.
+    ///
+    /// Paired with [`apply_staged`](Self::apply_staged): the checks run first so
+    /// a read-only or sealed file is reported before any user closure runs, the
+    /// closure then runs unlocked, and the lock is taken only to record what it
+    /// built (issue #200).
+    fn child_edit_path(&self, name: &str) -> Result<String, Error> {
+        self.file.check_staged_writable()?;
+        self.child_path(name).ok_or(Error::ReadOnly)
+    }
+
+    /// Record already-built edits on the writable session, holding the lock only
+    /// for the duration of the replay.
+    ///
+    /// The file is re-checked here because the closure that produced `ops` ran
+    /// unlocked and could have closed the file in the meantime; staging into a
+    /// sealed file would otherwise be silently accepted and then dropped.
+    fn apply_staged(&self, ops: Vec<StagedOp>) -> Result<(), Error> {
+        self.file.check_staged_writable()?;
+        let Backend::Mirror(m) = &self.file.backend else {
+            // `check_staged_writable` accepts only a mirror backend, and a
+            // file's backend is fixed for its lifetime.
+            return Err(Error::ReadOnly);
+        };
+        let mut session = m.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        for op in ops {
+            op.apply(&mut session);
+        }
+        Ok(())
     }
 
     /// Run `f` with the writable session and this group's *own* root-relative
@@ -2420,9 +2521,13 @@ impl Dataset {
     /// [`Error::ReadOnly`](crate::Error::ReadOnly). Unlike [`append`](Self::append)
     /// (immediate), this is a staged edit applied on [`File::commit`].
     pub fn write<T: H5Element>(&mut self, data: &[T]) -> Result<(), Error> {
+        // Build off the lock — `H5Element` is user-implementable, so
+        // `write_into` is potentially user code (see `write_staged`).
+        self.file.check_staged_writable()?;
+        let mut builder = DatasetBuilder::new("");
+        T::write_into(&mut builder, data);
         self.with_session_mut(true, |session, path| {
-            let builder = session.write_dataset(path);
-            T::write_into(builder, data);
+            session.stage_dataset_write(path, builder);
             Ok(())
         })
     }
@@ -2450,9 +2555,17 @@ impl Dataset {
     /// # Ok(())
     /// # }
     /// ```
+    /// The closure configures a standalone builder, not the file, so it may read
+    /// the same [`File`]; nothing it stages resolves until [`File::commit`].
     pub fn write_staged(&mut self, build: impl FnOnce(&mut DatasetBuilder)) -> Result<(), Error> {
+        // Report a read-only or sealed file before running the closure, then run
+        // it with no lock held; `stage_dataset_write` names the builder from the
+        // dataset's path (issue #200).
+        self.file.check_staged_writable()?;
+        let mut builder = DatasetBuilder::new("");
+        build(&mut builder);
         self.with_session_mut(true, |session, path| {
-            build(session.write_dataset(path));
+            session.stage_dataset_write(path, builder);
             Ok(())
         })
     }
@@ -2474,9 +2587,14 @@ impl Dataset {
     ///
     /// The file must have been opened with [`File::open_rw`], else
     /// [`Error::ReadOnly`](crate::Error::ReadOnly).
+    /// The closure configures a standalone builder, not the file, so it may read
+    /// the same [`File`]; nothing it stages resolves until [`File::commit`].
     pub fn append_staged(&mut self, build: impl FnOnce(&mut AppendBuilder)) -> Result<(), Error> {
+        self.file.check_staged_writable()?;
+        let mut builder = AppendBuilder::new();
+        build(&mut builder);
         self.with_session_mut(true, |session, path| {
-            build(session.append_dataset(path));
+            session.stage_dataset_append(path, builder);
             Ok(())
         })
     }

--- a/src/repack.rs
+++ b/src/repack.rs
@@ -33,7 +33,12 @@
 //!   null-vs-empty distinction, embedded NULs, and non-UTF-8 payloads, and the
 //!   source's chunk geometry, filters, and resizability are carried onto the
 //!   rebuilt dataset.
-//! - Contiguous/compact **object-reference** datasets: each stored address is
+//! - Datatypes that *contain* a variable-length member without being one — a
+//!   compound with a VL member, an array of such compounds, and nesting of
+//!   either. The embedded heap references are re-staged exactly as a top-level
+//!   one is, while every other byte of the element is carried through untouched.
+//! - Contiguous/compact **object-reference** datasets, and contiguous/compact
+//!   datatypes containing an object-reference member: each stored address is
 //!   rewritten to its target object's new location in the compacted file (null
 //!   and undefined references are carried verbatim).
 //! - Group hierarchy of arbitrary depth.
@@ -52,8 +57,9 @@
 //! refused.
 //!
 //! Refused (named, never dropped silently): chunked, filtered, or resizable
-//! object-reference datasets (their element addresses are resolved as elements
-//! are re-staged, which a compressed chunk would need rewritten in place);
+//! datasets whose datatype is or contains an object reference (their element
+//! addresses are resolved as elements are re-staged, which a compressed chunk
+//! would need rewritten in place);
 //! region references and
 //! non-8-byte object references; an object reference to a dropped object or to a
 //! target outside the hard-link hierarchy (a dangling, named-datatype, or region
@@ -94,9 +100,13 @@ use crate::reader::{Dataset, File, Group};
 use crate::scaleoffset::{self, ScaleOffset};
 use crate::source::Source;
 use crate::type_builders::{
-    AttrValue, DatasetBuilder, FinishedGroup, GroupBuilder, ObjectRefTarget, VlStringElement,
+    AttrValue, DatasetBuilder, FinishedGroup, GroupBuilder, ObjectRefPatch, ObjectRefTarget,
+    VlStringElement,
 };
-use crate::vl_data::{VlByteObject, VlenStringReadOptions, is_vlen_string_datatype};
+use crate::vl_data::{
+    EmbeddedVlSlot, VlByteObject, VlenStringReadOptions, embedded_vlen_slots,
+    is_vlen_string_datatype,
+};
 use crate::writer::FileBuilder;
 
 /// Options controlling a [`repack`].
@@ -308,6 +318,25 @@ fn emit_dataset(
     let dims = dataspace.dimensions.clone();
     let n_elements: u64 = dims.iter().product();
 
+    // Every variable-length reference the datatype reaches, whether it *is*
+    // variable-length or merely contains one through a compound member or array
+    // entry. Both kinds are re-staged rather than copied, so both disqualify the
+    // verbatim and fill-value paths below.
+    let vlen_slots = embedded_vlen_slots(&datatype).ok_or_else(|| {
+        Error::RepackUnsupported(format!(
+            "dataset {path}: datatype declares variable-length members its own element \
+             size cannot hold"
+        ))
+    })?;
+    // Likewise every object-header address it reaches. Both kinds of address are
+    // rewritten rather than copied, so both disqualify the paths that move
+    // element bytes unchanged.
+    let reference_slots = embedded_reference_slots(&datatype).ok_or_else(|| {
+        Error::RepackUnsupported(format!(
+            "dataset {path}: datatype declares object references its own element size cannot hold"
+        ))
+    })?;
+
     // A user-defined fill value is fixed element bytes in the datatype, so it
     // reproduces exactly on the fixed-size paths below (dense-chunked verbatim,
     // and contiguous/compact/sparse re-encode). The variable-length and
@@ -316,11 +345,7 @@ fn emit_dataset(
     // or address bytes; refuse rather than copy it, matching the crate's
     // never-degrade-on-rewrite contract.
     let fill = ds.defined_fill_bytes()?;
-    if fill.is_some()
-        && (is_vlen_string_datatype(&datatype)
-            || is_nonstring_vlen(&datatype)
-            || is_object_reference(&datatype))
-    {
+    if fill.is_some() && !(vlen_slots.is_empty() && reference_slots.is_empty()) {
         return Err(Error::RepackUnsupported(format!(
             "dataset {path}: a fill value on a variable-length or object-reference \
              dataset cannot be repacked faithfully"
@@ -364,6 +389,55 @@ fn emit_dataset(
     // chunked one is refused (not copied with stale addresses).
     if is_object_reference(&datatype) {
         emit_object_reference_dataset(db, ds, path, &dims, &layout, file, drop, addr_map)?;
+        let attrs = ds.attrs()?;
+        check_attr_completeness(&attrs, &ds.attr_names()?, &format!("dataset {path}"))?;
+        for (name, value) in sorted(attrs) {
+            db.set_attr(&name, value);
+        }
+        return Ok(());
+    }
+
+    // A datatype that merely *contains* variable-length members — a compound with
+    // a VL member, or an array of them — embeds a global-heap reference inside
+    // each element. Those references go stale on rewrite exactly as a top-level
+    // one does, so this dataset is re-staged through a fresh heap rather than
+    // copied. Routed before the verbatim chunk-copy path so a chunked one is
+    // rebuilt, not copied with source addresses (issue #201).
+    if !vlen_slots.is_empty() {
+        emit_embedded_vlen_dataset(
+            db,
+            ds,
+            path,
+            &datatype,
+            &dims,
+            &layout,
+            &pipeline,
+            &vlen_slots,
+        )?;
+        let attrs = ds.attrs()?;
+        check_attr_completeness(&attrs, &ds.attr_names()?, &format!("dataset {path}"))?;
+        for (name, value) in sorted(attrs) {
+            db.set_attr(&name, value);
+        }
+        return Ok(());
+    }
+
+    // The same argument for an object-header address embedded in a compound
+    // member or array entry: it names an object in the source file, and the
+    // destination puts that object elsewhere.
+    if !reference_slots.is_empty() {
+        emit_embedded_reference_dataset(
+            db,
+            ds,
+            path,
+            &datatype,
+            &dims,
+            &layout,
+            file,
+            drop,
+            addr_map,
+            &reference_slots,
+        )?;
         let attrs = ds.attrs()?;
         check_attr_completeness(&attrs, &ds.attr_names()?, &format!("dataset {path}"))?;
         for (name, value) in sorted(attrs) {
@@ -624,6 +698,63 @@ fn emit_vlen_sequence_dataset(
 
     db.with_vlen_sequence_elements(datatype.clone(), &elements)
         .map_err(Error::Format)?;
+    db.with_shape(dims);
+    carry_shape_and_pipeline(
+        db,
+        dims,
+        ds.dataspace()?.max_dimensions.as_deref(),
+        layout,
+        pipeline,
+    );
+    Ok(())
+}
+
+/// Re-emit a dataset whose datatype *contains* variable-length references
+/// without being one — a compound with a variable-length member, or an array of
+/// such compounds (issue #201).
+///
+/// The element bytes are read as they stand and each embedded reference is
+/// resolved against the source's global heap; the payloads are then re-staged
+/// into the destination's own heap and the references rewritten in place. Copying
+/// the element bytes verbatim instead would leave every reference naming a
+/// collection in the *source* file's address space, which the destination never
+/// allocates — a file that reads back plausibly here and not at all in the
+/// reference C library.
+///
+/// Everything outside the references is carried byte-for-byte, so the fixed-size
+/// members keep their exact stored bytes and byte order.
+fn emit_embedded_vlen_dataset(
+    db: &mut DatasetBuilder,
+    ds: &Dataset,
+    path: &str,
+    datatype: &Datatype,
+    dims: &[u64],
+    layout: &DataLayout,
+    pipeline: &Option<FilterPipeline>,
+    slots: &[EmbeddedVlSlot],
+) -> Result<(), Error> {
+    // This path re-encodes, so a lossy filter cannot be reproduced — the same
+    // guard the other re-staging paths apply.
+    check_pipeline(pipeline.as_ref(), path)?;
+
+    let data = ds.read_embedded_vlen_bytes(slots, VlenStringReadOptions::default())?;
+    let elements: Vec<VlStringElement> = data
+        .objects
+        .into_iter()
+        .map(|o| match o {
+            VlByteObject::Null => VlStringElement::Null,
+            VlByteObject::Bytes(bytes) => VlStringElement::Bytes(bytes),
+        })
+        .collect();
+
+    let n_elements: u64 = dims.iter().product();
+    db.with_embedded_vlen_elements(
+        datatype.clone(),
+        data.raw,
+        n_elements,
+        &data.offsets,
+        &elements,
+    );
     db.with_shape(dims);
     carry_shape_and_pipeline(
         db,
@@ -940,27 +1071,7 @@ fn emit_object_reference_dataset(
         let mut targets = Vec::with_capacity(n_elements);
         for chunk in raw[..needed].chunks_exact(8) {
             let v = u64::from_le_bytes(chunk.try_into().expect("chunks_exact(8) yields 8 bytes"));
-            // 0 = null, all-ones = HADDR_UNDEF: both point at nothing, carried as-is.
-            if v == 0 || v == u64::MAX {
-                targets.push(ObjectRefTarget::Raw(v));
-                continue;
-            }
-            match addr_map.get(&v) {
-                Some(target_path) if is_dropped(target_path, drop) => {
-                    return Err(Error::RepackUnsupported(format!(
-                        "dataset {path}: object reference to dropped object {target_path:?} \
-                         cannot be repacked"
-                    )));
-                }
-                Some(target_path) => targets.push(ObjectRefTarget::Path(target_path.clone())),
-                None => {
-                    return Err(Error::RepackUnsupported(format!(
-                        "dataset {path}: object reference to address {v:#x} resolves to no \
-                         hard-linked object in the source (dangling, or a named-datatype / \
-                         region target not supported yet)"
-                    )));
-                }
-            }
+            targets.push(resolve_reference_address(v, path, drop, addr_map)?);
         }
         targets
     };
@@ -968,6 +1079,182 @@ fn emit_object_reference_dataset(
     db.with_object_references(targets);
     db.with_shape(dims);
     Ok(())
+}
+
+/// Re-emit a dataset whose datatype *contains* object references without being
+/// one — a compound with a reference member, or an array of them.
+///
+/// The same staleness that afflicts a top-level reference dataset applies here:
+/// the stored address names an object header in the source file, and the
+/// destination puts that object somewhere else. Copying the element bytes
+/// verbatim yields a file whose fixed-size members read back correctly and whose
+/// references dereference into whatever now occupies that address.
+///
+/// Each embedded address is resolved through `addr_map` to a source path and
+/// re-staged as a path target, exactly as [`emit_object_reference_dataset`] does,
+/// while every other byte of the element is carried through untouched.
+#[allow(clippy::too_many_arguments)]
+fn emit_embedded_reference_dataset(
+    db: &mut DatasetBuilder,
+    ds: &Dataset,
+    path: &str,
+    datatype: &Datatype,
+    dims: &[u64],
+    layout: &DataLayout,
+    file: &Arc<File>,
+    drop: &BTreeSet<String>,
+    addr_map: &HashMap<u64, String>,
+    slots: &[usize],
+) -> Result<(), Error> {
+    if matches!(layout, DataLayout::Chunked { .. }) {
+        return Err(Error::RepackUnsupported(format!(
+            "dataset {path}: chunked or filtered datasets with an object-reference member cannot \
+             be repacked (their addresses live inside compressed chunks and would need rewriting \
+             in place)"
+        )));
+    }
+    if let Some(maxshape) = &ds.dataspace()?.max_dimensions
+        && maxshape != dims
+    {
+        return Err(Error::RepackUnsupported(format!(
+            "dataset {path}: resizable datasets with an object-reference member cannot be repacked"
+        )));
+    }
+    if file.base_address() != 0 {
+        return Err(Error::RepackUnsupported(format!(
+            "dataset {path}: object references in a file with a non-zero base address (userblock) \
+             cannot be repacked yet"
+        )));
+    }
+
+    let stride = datatype.type_size() as usize;
+    let n_elements: usize = dims.iter().product::<u64>().to_usize()?;
+    let raw = if n_elements == 0 {
+        Vec::new()
+    } else {
+        ds.read_raw()?
+    };
+    let needed = n_elements
+        .checked_mul(stride)
+        .ok_or(FormatError::OffsetOverflow {
+            offset: n_elements as u64,
+            length: stride as u64,
+        })?;
+    if raw.len() < needed {
+        return Err(FormatError::UnexpectedEof {
+            expected: needed,
+            available: raw.len(),
+        }
+        .into());
+    }
+
+    let mut patches = Vec::with_capacity(n_elements * slots.len());
+    for e in 0..n_elements {
+        for &slot in slots {
+            let at = e * stride + slot;
+            let v = u64::from_le_bytes(
+                raw[at..at + 8]
+                    .try_into()
+                    .expect("slot offsets leave 8 bytes inside the element"),
+            );
+            patches.push(ObjectRefPatch {
+                byte_offset: at,
+                target: resolve_reference_address(v, path, drop, addr_map)?,
+            });
+        }
+    }
+
+    db.with_embedded_object_references(datatype.clone(), raw, n_elements as u64, patches);
+    db.with_shape(dims);
+    Ok(())
+}
+
+/// Turn one stored object-reference address into the target the writer resolves
+/// at serialization time. Null (0) and undefined (`HADDR_UNDEF`) point at nothing
+/// and are carried verbatim; anything else must name a hard-linked object that
+/// survives the repack.
+fn resolve_reference_address(
+    address: u64,
+    path: &str,
+    drop: &BTreeSet<String>,
+    addr_map: &HashMap<u64, String>,
+) -> Result<ObjectRefTarget, Error> {
+    if address == 0 || address == u64::MAX {
+        return Ok(ObjectRefTarget::Raw(address));
+    }
+    match addr_map.get(&address) {
+        Some(target_path) if is_dropped(target_path, drop) => {
+            Err(Error::RepackUnsupported(format!(
+                "dataset {path}: object reference to dropped object {target_path:?} cannot be repacked"
+            )))
+        }
+        Some(target_path) => Ok(ObjectRefTarget::Path(target_path.clone())),
+        None => Err(Error::RepackUnsupported(format!(
+            "dataset {path}: object reference to address {address:#x} resolves to no hard-linked \
+             object in the source (dangling, or a named-datatype / region target not supported yet)"
+        ))),
+    }
+}
+
+/// Every 8-byte object reference `datatype` reaches through a compound member or
+/// array entry, as byte offsets within one element, in declaration order.
+///
+/// Mirrors [`embedded_vlen_slots`] for the other kind of address a rewrite
+/// invalidates. A datatype that *is* an object reference yields the single slot
+/// at offset 0, so callers handling that case separately should test for it
+/// first. Returns `None` if the offsets found do not fit the datatype's declared
+/// element size, which means the element bytes cannot be walked safely.
+fn embedded_reference_slots(datatype: &Datatype) -> Option<Vec<usize>> {
+    fn collect(datatype: &Datatype, base: usize, capacity: usize, out: &mut Vec<usize>) {
+        if out.len() > capacity {
+            return;
+        }
+        match datatype {
+            Datatype::Reference {
+                ref_type: ReferenceType::Object,
+                size: 8,
+            } => out.push(base),
+            Datatype::Compound { members, .. } => {
+                for m in members {
+                    collect(&m.datatype, base + m.byte_offset as usize, capacity, out);
+                }
+            }
+            Datatype::Array {
+                base_type,
+                dimensions,
+            } => {
+                // As in `embedded_vlen_slots`: probe once so that entries which can
+                // never contribute do not drive a walk over huge declared
+                // dimensions, and so every iteration below pushes at least one slot.
+                let mut probe = Vec::new();
+                collect(base_type, 0, capacity, &mut probe);
+                if probe.is_empty() {
+                    return;
+                }
+                let count = dimensions
+                    .iter()
+                    .copied()
+                    .fold(1u64, |a, b| a.saturating_mul(u64::from(b)));
+                let stride = base_type.type_size() as usize;
+                for i in 0..count {
+                    collect(base_type, base + (i as usize) * stride, capacity, out);
+                    if out.len() > capacity {
+                        return;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let element_size = datatype.type_size() as usize;
+    let capacity = element_size / 8;
+    let mut slots = Vec::new();
+    collect(datatype, 0, capacity, &mut slots);
+    if slots.len() > capacity || slots.iter().any(|&s| s + 8 > element_size) {
+        return None;
+    }
+    Some(slots)
 }
 
 /// Reject data layouts that cannot be read and re-emitted (virtual datasets;

--- a/src/repack.rs
+++ b/src/repack.rs
@@ -33,10 +33,12 @@
 //!   null-vs-empty distinction, embedded NULs, and non-UTF-8 payloads, and the
 //!   source's chunk geometry, filters, and resizability are carried onto the
 //!   rebuilt dataset.
-//! - Datatypes that *contain* a variable-length member without being one — a
-//!   compound with a VL member, an array of such compounds, and nesting of
-//!   either. The embedded heap references are re-staged exactly as a top-level
-//!   one is, while every other byte of the element is carried through untouched.
+//! - Datatypes that *contain* an address without being one — a compound with a
+//!   variable-length member, an object-reference member, or both; an array of
+//!   such compounds; and nesting of either. The embedded heap references are
+//!   re-staged and the embedded object addresses resolved exactly as their
+//!   top-level counterparts are, in a single pass, while every other byte of the
+//!   element is carried through untouched.
 //! - Contiguous/compact **object-reference** datasets, and contiguous/compact
 //!   datatypes containing an object-reference member: each stored address is
 //!   rewritten to its target object's new location in the compacted file (null
@@ -397,14 +399,19 @@ fn emit_dataset(
         return Ok(());
     }
 
-    // A datatype that merely *contains* variable-length members — a compound with
-    // a VL member, or an array of them — embeds a global-heap reference inside
-    // each element. Those references go stale on rewrite exactly as a top-level
-    // one does, so this dataset is re-staged through a fresh heap rather than
-    // copied. Routed before the verbatim chunk-copy path so a chunked one is
-    // rebuilt, not copied with source addresses (issue #201).
-    if !vlen_slots.is_empty() {
-        emit_embedded_vlen_dataset(
+    // A datatype that merely *contains* a variable-length member or an object
+    // reference — a compound with either, or an array of them — embeds the
+    // address inside each element. Those addresses go stale on rewrite exactly as
+    // a top-level one does, so this dataset is re-staged rather than copied.
+    // Routed before the verbatim chunk-copy path so a chunked one is rebuilt, not
+    // copied with source addresses (issue #201).
+    //
+    // Both kinds are handled together rather than in sequence: a compound can
+    // carry one of each, and rewriting only the first kind found would leave the
+    // other pointing into the source file — reintroducing the very bug this path
+    // exists to fix, and skipping the other kind's refusals with it.
+    if !vlen_slots.is_empty() || !reference_slots.is_empty() {
+        emit_embedded_address_dataset(
             db,
             ds,
             path,
@@ -413,30 +420,10 @@ fn emit_dataset(
             &layout,
             &pipeline,
             &vlen_slots,
-        )?;
-        let attrs = ds.attrs()?;
-        check_attr_completeness(&attrs, &ds.attr_names()?, &format!("dataset {path}"))?;
-        for (name, value) in sorted(attrs) {
-            db.set_attr(&name, value);
-        }
-        return Ok(());
-    }
-
-    // The same argument for an object-header address embedded in a compound
-    // member or array entry: it names an object in the source file, and the
-    // destination puts that object elsewhere.
-    if !reference_slots.is_empty() {
-        emit_embedded_reference_dataset(
-            db,
-            ds,
-            path,
-            &datatype,
-            &dims,
-            &layout,
+            &reference_slots,
             file,
             drop,
             addr_map,
-            &reference_slots,
         )?;
         let attrs = ds.attrs()?;
         check_attr_completeness(&attrs, &ds.attr_names()?, &format!("dataset {path}"))?;
@@ -709,21 +696,25 @@ fn emit_vlen_sequence_dataset(
     Ok(())
 }
 
-/// Re-emit a dataset whose datatype *contains* variable-length references
-/// without being one — a compound with a variable-length member, or an array of
-/// such compounds (issue #201).
+/// Re-emit a dataset whose datatype *contains* an address without being one — a
+/// compound with a variable-length or object-reference member, an array of such
+/// compounds, or nesting of either (issue #201).
 ///
-/// The element bytes are read as they stand and each embedded reference is
-/// resolved against the source's global heap; the payloads are then re-staged
-/// into the destination's own heap and the references rewritten in place. Copying
-/// the element bytes verbatim instead would leave every reference naming a
-/// collection in the *source* file's address space, which the destination never
-/// allocates — a file that reads back plausibly here and not at all in the
+/// The element bytes are read as they stand; each embedded variable-length
+/// reference is resolved against the source's global heap and its payload
+/// re-staged into the destination's own, and each embedded object address is
+/// resolved to the path it names so the writer can fill in the target's *new*
+/// location. Copying the element bytes verbatim instead would leave every
+/// address pointing into the source file, which the destination never
+/// reproduces — a file that reads back plausibly here and not at all in the
 /// reference C library.
 ///
-/// Everything outside the references is carried byte-for-byte, so the fixed-size
-/// members keep their exact stored bytes and byte order.
-fn emit_embedded_vlen_dataset(
+/// Both kinds are handled in one pass because a single compound can carry one of
+/// each, and they patch disjoint byte ranges of the same buffer. Everything
+/// outside those ranges is carried byte-for-byte, so the fixed-size members keep
+/// their exact stored bytes and byte order.
+#[allow(clippy::too_many_arguments)]
+fn emit_embedded_address_dataset(
     db: &mut DatasetBuilder,
     ds: &Dataset,
     path: &str,
@@ -731,30 +722,69 @@ fn emit_embedded_vlen_dataset(
     dims: &[u64],
     layout: &DataLayout,
     pipeline: &Option<FilterPipeline>,
-    slots: &[EmbeddedVlSlot],
+    vlen_slots: &[EmbeddedVlSlot],
+    reference_slots: &[usize],
+    file: &Arc<File>,
+    drop: &BTreeSet<String>,
+    addr_map: &HashMap<u64, String>,
 ) -> Result<(), Error> {
     // This path re-encodes, so a lossy filter cannot be reproduced — the same
     // guard the other re-staging paths apply.
     check_pipeline(pipeline.as_ref(), path)?;
 
-    let data = ds.read_embedded_vlen_bytes(slots, VlenStringReadOptions::default())?;
-    let elements: Vec<VlStringElement> = data
-        .objects
-        .into_iter()
-        .map(|o| match o {
-            VlByteObject::Null => VlStringElement::Null,
-            VlByteObject::Bytes(bytes) => VlStringElement::Bytes(bytes),
-        })
-        .collect();
+    // An embedded object address is resolved as the elements are re-staged, which
+    // a compressed chunk would need rewritten in place, so the layout guards that
+    // protect a top-level object-reference dataset apply here too. They are
+    // checked before anything is read, and before the variable-length work, so a
+    // compound carrying both kinds is refused rather than half-rewritten.
+    if !reference_slots.is_empty() {
+        check_embedded_reference_layout(ds, path, dims, layout, file)?;
+    }
 
     let n_elements: u64 = dims.iter().product();
-    db.with_embedded_vlen_elements(
-        datatype.clone(),
-        data.raw,
-        n_elements,
-        &data.offsets,
-        &elements,
-    );
+
+    // Read the element bytes once, resolving the variable-length payloads in the
+    // same pass when there are any.
+    let (raw, vl_offsets, vl_elements) = if vlen_slots.is_empty() {
+        let raw = if n_elements == 0 {
+            Vec::new()
+        } else {
+            ds.read_raw()?
+        };
+        (raw, Vec::new(), Vec::new())
+    } else {
+        let data = ds.read_embedded_vlen_bytes(vlen_slots, VlenStringReadOptions::default())?;
+        let elements: Vec<VlStringElement> = data
+            .objects
+            .into_iter()
+            .map(|o| match o {
+                VlByteObject::Null => VlStringElement::Null,
+                VlByteObject::Bytes(bytes) => VlStringElement::Bytes(bytes),
+            })
+            .collect();
+        (data.raw, data.offsets, elements)
+    };
+
+    // Resolve the object addresses from the bytes as read, before the
+    // variable-length staging below consumes `raw`. The two kinds occupy disjoint
+    // slots, so reading one is unaffected by rewriting the other.
+    let reference_patches =
+        resolve_embedded_references(&raw, datatype, dims, path, drop, addr_map, reference_slots)?;
+
+    if vlen_slots.is_empty() {
+        db.with_embedded_object_references(datatype.clone(), raw, n_elements, reference_patches);
+    } else {
+        db.with_embedded_vlen_elements(
+            datatype.clone(),
+            raw,
+            n_elements,
+            &vl_offsets,
+            &vl_elements,
+        );
+        if !reference_patches.is_empty() {
+            db.reference_targets = Some(reference_patches);
+        }
+    }
     db.with_shape(dims);
     carry_shape_and_pipeline(
         db,
@@ -764,6 +794,54 @@ fn emit_embedded_vlen_dataset(
         pipeline,
     );
     Ok(())
+}
+
+/// Turn every embedded object address in `raw` into the target the writer
+/// resolves at serialization time.
+fn resolve_embedded_references(
+    raw: &[u8],
+    datatype: &Datatype,
+    dims: &[u64],
+    path: &str,
+    drop: &BTreeSet<String>,
+    addr_map: &HashMap<u64, String>,
+    slots: &[usize],
+) -> Result<Vec<ObjectRefPatch>, Error> {
+    if slots.is_empty() {
+        return Ok(Vec::new());
+    }
+    let stride = datatype.type_size() as usize;
+    let n_elements: usize = dims.iter().product::<u64>().to_usize()?;
+    let needed = n_elements
+        .checked_mul(stride)
+        .ok_or(FormatError::OffsetOverflow {
+            offset: n_elements as u64,
+            length: stride as u64,
+        })?;
+    if raw.len() < needed {
+        return Err(FormatError::UnexpectedEof {
+            expected: needed,
+            available: raw.len(),
+        }
+        .into());
+    }
+
+    let mut patches = Vec::with_capacity(n_elements * slots.len());
+    for e in 0..n_elements {
+        for &slot in slots {
+            let at = e * stride + slot;
+            let v = u64::from_le_bytes(
+                raw[at..at + 8]
+                    .try_into()
+                    .expect("slot offsets leave 8 bytes inside the element"),
+            );
+            patches.push(ObjectRefPatch {
+                byte_offset: at,
+                target: resolve_reference_address(v, path, drop, addr_map)?,
+            });
+        }
+    }
+    Ok(patches)
 }
 
 /// A [`ChunkProvider`] that streams a dense chunked dataset's chunks from the
@@ -1081,30 +1159,18 @@ fn emit_object_reference_dataset(
     Ok(())
 }
 
-/// Re-emit a dataset whose datatype *contains* object references without being
-/// one — a compound with a reference member, or an array of them.
+/// The layout guards that protect a dataset carrying an embedded object address.
 ///
-/// The same staleness that afflicts a top-level reference dataset applies here:
-/// the stored address names an object header in the source file, and the
-/// destination puts that object somewhere else. Copying the element bytes
-/// verbatim yields a file whose fixed-size members read back correctly and whose
-/// references dereference into whatever now occupies that address.
-///
-/// Each embedded address is resolved through `addr_map` to a source path and
-/// re-staged as a path target, exactly as [`emit_object_reference_dataset`] does,
-/// while every other byte of the element is carried through untouched.
-#[allow(clippy::too_many_arguments)]
-fn emit_embedded_reference_dataset(
-    db: &mut DatasetBuilder,
+/// The address is resolved as the elements are re-staged, which a compressed
+/// chunk would need rewritten in place, and a userblock shifts every address by a
+/// base this rewrite path does not model. Each is refused by name rather than
+/// risking a mis-resolved address.
+fn check_embedded_reference_layout(
     ds: &Dataset,
     path: &str,
-    datatype: &Datatype,
     dims: &[u64],
     layout: &DataLayout,
     file: &Arc<File>,
-    drop: &BTreeSet<String>,
-    addr_map: &HashMap<u64, String>,
-    slots: &[usize],
 ) -> Result<(), Error> {
     if matches!(layout, DataLayout::Chunked { .. }) {
         return Err(Error::RepackUnsupported(format!(
@@ -1126,46 +1192,6 @@ fn emit_embedded_reference_dataset(
              cannot be repacked yet"
         )));
     }
-
-    let stride = datatype.type_size() as usize;
-    let n_elements: usize = dims.iter().product::<u64>().to_usize()?;
-    let raw = if n_elements == 0 {
-        Vec::new()
-    } else {
-        ds.read_raw()?
-    };
-    let needed = n_elements
-        .checked_mul(stride)
-        .ok_or(FormatError::OffsetOverflow {
-            offset: n_elements as u64,
-            length: stride as u64,
-        })?;
-    if raw.len() < needed {
-        return Err(FormatError::UnexpectedEof {
-            expected: needed,
-            available: raw.len(),
-        }
-        .into());
-    }
-
-    let mut patches = Vec::with_capacity(n_elements * slots.len());
-    for e in 0..n_elements {
-        for &slot in slots {
-            let at = e * stride + slot;
-            let v = u64::from_le_bytes(
-                raw[at..at + 8]
-                    .try_into()
-                    .expect("slot offsets leave 8 bytes inside the element"),
-            );
-            patches.push(ObjectRefPatch {
-                byte_offset: at,
-                target: resolve_reference_address(v, path, drop, addr_map)?,
-            });
-        }
-    }
-
-    db.with_embedded_object_references(datatype.clone(), raw, n_elements as u64, patches);
-    db.with_shape(dims);
     Ok(())
 }
 
@@ -1240,6 +1266,9 @@ fn embedded_reference_slots(datatype: &Datatype) -> Option<Vec<usize>> {
                 // As in `embedded_vlen_slots`: probe once so that entries which can
                 // never contribute do not drive a walk over huge declared
                 // dimensions, and so every iteration below pushes at least one slot.
+                // Walked once and translated per entry, for the reason
+                // `embedded_vlen_slots` documents: re-walking is exponential in
+                // nesting depth.
                 let mut probe = Vec::new();
                 if !collect(base_type, 0, capacity, &mut probe) {
                     return false;
@@ -1263,11 +1292,14 @@ fn embedded_reference_slots(datatype: &Datatype) -> Option<Vec<usize>> {
                     else {
                         return false;
                     };
-                    if !collect(base_type, at, capacity, out) {
-                        return false;
-                    }
-                    if out.len() > capacity {
-                        return true;
+                    for &slot in &probe {
+                        let Some(off) = at.checked_add(slot) else {
+                            return false;
+                        };
+                        out.push(off);
+                        if out.len() > capacity {
+                            return true;
+                        }
                     }
                 }
                 true

--- a/src/repack.rs
+++ b/src/repack.rs
@@ -1205,19 +1205,33 @@ fn resolve_reference_address(
 /// first. Returns `None` if the offsets found do not fit the datatype's declared
 /// element size, which means the element bytes cannot be walked safely.
 fn embedded_reference_slots(datatype: &Datatype) -> Option<Vec<usize>> {
-    fn collect(datatype: &Datatype, base: usize, capacity: usize, out: &mut Vec<usize>) {
+    /// Returns `false` when the datatype cannot be walked on this target, for the
+    /// reasons [`embedded_vlen_slots`]' walker documents.
+    fn collect(datatype: &Datatype, base: usize, capacity: usize, out: &mut Vec<usize>) -> bool {
         if out.len() > capacity {
-            return;
+            return true;
         }
         match datatype {
             Datatype::Reference {
                 ref_type: ReferenceType::Object,
                 size: 8,
-            } => out.push(base),
+            } => {
+                out.push(base);
+                true
+            }
             Datatype::Compound { members, .. } => {
                 for m in members {
-                    collect(&m.datatype, base + m.byte_offset as usize, capacity, out);
+                    let Some(at) = usize::try_from(m.byte_offset)
+                        .ok()
+                        .and_then(|off| base.checked_add(off))
+                    else {
+                        return false;
+                    };
+                    if !collect(&m.datatype, at, capacity, out) {
+                        return false;
+                    }
                 }
+                true
             }
             Datatype::Array {
                 base_type,
@@ -1227,31 +1241,54 @@ fn embedded_reference_slots(datatype: &Datatype) -> Option<Vec<usize>> {
                 // never contribute do not drive a walk over huge declared
                 // dimensions, and so every iteration below pushes at least one slot.
                 let mut probe = Vec::new();
-                collect(base_type, 0, capacity, &mut probe);
+                if !collect(base_type, 0, capacity, &mut probe) {
+                    return false;
+                }
                 if probe.is_empty() {
-                    return;
+                    return true;
                 }
                 let count = dimensions
                     .iter()
                     .copied()
                     .fold(1u64, |a, b| a.saturating_mul(u64::from(b)));
+                // As in `embedded_vlen_slots`: more entries than the element has
+                // room for cannot fit, so reject without walking them.
+                if count > capacity as u64 {
+                    return false;
+                }
+                let entries = usize::try_from(count).unwrap_or(usize::MAX);
                 let stride = base_type.type_size() as usize;
-                for i in 0..count {
-                    collect(base_type, base + (i as usize) * stride, capacity, out);
+                for i in 0..entries {
+                    let Some(at) = i.checked_mul(stride).and_then(|off| base.checked_add(off))
+                    else {
+                        return false;
+                    };
+                    if !collect(base_type, at, capacity, out) {
+                        return false;
+                    }
                     if out.len() > capacity {
-                        return;
+                        return true;
                     }
                 }
+                true
             }
-            _ => {}
+            _ => true,
         }
     }
 
     let element_size = datatype.type_size() as usize;
     let capacity = element_size / 8;
     let mut slots = Vec::new();
-    collect(datatype, 0, capacity, &mut slots);
-    if slots.len() > capacity || slots.iter().any(|&s| s + 8 > element_size) {
+    if !collect(datatype, 0, capacity, &mut slots) {
+        return None;
+    }
+    // `checked_add`: an offset near the top of the address space would otherwise
+    // wrap here and read as "fits".
+    if slots.len() > capacity
+        || slots
+            .iter()
+            .any(|&s| s.checked_add(8).is_none_or(|end| end > element_size))
+    {
         return None;
     }
     Some(slots)

--- a/src/type_builders.rs
+++ b/src/type_builders.rs
@@ -1013,9 +1013,14 @@ pub(crate) struct ObjectRefPatch {
 ///
 /// The offset comes from the datatype's own layout and `raw` is sized from the
 /// same datatype, so a slot that does not fit means the two disagree — a bug in
-/// whoever staged them, not input this can correct. Skipping the write leaves the
-/// placeholder zeros (a null reference) rather than corrupting a neighbouring
-/// field, and the debug assertion catches it in the test suite.
+/// whoever staged them, not input this can correct. The debug assertion catches
+/// that in the test suite; in release the write is skipped rather than allowed to
+/// corrupt a neighbouring field. Note what a skip leaves behind depends on the
+/// caller: placeholder zeros (a null reference) for a dataset staged by
+/// [`DatasetBuilder::with_object_references`], but the *source's* address for one
+/// staged by [`DatasetBuilder::with_embedded_object_references`], whose buffer is
+/// the source's element bytes. Neither is reachable without the assertion firing
+/// first.
 pub(crate) fn write_reference_address(raw: &mut [u8], byte_offset: usize, address: u64) {
     debug_assert!(
         byte_offset + 8 <= raw.len(),

--- a/src/type_builders.rs
+++ b/src/type_builders.rs
@@ -736,25 +736,30 @@ pub(crate) enum VlStringElement {
 /// length(4) + collection address(8) + object index(4).
 pub(crate) const VL_REF_SIZE: usize = 16;
 
-/// Staged VL-string dataset/attribute element data: the per-element 16-byte
-/// references (with placeholder heap addresses) plus the global heap
+/// Staged variable-length dataset/attribute element data: the element bytes
+/// (carrying VL references with placeholder heap addresses) plus the global heap
 /// collections holding the non-null elements' bytes.
 ///
 /// The non-null elements' bytes become heap objects in order, packed
 /// [`MAX_HEAP_OBJECTS`] to a collection, and each reference carries its
 /// object's 1-based index within its own collection — matching
-/// [`build_global_heap_collections_from_bytes`]. Null elements carry an
-/// undefined address and object index 0, and are never patched so they read
-/// back as null.
+/// [`build_global_heap_collections_from_bytes`]. Null elements carry a zero
+/// address and object index 0, and are never patched so they read back as null.
 pub(crate) struct VlStringStaging {
-    /// The dataset/attribute element bytes: one 16-byte reference per element.
+    /// The dataset/attribute element bytes. For a dataset whose datatype *is*
+    /// variable-length this is one 16-byte reference per element; for one that
+    /// merely *contains* variable-length members (a compound, or an array of
+    /// them) it is the full element bytes with the embedded references stamped
+    /// in place.
     pub refs: Vec<u8>,
     /// The serialized global heap collections holding the non-null objects, in
     /// the order their objects appear. Empty when there are no such objects.
     pub collections: Vec<Vec<u8>>,
-    /// `true` for each element that references a heap object and must have its
-    /// address patched; `false` for a null element that must stay undefined.
-    pub patch_mask: Vec<bool>,
+    /// Byte offset within [`refs`](Self::refs) of each reference that names a
+    /// heap object and so needs its address patched once the collections are
+    /// placed, in the same order as those objects. Null references are absent:
+    /// their address must stay zero so they read back as null.
+    pub patch_offsets: Vec<usize>,
 }
 
 /// Stage the references and global-heap collections for a variable-length
@@ -774,7 +779,7 @@ pub(crate) fn stage_vl_elements(
     // object indices, 1-based within each collection.
     let mut objects: Vec<&[u8]> = Vec::new();
     let mut refs = Vec::with_capacity(elements.len() * VL_REF_SIZE);
-    let mut patch_mask = Vec::with_capacity(elements.len());
+    let mut patch_offsets = Vec::with_capacity(elements.len());
     for element in elements {
         match element {
             VlStringElement::Null => {
@@ -785,9 +790,9 @@ pub(crate) fn stage_vl_elements(
                 refs.extend_from_slice(&0u32.to_le_bytes()); // length 0
                 refs.extend_from_slice(&0u64.to_le_bytes()); // null heap address
                 refs.extend_from_slice(&0u32.to_le_bytes()); // object index 0
-                patch_mask.push(false);
             }
             VlStringElement::Bytes(bytes) => {
+                patch_offsets.push(refs.len());
                 #[expect(
                     clippy::cast_possible_truncation,
                     reason = "VL element length (element count) is written into the 4-byte \
@@ -804,7 +809,6 @@ pub(crate) fn stage_vl_elements(
                 )]
                 refs.extend_from_slice(&(index as u32).to_le_bytes());
                 objects.push(bytes);
-                patch_mask.push(true);
             }
         }
     }
@@ -814,30 +818,78 @@ pub(crate) fn stage_vl_elements(
     VlStringStaging {
         refs,
         collections: build_global_heap_collections_from_bytes(&objects),
-        patch_mask,
+        patch_offsets,
     }
 }
 
-/// Patch the heap address of each VL reference flagged in `patch_mask`, leaving
-/// null references (mask `false`) with their undefined address. Mirrors
-/// [`patch_vl_refs`] but skips null elements so they read back as null, so the
-/// collection a reference resolves to is selected by its *object* position
-/// rather than its element position. `collection_addresses` holds the placed
-/// addresses of [`VlStringStaging::collections`], in order.
+/// Stage the global-heap collections for a dataset whose datatype merely
+/// *contains* variable-length members — a compound with a VL member, or an array
+/// of such compounds — rather than being variable-length itself.
+///
+/// `raw` is the dataset's element bytes as read from the source, and `offsets`
+/// gives the byte offset of every embedded VL reference within `raw`, in the same
+/// order as `elements`. Each reference is rewritten in place: a null element is
+/// zeroed outright, and a heap-backed one keeps the source's `length` field
+/// (which counts base-type elements, whose width varies per member) while
+/// gaining the destination's object index. The addresses stay at zero until
+/// [`patch_vl_refs_masked`] fills them in, exactly as for a top-level VL dataset.
+pub(crate) fn stage_embedded_vl_elements(
+    mut raw: Vec<u8>,
+    offsets: &[usize],
+    elements: &[VlStringElement],
+) -> VlStringStaging {
+    debug_assert_eq!(
+        offsets.len(),
+        elements.len(),
+        "one staged payload per embedded variable-length reference"
+    );
+    let mut objects: Vec<&[u8]> = Vec::new();
+    let mut patch_offsets = Vec::with_capacity(elements.len());
+    for (&offset, element) in offsets.iter().zip(elements) {
+        let slot = &mut raw[offset..offset + VL_REF_SIZE];
+        match element {
+            VlStringElement::Null => slot.fill(0),
+            VlStringElement::Bytes(bytes) => {
+                patch_offsets.push(offset);
+                // Leave the source's element-count `length` in bytes 0..4 alone,
+                // and blank the address so an unpatched reference is visibly null
+                // rather than a stale source address.
+                slot[4..12].fill(0);
+                let index = objects.len() % MAX_HEAP_OBJECTS + 1;
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "1-based heap object index is written into the 4-byte object-index \
+                              field of the variable-length reference"
+                )]
+                slot[12..16].copy_from_slice(&(index as u32).to_le_bytes());
+                objects.push(bytes);
+            }
+        }
+    }
+    VlStringStaging {
+        collections: build_global_heap_collections_from_bytes(&objects),
+        refs: raw,
+        patch_offsets,
+    }
+}
+
+/// Patch the heap address of each VL reference named by `patch_offsets`, leaving
+/// null references (which are absent from that list) with their zero address so
+/// they read back as null. Mirrors [`patch_vl_refs`], but because only
+/// heap-backed references are listed, the collection a reference resolves to is
+/// selected by its *object* position rather than its element position — and the
+/// references need not sit at a fixed stride, which is what lets a compound with
+/// variable-length members share this path. `collection_addresses` holds the
+/// placed addresses of [`VlStringStaging::collections`], in order.
 pub(crate) fn patch_vl_refs_masked(
     raw_data: &mut [u8],
-    patch_mask: &[bool],
+    patch_offsets: &[usize],
     collection_addresses: &[u64],
 ) {
-    let mut object_ordinal = 0usize;
-    for (i, &patch) in patch_mask.iter().enumerate() {
-        if !patch {
-            continue;
-        }
+    for (object_ordinal, &offset) in patch_offsets.iter().enumerate() {
         let address = collection_addresses[object_ordinal / MAX_HEAP_OBJECTS];
-        let addr_offset = i * VL_REF_SIZE + 4; // skip sequence_length
+        let addr_offset = offset + 4; // skip sequence_length
         raw_data[addr_offset..addr_offset + 8].copy_from_slice(&address.to_le_bytes());
-        object_ordinal += 1;
     }
 }
 
@@ -942,6 +994,39 @@ pub(crate) enum ObjectRefTarget {
     Raw(u64),
 }
 
+/// One object-reference address to resolve during serialization, and where in
+/// the dataset's element bytes it sits.
+///
+/// The offset is explicit rather than implied by a fixed stride so that a
+/// reference embedded in a larger element — a compound member, or an array entry
+/// — is rewritten in place alongside the fixed-size bytes around it. A dataset
+/// whose datatype *is* an object reference simply has one patch every 8 bytes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ObjectRefPatch {
+    /// Byte offset of the 8-byte address within the dataset's element bytes.
+    pub byte_offset: usize,
+    /// What to write there.
+    pub target: ObjectRefTarget,
+}
+
+/// Write a resolved object-reference address into a dataset's element bytes.
+///
+/// The offset comes from the datatype's own layout and `raw` is sized from the
+/// same datatype, so a slot that does not fit means the two disagree — a bug in
+/// whoever staged them, not input this can correct. Skipping the write leaves the
+/// placeholder zeros (a null reference) rather than corrupting a neighbouring
+/// field, and the debug assertion catches it in the test suite.
+pub(crate) fn write_reference_address(raw: &mut [u8], byte_offset: usize, address: u64) {
+    debug_assert!(
+        byte_offset + 8 <= raw.len(),
+        "object-reference slot at {byte_offset} does not fit {} element bytes",
+        raw.len()
+    );
+    if let Some(slot) = raw.get_mut(byte_offset..byte_offset + 8) {
+        slot.copy_from_slice(&address.to_le_bytes());
+    }
+}
+
 /// Builder for datasets.
 pub struct DatasetBuilder {
     pub(crate) name: String,
@@ -959,7 +1044,7 @@ pub struct DatasetBuilder {
     /// When set, this dataset is an object-reference dataset whose element
     /// addresses are resolved (per-element by path, or written raw) during file
     /// serialization once every object's destination address is known.
-    pub(crate) reference_targets: Option<Vec<ObjectRefTarget>>,
+    pub(crate) reference_targets: Option<Vec<ObjectRefPatch>>,
     /// When set, this dataset stores variable-length strings: `data` holds the
     /// 16-byte references with placeholder heap addresses, and this staging
     /// carries the global heap collection plus the mask of references to patch
@@ -1159,7 +1244,40 @@ impl DatasetBuilder {
         if self.shape.is_none() {
             self.shape = Some(vec![targets.len() as u64]);
         }
-        self.reference_targets = Some(targets);
+        self.reference_targets = Some(
+            targets
+                .into_iter()
+                .enumerate()
+                .map(|(i, target)| ObjectRefPatch {
+                    byte_offset: i * 8,
+                    target,
+                })
+                .collect(),
+        );
+        self
+    }
+
+    /// Write a dataset whose datatype *contains* object references without being
+    /// one — a compound with a reference member, or an array of them.
+    ///
+    /// `raw` is the source's element bytes; each [`ObjectRefPatch`] names an
+    /// address within them to resolve during serialization. Every other byte is
+    /// carried through untouched, so the fixed-size members keep their exact
+    /// stored bytes. The shape defaults to `[num_elements]` unless
+    /// [`with_shape`](Self::with_shape) sets it.
+    pub(crate) fn with_embedded_object_references(
+        &mut self,
+        datatype: Datatype,
+        raw: Vec<u8>,
+        num_elements: u64,
+        patches: Vec<ObjectRefPatch>,
+    ) -> &mut Self {
+        self.datatype = Some(datatype);
+        self.data = Some(raw);
+        if self.shape.is_none() {
+            self.shape = Some(vec![num_elements]);
+        }
+        self.reference_targets = Some(patches);
         self
     }
 
@@ -1431,6 +1549,35 @@ impl DatasetBuilder {
         }
         self.stage_vlen_elements(datatype, elements, element_size);
         Ok(self)
+    }
+
+    /// Write a dataset whose datatype *contains* variable-length members without
+    /// being variable-length itself — a compound with a VL member, or an array of
+    /// such compounds.
+    ///
+    /// `raw` is the source's element bytes and `offsets` gives the byte offset of
+    /// every embedded VL reference within them, paired in order with `elements`
+    /// (each either a null reference or the exact heap bytes it named). The
+    /// references are re-stamped to point at this file's own global heap, so the
+    /// source's addresses never survive into the output. This is the faithful
+    /// re-emit path used by repack; the shape defaults to `[num_elements]` unless
+    /// [`with_shape`](Self::with_shape) sets it.
+    pub(crate) fn with_embedded_vlen_elements(
+        &mut self,
+        datatype: Datatype,
+        raw: Vec<u8>,
+        num_elements: u64,
+        offsets: &[usize],
+        elements: &[VlStringElement],
+    ) -> &mut Self {
+        let staging = stage_embedded_vl_elements(raw, offsets, elements);
+        self.datatype = Some(datatype);
+        self.data = Some(staging.refs.clone());
+        self.vl_string_staging = Some(staging);
+        if self.shape.is_none() {
+            self.shape = Some(vec![num_elements]);
+        }
+        self
     }
 
     /// Shared body of the VL write entry points (string and sequence): stage the

--- a/src/vl_data.rs
+++ b/src/vl_data.rs
@@ -285,10 +285,17 @@ fn collect_vlen_slots(
             // dimensions from spinning through entries that can never contribute,
             // and makes every iteration below push at least one slot — so the
             // `capacity` bound terminates the loop.
+            // Walk the entry type *once*, at offset 0, then translate that result
+            // to each entry's base. Re-walking per entry would recompute the same
+            // sub-tree `entries` times at every level of nesting, which is
+            // exponential in nesting depth: a ~300-byte datatype of nested arrays
+            // is enough to burn hours of CPU on work whose output is bounded by
+            // `capacity`.
             let mut probe = Vec::new();
             if !collect_vlen_slots(base_type, 0, capacity, &mut probe) {
                 return false;
             }
+            // No reference in one entry means none in any repetition of it.
             if probe.is_empty() {
                 return true;
             }
@@ -311,11 +318,19 @@ fn collect_vlen_slots(
                 let Some(at) = i.checked_mul(stride).and_then(|off| base.checked_add(off)) else {
                     return false;
                 };
-                if !collect_vlen_slots(base_type, at, capacity, out) {
-                    return false;
-                }
-                if out.len() > capacity {
-                    return true;
+                for slot in &probe {
+                    let Some(byte_offset) = at.checked_add(slot.byte_offset) else {
+                        return false;
+                    };
+                    out.push(EmbeddedVlSlot {
+                        byte_offset,
+                        element_size: slot.element_size,
+                    });
+                    // Stop one past the bound so the caller can still tell
+                    // "too many" from "fits".
+                    if out.len() > capacity {
+                        return true;
+                    }
                 }
             }
             true
@@ -962,6 +977,39 @@ mod embedded_slot_tests {
             dimensions: vec![u32::MAX, u32::MAX],
         };
         assert_eq!(embedded_vlen_slots(&dt), None);
+    }
+
+    /// Deeply nested arrays must cost time proportional to the slots they
+    /// produce, not exponential in nesting depth.
+    ///
+    /// Walking each entry from scratch recomputes the same sub-tree once per
+    /// entry at every level, so a datatype of ~13 bytes per level — trivially
+    /// small in an object header, and depth-unlimited in `Datatype::parse` — used
+    /// to burn seconds here and hours a few levels further down. Any repack of an
+    /// untrusted file reaches this walk.
+    #[test]
+    fn deeply_nested_arrays_cost_time_proportional_to_their_slots() {
+        let mut dt = vlen_string();
+        for _ in 0..17 {
+            dt = Datatype::Array {
+                base_type: Box::new(dt),
+                dimensions: vec![2],
+            };
+        }
+        let started = std::time::Instant::now();
+        let slots = embedded_vlen_slots(&dt).expect("a well-formed nesting must be walkable");
+        let elapsed = started.elapsed();
+
+        assert_eq!(slots.len(), 1 << 17, "one slot per leaf entry");
+        // The linear walk does this in milliseconds even unoptimized; the
+        // exponential one took seconds in release. A wide margin keeps the test
+        // from being a CI-timing flake while still failing the regression by
+        // orders of magnitude.
+        assert!(
+            elapsed < std::time::Duration::from_secs(10),
+            "walking {} slots took {elapsed:?}; the walk is no longer linear in its output",
+            slots.len()
+        );
     }
 
     /// A member offset is read from the file as a `u64`, so it can name a

--- a/src/vl_data.rs
+++ b/src/vl_data.rs
@@ -170,6 +170,123 @@ pub(crate) fn is_vlen_string_datatype(datatype: &Datatype) -> bool {
     }
 }
 
+/// A variable-length reference reached *inside* a larger element rather than
+/// being the element itself: a member of a compound, or an entry of an array of
+/// them. Repack needs both coordinates to re-stage the payload and rewrite the
+/// reference in place.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct EmbeddedVlSlot {
+    /// Byte offset of the 16-byte reference within one element of the dataset.
+    pub byte_offset: usize,
+    /// Byte width of the variable-length base type. The reference's stored
+    /// `length` counts base-type elements, so the heap object holds
+    /// `length * element_size` bytes.
+    pub element_size: usize,
+}
+
+/// A dataset with embedded variable-length references, read for rewriting: the
+/// element bytes as they stand, plus each reference's position within them and
+/// the heap payload it names.
+pub(crate) struct EmbeddedVlData {
+    /// The dataset's element bytes, references still carrying source addresses.
+    pub raw: Vec<u8>,
+    /// Byte offset within `raw` of each embedded reference.
+    pub offsets: Vec<usize>,
+    /// The heap payload each reference names, paired in order with `offsets`.
+    pub objects: Vec<VlByteObject>,
+}
+
+/// Every variable-length reference `datatype` reaches through a compound member
+/// or array entry, in declaration order.
+///
+/// A datatype that *is* variable-length yields the single slot at offset 0, so
+/// callers that handle the top-level case separately should test for that first.
+/// Returns `None` if the datatype's declared size cannot hold the slots found,
+/// which means either a malformed datatype or dimensions that overflowed — in
+/// both cases the element bytes cannot be walked safely.
+pub(crate) fn embedded_vlen_slots(datatype: &Datatype) -> Option<Vec<EmbeddedVlSlot>> {
+    // A reference is 16 bytes, so an element can hold no more than this many.
+    // Bounding the walk keeps a datatype declaring absurd array dimensions from
+    // driving an unbounded allocation here.
+    let element_size = datatype.type_size() as usize;
+    let capacity = element_size / VL_REF_BYTES;
+    let mut slots = Vec::new();
+    collect_vlen_slots(datatype, 0, capacity, &mut slots);
+    if slots.len() > capacity
+        || slots
+            .iter()
+            .any(|s| s.byte_offset + VL_REF_BYTES > element_size)
+    {
+        return None;
+    }
+    Some(slots)
+}
+
+/// On-disk width of a variable-length reference with 8-byte offsets, which is
+/// the only offset size the write path emits and the only one repack re-stages.
+const VL_REF_BYTES: usize = 16;
+
+fn collect_vlen_slots(
+    datatype: &Datatype,
+    base: usize,
+    capacity: usize,
+    out: &mut Vec<EmbeddedVlSlot>,
+) {
+    // Stop one past the bound so the caller can still tell "too many" from "fits".
+    if out.len() > capacity {
+        return;
+    }
+    match datatype {
+        Datatype::VariableLength { base_type, .. } => {
+            // A VL string's reference counts bytes (its base type is one byte
+            // wide); a sequence's counts base-type elements.
+            let element_size = if is_vlen_string_datatype(datatype) {
+                1
+            } else {
+                (base_type.type_size() as usize).max(1)
+            };
+            out.push(EmbeddedVlSlot {
+                byte_offset: base,
+                element_size,
+            });
+        }
+        Datatype::Compound { members, .. } => {
+            for m in members {
+                collect_vlen_slots(&m.datatype, base + m.byte_offset as usize, capacity, out);
+            }
+        }
+        Datatype::Array {
+            base_type,
+            dimensions,
+        } => {
+            // If the entry type reaches no reference then no repetition of it
+            // does either. Checking once keeps a datatype declaring huge
+            // dimensions from spinning through entries that can never contribute,
+            // and makes every iteration below push at least one slot — so the
+            // `capacity` bound terminates the loop.
+            let mut probe = Vec::new();
+            collect_vlen_slots(base_type, 0, capacity, &mut probe);
+            if probe.is_empty() {
+                return;
+            }
+            let count = dimensions
+                .iter()
+                .copied()
+                .fold(1u64, |a, b| a.saturating_mul(u64::from(b)));
+            let stride = base_type.type_size() as usize;
+            for i in 0..count {
+                collect_vlen_slots(base_type, base + (i as usize) * stride, capacity, out);
+                if out.len() > capacity {
+                    return;
+                }
+            }
+        }
+        // An enumeration's base is an integer, and no other class can reach a
+        // variable-length reference.
+        _ => {}
+    }
+}
+
 fn check_element_limit(
     num_elements: u64,
     options: VlenStringReadOptions,
@@ -641,5 +758,170 @@ mod tests {
         let raw = vec![0u8; 10]; // too short for 1 element with offset_size=8
         let err = parse_vl_references(&raw, 1, 8).unwrap_err();
         assert!(matches!(err, FormatError::UnexpectedEof { .. }));
+    }
+}
+
+#[cfg(test)]
+mod embedded_slot_tests {
+    use super::*;
+    use crate::datatype::{CompoundMember, StringPadding};
+
+    fn vlen_string() -> Datatype {
+        Datatype::VariableLength {
+            is_string: true,
+            base_type: Box::new(Datatype::String {
+                size: 1,
+                charset: CharacterSet::Utf8,
+                padding: StringPadding::NullTerminate,
+            }),
+            padding: Some(StringPadding::NullTerminate),
+            charset: Some(CharacterSet::Utf8),
+        }
+    }
+
+    fn vlen_i32_sequence() -> Datatype {
+        Datatype::VariableLength {
+            is_string: false,
+            base_type: Box::new(Datatype::FixedPoint {
+                size: 4,
+                signed: true,
+                byte_order: crate::datatype::DatatypeByteOrder::LittleEndian,
+                bit_offset: 0,
+                bit_precision: 32,
+            }),
+            padding: None,
+            charset: None,
+        }
+    }
+
+    fn i32_type() -> Datatype {
+        Datatype::FixedPoint {
+            size: 4,
+            signed: true,
+            byte_order: crate::datatype::DatatypeByteOrder::LittleEndian,
+            bit_offset: 0,
+            bit_precision: 32,
+        }
+    }
+
+    fn member(name: &str, byte_offset: u64, datatype: Datatype) -> CompoundMember {
+        CompoundMember {
+            name: name.to_string(),
+            byte_offset,
+            datatype,
+        }
+    }
+
+    #[test]
+    fn a_plain_datatype_reaches_no_reference() {
+        assert_eq!(embedded_vlen_slots(&i32_type()), Some(Vec::new()));
+    }
+
+    #[test]
+    fn a_top_level_vlen_is_its_own_slot() {
+        assert_eq!(
+            embedded_vlen_slots(&vlen_string()),
+            Some(vec![EmbeddedVlSlot {
+                byte_offset: 0,
+                element_size: 1
+            }])
+        );
+    }
+
+    /// Each member keeps its own base-type width: a string reference counts
+    /// bytes, a sequence reference counts base-type elements. Collapsing the two
+    /// would read the wrong number of heap bytes back.
+    #[test]
+    fn compound_members_keep_their_own_element_size() {
+        let dt = Datatype::Compound {
+            size: 40,
+            members: vec![
+                member("label", 0, vlen_string()),
+                member("id", 16, i32_type()),
+                member("samples", 24, vlen_i32_sequence()),
+            ],
+        };
+        assert_eq!(
+            embedded_vlen_slots(&dt),
+            Some(vec![
+                EmbeddedVlSlot {
+                    byte_offset: 0,
+                    element_size: 1
+                },
+                EmbeddedVlSlot {
+                    byte_offset: 24,
+                    element_size: 4
+                },
+            ])
+        );
+    }
+
+    /// A compound nested inside a compound, and an array of compounds, both reach
+    /// references that a single-level walk would miss.
+    #[test]
+    fn nested_compounds_and_arrays_are_walked() {
+        let inner = Datatype::Compound {
+            size: 20,
+            members: vec![member("id", 0, i32_type()), member("s", 4, vlen_string())],
+        };
+        let nested = Datatype::Compound {
+            size: 24,
+            members: vec![
+                member("n", 0, i32_type()),
+                member("inner", 4, inner.clone()),
+            ],
+        };
+        assert_eq!(
+            embedded_vlen_slots(&nested),
+            Some(vec![EmbeddedVlSlot {
+                byte_offset: 8,
+                element_size: 1
+            }])
+        );
+
+        let array = Datatype::Array {
+            base_type: Box::new(inner),
+            dimensions: vec![3],
+        };
+        assert_eq!(
+            embedded_vlen_slots(&array),
+            Some(vec![
+                EmbeddedVlSlot {
+                    byte_offset: 4,
+                    element_size: 1
+                },
+                EmbeddedVlSlot {
+                    byte_offset: 24,
+                    element_size: 1
+                },
+                EmbeddedVlSlot {
+                    byte_offset: 44,
+                    element_size: 1
+                },
+            ])
+        );
+    }
+
+    /// A datatype whose declared size cannot hold the references it declares is
+    /// rejected rather than walked: the element bytes and the datatype disagree,
+    /// so any offset derived from the latter would index the wrong place.
+    #[test]
+    fn a_datatype_too_small_for_its_own_references_is_rejected() {
+        let dt = Datatype::Compound {
+            size: 8, // one VL reference needs 16
+            members: vec![member("s", 0, vlen_string())],
+        };
+        assert_eq!(embedded_vlen_slots(&dt), None);
+    }
+
+    /// An array declaring dimensions whose product overflows must not drive an
+    /// unbounded walk; the capacity bound stops it and the result is rejected.
+    #[test]
+    fn an_array_declaring_absurd_dimensions_is_rejected_not_walked() {
+        let dt = Datatype::Array {
+            base_type: Box::new(vlen_string()),
+            dimensions: vec![u32::MAX, u32::MAX],
+        };
+        assert_eq!(embedded_vlen_slots(&dt), None);
     }
 }

--- a/src/vl_data.rs
+++ b/src/vl_data.rs
@@ -211,11 +211,17 @@ pub(crate) fn embedded_vlen_slots(datatype: &Datatype) -> Option<Vec<EmbeddedVlS
     let element_size = datatype.type_size() as usize;
     let capacity = element_size / VL_REF_BYTES;
     let mut slots = Vec::new();
-    collect_vlen_slots(datatype, 0, capacity, &mut slots);
+    if !collect_vlen_slots(datatype, 0, capacity, &mut slots) {
+        return None;
+    }
+    // `checked_add`: an offset near the top of the address space would otherwise
+    // wrap here and read as "fits".
     if slots.len() > capacity
-        || slots
-            .iter()
-            .any(|s| s.byte_offset + VL_REF_BYTES > element_size)
+        || slots.iter().any(|s| {
+            s.byte_offset
+                .checked_add(VL_REF_BYTES)
+                .is_none_or(|end| end > element_size)
+        })
     {
         return None;
     }
@@ -226,15 +232,20 @@ pub(crate) fn embedded_vlen_slots(datatype: &Datatype) -> Option<Vec<EmbeddedVlS
 /// the only offset size the write path emits and the only one repack re-stages.
 const VL_REF_BYTES: usize = 16;
 
+/// Walk `datatype`, appending a slot for each variable-length reference it
+/// reaches. Returns `false` if it cannot be walked on this target: an offset the
+/// file declares that does not fit `usize`, or one that overflows it, names a
+/// position this platform cannot address, and silently truncating it would place
+/// a slot somewhere plausible but wrong.
 fn collect_vlen_slots(
     datatype: &Datatype,
     base: usize,
     capacity: usize,
     out: &mut Vec<EmbeddedVlSlot>,
-) {
+) -> bool {
     // Stop one past the bound so the caller can still tell "too many" from "fits".
     if out.len() > capacity {
-        return;
+        return true;
     }
     match datatype {
         Datatype::VariableLength { base_type, .. } => {
@@ -249,11 +260,21 @@ fn collect_vlen_slots(
                 byte_offset: base,
                 element_size,
             });
+            true
         }
         Datatype::Compound { members, .. } => {
             for m in members {
-                collect_vlen_slots(&m.datatype, base + m.byte_offset as usize, capacity, out);
+                let Some(at) = usize::try_from(m.byte_offset)
+                    .ok()
+                    .and_then(|off| base.checked_add(off))
+                else {
+                    return false;
+                };
+                if !collect_vlen_slots(&m.datatype, at, capacity, out) {
+                    return false;
+                }
             }
+            true
         }
         Datatype::Array {
             base_type,
@@ -265,25 +286,43 @@ fn collect_vlen_slots(
             // and makes every iteration below push at least one slot — so the
             // `capacity` bound terminates the loop.
             let mut probe = Vec::new();
-            collect_vlen_slots(base_type, 0, capacity, &mut probe);
+            if !collect_vlen_slots(base_type, 0, capacity, &mut probe) {
+                return false;
+            }
             if probe.is_empty() {
-                return;
+                return true;
             }
             let count = dimensions
                 .iter()
                 .copied()
                 .fold(1u64, |a, b| a.saturating_mul(u64::from(b)));
+            // Every entry contributes at least one slot, so more entries than the
+            // element has room for cannot fit however the walk goes. Reject up
+            // front rather than materializing that many slots for the caller to
+            // discard: for a datatype whose declared size saturates, `capacity`
+            // runs to hundreds of millions, which is merely wasteful on a 64-bit
+            // target and an outright allocation failure on a 32-bit one.
+            if count > capacity as u64 {
+                return false;
+            }
+            let entries = usize::try_from(count).unwrap_or(usize::MAX);
             let stride = base_type.type_size() as usize;
-            for i in 0..count {
-                collect_vlen_slots(base_type, base + (i as usize) * stride, capacity, out);
+            for i in 0..entries {
+                let Some(at) = i.checked_mul(stride).and_then(|off| base.checked_add(off)) else {
+                    return false;
+                };
+                if !collect_vlen_slots(base_type, at, capacity, out) {
+                    return false;
+                }
                 if out.len() > capacity {
-                    return;
+                    return true;
                 }
             }
+            true
         }
         // An enumeration's base is an integer, and no other class can reach a
         // variable-length reference.
-        _ => {}
+        _ => true,
     }
 }
 
@@ -921,6 +960,20 @@ mod embedded_slot_tests {
         let dt = Datatype::Array {
             base_type: Box::new(vlen_string()),
             dimensions: vec![u32::MAX, u32::MAX],
+        };
+        assert_eq!(embedded_vlen_slots(&dt), None);
+    }
+
+    /// A member offset is read from the file as a `u64`, so it can name a
+    /// position no `usize` can address. Truncating it would land the slot
+    /// somewhere plausible *inside* the element, where the size check below would
+    /// wave it through and the rewrite would corrupt an unrelated field; the walk
+    /// has to refuse instead. On 64-bit the offset simply exceeds the element.
+    #[test]
+    fn a_member_offset_beyond_the_address_space_is_rejected() {
+        let dt = Datatype::Compound {
+            size: 40,
+            members: vec![member("s", u64::MAX - 8, vlen_string())],
         };
         assert_eq!(embedded_vlen_slots(&dt), None);
     }

--- a/tests/closure_reentrancy.rs
+++ b/tests/closure_reentrancy.rs
@@ -1,0 +1,207 @@
+//! Calling back into the same `File` from inside a builder closure must not
+//! deadlock (issue #200).
+//!
+//! The owned-handle write API takes `&self` plus interior mutability, so the
+//! session lives behind a `Mutex`. Holding that mutex across the user's closure
+//! made any read from inside it block forever on a lock the same thread already
+//! held — no error, no panic, no timeout. The deprecated `EditSession` took
+//! `&mut self`, so the same mistake was a borrow-check error; the owned API
+//! turned a compiler diagnostic into a lockup.
+//!
+//! Every test here runs the closure on a worker thread and fails on a timeout,
+//! so a regression reports a failure instead of hanging the suite forever.
+
+use hdf5_pure::{AttrValue, File, FileBuilder};
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+/// Run `body` on a worker thread, failing if it has not finished in time.
+///
+/// A plain call would hang the whole test binary on regression, which reads as
+/// a stuck CI job rather than a failing test.
+fn without_deadlocking(what: &str, body: impl FnOnce() + Send + 'static) {
+    let (tx, rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        body();
+        let _ = tx.send(());
+    });
+    match rx.recv_timeout(Duration::from_secs(20)) {
+        Ok(()) => handle.join().expect("worker panicked"),
+        // A panic in `body` drops the sender, which disconnects rather than
+        // times out. Re-raise it so an assertion failure reads as itself and
+        // only a genuine hang is reported as a deadlock.
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            std::panic::resume_unwind(handle.join().unwrap_err())
+        }
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            panic!("{what} deadlocked: the closure never returned")
+        }
+    }
+}
+
+fn seed(path: &std::path::Path) {
+    let mut b = FileBuilder::new();
+    b.create_dataset("existing").with_i32_data(&[1, 2, 3, 4]);
+    let grp = b.create_group("grp").finish();
+    b.add_group(grp);
+    b.write(path).unwrap();
+}
+
+/// The reproduction from the issue: reading the file from inside
+/// `create_dataset`'s closure.
+#[test]
+fn create_dataset_closure_may_read_the_same_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("reentrant_create.h5");
+    seed(&path);
+    let p = path.clone();
+
+    without_deadlocking("create_dataset", move || {
+        let file = File::open_rw(&p).unwrap();
+        file.root()
+            .create_dataset("derived", |b| {
+                // Every one of these reaches the mirror, which is exactly what
+                // used to block on the lock the closure was running under.
+                let root = file.root();
+                let existing = file.dataset("existing").unwrap();
+                let values = existing.read_i32().unwrap();
+                assert_eq!(values, vec![1, 2, 3, 4]);
+                assert!(root.datasets().unwrap().contains(&"existing".to_string()));
+                // The staged dataset's contents genuinely depend on the read —
+                // the case the issue calls out as natural to write.
+                let doubled: Vec<i32> = values.iter().map(|v| v * 2).collect();
+                b.with_i32_data(&doubled);
+            })
+            .unwrap();
+        file.commit().unwrap();
+    });
+
+    let f = File::open(&path).unwrap();
+    assert_eq!(
+        f.dataset("derived").unwrap().read_i32().unwrap(),
+        vec![2, 4, 6, 8]
+    );
+}
+
+/// The same for the group closure, including a nested one: the nested
+/// `StagedGroup` must record into the same buffer rather than re-enter the lock.
+#[test]
+fn create_group_with_closure_may_read_the_same_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("reentrant_group.h5");
+    seed(&path);
+    let p = path.clone();
+
+    without_deadlocking("create_group_with", move || {
+        let file = File::open_rw(&p).unwrap();
+        file.root()
+            .create_group_with("run2", |g| {
+                let n = file.dataset("existing").unwrap().read_i32().unwrap().len();
+                g.set_attr("source_len", AttrValue::I64(n as i64));
+                g.create_group_with("nested", |inner| {
+                    assert!(file.group("grp").is_ok());
+                    inner.set_attr("depth", AttrValue::I64(2));
+                    inner.create_dataset("leaf", |b| {
+                        b.with_i32_data(&[9, 9]);
+                    });
+                });
+            })
+            .unwrap();
+        file.commit().unwrap();
+    });
+
+    let f = File::open(&path).unwrap();
+    assert_eq!(
+        f.group("run2").unwrap().attrs().unwrap().get("source_len"),
+        Some(&AttrValue::I64(4))
+    );
+    assert_eq!(
+        f.group("run2/nested")
+            .unwrap()
+            .attrs()
+            .unwrap()
+            .get("depth"),
+        Some(&AttrValue::I64(2))
+    );
+    assert_eq!(
+        f.dataset("run2/nested/leaf").unwrap().read_i32().unwrap(),
+        vec![9, 9]
+    );
+}
+
+/// `Dataset::write_staged` and `append_staged` take closures over the same
+/// session, so they carried the same hazard.
+#[test]
+fn dataset_closures_may_read_the_same_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("reentrant_dataset.h5");
+    {
+        let mut b = FileBuilder::new();
+        b.create_dataset("fixed").with_i32_data(&[1, 2, 3, 4]);
+        b.create_dataset("growable")
+            .with_i32_data(&[10, 20])
+            .with_chunks(&[2])
+            .with_maxshape(&[u64::MAX]);
+        b.write(&path).unwrap();
+    }
+    let p = path.clone();
+
+    without_deadlocking("write_staged / append_staged", move || {
+        let file = File::open_rw(&p).unwrap();
+
+        let mut fixed = file.dataset("fixed").unwrap();
+        fixed
+            .write_staged(|b| {
+                let seen = file.dataset("growable").unwrap().read_i32().unwrap();
+                assert_eq!(seen, vec![10, 20]);
+                b.with_i32_data(&[5, 6, 7, 8]);
+            })
+            .unwrap();
+
+        let mut growable = file.dataset("growable").unwrap();
+        growable
+            .append_staged(|b| {
+                let seen = file.dataset("fixed").unwrap().read_i32().unwrap();
+                // The staged overwrite above is not committed yet, so the read
+                // sees the on-disk values — staged edits stay invisible until
+                // `commit`, exactly as they do outside a closure.
+                assert_eq!(seen, vec![1, 2, 3, 4]);
+                b.append(&[30i32, 40]);
+            })
+            .unwrap();
+
+        file.commit().unwrap();
+    });
+
+    let f = File::open(&path).unwrap();
+    assert_eq!(
+        f.dataset("fixed").unwrap().read_i32().unwrap(),
+        vec![5, 6, 7, 8]
+    );
+    assert_eq!(
+        f.dataset("growable").unwrap().read_i32().unwrap(),
+        vec![10, 20, 30, 40]
+    );
+}
+
+/// A read-only file must still be refused *before* the closure runs, so the
+/// error a caller sees does not depend on whether the fix reordered the work.
+#[test]
+fn a_read_only_file_is_refused_without_running_the_closure() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("read_only.h5");
+    seed(&path);
+
+    let file = File::open(&path).unwrap();
+    let mut ran = false;
+    let err = file
+        .root()
+        .create_dataset("nope", |b| {
+            ran = true;
+            b.with_i32_data(&[1]);
+        })
+        .unwrap_err();
+    assert!(matches!(err, hdf5_pure::Error::ReadOnly), "got {err:?}");
+    assert!(!ran, "the closure must not run on a read-only file");
+}

--- a/tests/closure_reentrancy.rs
+++ b/tests/closure_reentrancy.rs
@@ -205,3 +205,39 @@ fn a_read_only_file_is_refused_without_running_the_closure() {
     assert!(matches!(err, hdf5_pure::Error::ReadOnly), "got {err:?}");
     assert!(!ran, "the closure must not run on a read-only file");
 }
+
+/// The same property for the other reason a staged edit is refused: a `Dataset`
+/// reached by object reference has no resolvable path, so it cannot be edited.
+/// Every reason to refuse must be reported before the closure runs, not after —
+/// otherwise the caller's closure runs and its work is silently discarded.
+#[test]
+fn a_pathless_dataset_handle_is_refused_without_running_the_closure() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("refs.h5");
+    {
+        let mut b = FileBuilder::new();
+        b.create_dataset("target").with_i32_data(&[1, 2, 3]);
+        b.create_dataset("refs").with_path_references(&["target"]);
+        b.write(&path).unwrap();
+    }
+
+    let file = File::open_rw(&path).unwrap();
+    let refs = file.dataset("refs").unwrap();
+    let mut resolved = refs.dereference().unwrap();
+    let hdf5_pure::Object::Dataset(mut reached) = resolved.remove(0) else {
+        panic!("expected the reference to resolve to a dataset");
+    };
+
+    let mut ran = false;
+    let err = reached
+        .write_staged(|b| {
+            ran = true;
+            b.with_i32_data(&[9, 9, 9]);
+        })
+        .unwrap_err();
+    assert!(matches!(err, hdf5_pure::Error::ReadOnly), "got {err:?}");
+    assert!(
+        !ran,
+        "the closure must not run for a handle with no resolvable path"
+    );
+}

--- a/tests/repack_crosscheck.rs
+++ b/tests/repack_crosscheck.rs
@@ -708,3 +708,338 @@ fn c_sparse_chunked_lossy_repack_refused() {
     }
     assert!(!dst.exists(), "dst must not be created when repack refuses");
 }
+
+/// A compound whose members include a variable-length string stores a 16-byte
+/// global-heap reference *inside* each element. Copying those element bytes
+/// verbatim leaves the reference pointing at a collection in the source file's
+/// address space, which the destination never allocates (issue #201). Repack has
+/// to re-stage the payloads through the destination's own heap and rewrite the
+/// embedded references, exactly as it does for a top-level VL dataset.
+///
+/// The C library is the load-bearing reader here: this crate's own reader
+/// resolves the heap lazily and reads `read_raw` bytes without validating the
+/// embedded addresses, so a self-round-trip alone would not catch a stale one.
+#[test]
+fn repack_roundtrips_c_compound_with_vlen_string_member() {
+    use hdf5::types::VarLenUnicode;
+    use std::str::FromStr;
+
+    #[derive(hdf5::H5Type, Clone, Debug, PartialEq)]
+    #[repr(C)]
+    struct Labelled {
+        id: i32,
+        label: VarLenUnicode,
+    }
+
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("c_compound_vlen.h5");
+    let dst = dir.path().join("compound_vlen_repacked.h5");
+
+    let rows = [
+        "alpha",
+        "",
+        "gamma",
+        "δelta",
+        "a longer label than the rest",
+    ];
+    {
+        let file = hdf5::File::create(&src).unwrap();
+        let vals: Vec<Labelled> = rows
+            .iter()
+            .enumerate()
+            .map(|(i, s)| Labelled {
+                id: i as i32 * 10,
+                label: VarLenUnicode::from_str(s).unwrap(),
+            })
+            .collect();
+        file.new_dataset::<Labelled>()
+            .shape((rows.len(),))
+            .create("rows")
+            .unwrap()
+            .write(&vals)
+            .unwrap();
+        file.close().unwrap();
+    }
+
+    repack(&src, &dst, &RepackOptions::new()).unwrap();
+
+    // The datatype must stay a compound carrying a variable-length member, not
+    // be flattened or converted.
+    let f = File::open(&dst).unwrap();
+    let ds = f.dataset("rows").unwrap();
+    match ds.datatype().unwrap() {
+        hdf5_pure::Datatype::Compound { members, .. } => {
+            assert_eq!(members.len(), 2);
+            assert!(
+                matches!(
+                    members[1].datatype,
+                    hdf5_pure::Datatype::VariableLength { .. }
+                ),
+                "the label member must stay variable-length"
+            );
+        }
+        other => panic!("expected a compound datatype, got {other:?}"),
+    }
+
+    // The reference C library reads every row back — the interop proof that the
+    // embedded heap references name collections in the *destination*.
+    let c = hdf5::File::open(&dst).unwrap();
+    let cvals = c.dataset("rows").unwrap().read_raw::<Labelled>().unwrap();
+    assert_eq!(cvals.len(), rows.len());
+    for (i, row) in rows.iter().enumerate() {
+        assert_eq!(cvals[i].id, i as i32 * 10, "row {i} id differs");
+        assert_eq!(cvals[i].label.as_str(), *row, "row {i} label differs");
+    }
+}
+
+/// A compound can carry several variable-length members of different kinds, and
+/// each one's reference stores a *count* in the units of its own base type — bytes
+/// for a string, elements for a sequence. Re-staging has to keep those units
+/// straight per member, not per dataset.
+#[test]
+fn repack_roundtrips_c_compound_with_two_vlen_members() {
+    use hdf5::types::{VarLenArray, VarLenUnicode};
+    use std::str::FromStr;
+
+    #[derive(hdf5::H5Type, Clone, Debug)]
+    #[repr(C)]
+    struct Row {
+        label: VarLenUnicode,
+        id: i64,
+        samples: VarLenArray<i32>,
+    }
+
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("c_compound_two_vlen.h5");
+    let dst = dir.path().join("compound_two_vlen_repacked.h5");
+
+    let labels = ["first", "", "third"];
+    let samples: Vec<Vec<i32>> = vec![vec![1, 2, 3], vec![], vec![-9, 400_000]];
+    {
+        let file = hdf5::File::create(&src).unwrap();
+        let vals: Vec<Row> = labels
+            .iter()
+            .zip(&samples)
+            .enumerate()
+            .map(|(i, (l, s))| Row {
+                label: VarLenUnicode::from_str(l).unwrap(),
+                id: i as i64 - 1,
+                samples: VarLenArray::from_slice(s.as_slice()),
+            })
+            .collect();
+        file.new_dataset::<Row>()
+            .shape((labels.len(),))
+            .create("rows")
+            .unwrap()
+            .write(&vals)
+            .unwrap();
+        file.close().unwrap();
+    }
+
+    repack(&src, &dst, &RepackOptions::new()).unwrap();
+
+    let c = hdf5::File::open(&dst).unwrap();
+    let cvals = c.dataset("rows").unwrap().read_raw::<Row>().unwrap();
+    assert_eq!(cvals.len(), labels.len());
+    for i in 0..labels.len() {
+        assert_eq!(cvals[i].label.as_str(), labels[i], "row {i} label differs");
+        assert_eq!(cvals[i].id, i as i64 - 1, "row {i} id differs");
+        assert_eq!(
+            cvals[i].samples.as_slice(),
+            samples[i].as_slice(),
+            "row {i} samples differ"
+        );
+    }
+}
+
+/// A chunked compound with a variable-length member has to reach the re-staging
+/// path rather than the verbatim chunk copy: copying compressed chunks would
+/// carry the source's heap addresses through untouched, and the destination's own
+/// collections have to be placed before the chunks are encoded (issue #109).
+#[test]
+fn repack_roundtrips_c_chunked_compound_with_vlen_member() {
+    use hdf5::types::VarLenUnicode;
+    use std::str::FromStr;
+
+    #[derive(hdf5::H5Type, Clone, Debug)]
+    #[repr(C)]
+    struct Row {
+        id: i32,
+        label: VarLenUnicode,
+    }
+
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("c_chunked_compound_vlen.h5");
+    let dst = dir.path().join("chunked_compound_vlen_repacked.h5");
+
+    let n = 40usize;
+    let labels: Vec<String> = (0..n).map(|i| format!("row-{i}")).collect();
+    {
+        let file = hdf5::File::create(&src).unwrap();
+        let vals: Vec<Row> = labels
+            .iter()
+            .enumerate()
+            .map(|(i, l)| Row {
+                id: i as i32,
+                label: VarLenUnicode::from_str(l).unwrap(),
+            })
+            .collect();
+        file.new_dataset::<Row>()
+            .shape((n,))
+            .chunk((8,))
+            .create("rows")
+            .unwrap()
+            .write(&vals)
+            .unwrap();
+        file.close().unwrap();
+    }
+
+    repack(&src, &dst, &RepackOptions::new()).unwrap();
+
+    // Chunking must survive the rebuild, not be flattened to contiguous.
+    let f = File::open(&dst).unwrap();
+    assert!(
+        matches!(
+            f.dataset("rows").unwrap().layout().unwrap(),
+            hdf5_pure::Layout::Chunked { .. }
+        ),
+        "repacked dataset must stay chunked"
+    );
+
+    let c = hdf5::File::open(&dst).unwrap();
+    let cvals = c.dataset("rows").unwrap().read_raw::<Row>().unwrap();
+    assert_eq!(cvals.len(), n);
+    for i in 0..n {
+        assert_eq!(cvals[i].id, i as i32, "row {i} id differs");
+        assert_eq!(cvals[i].label.as_str(), labels[i], "row {i} label differs");
+    }
+}
+
+/// An object-header address embedded in a compound member goes stale on rewrite
+/// for the same reason a top-level one does: the destination puts the target
+/// object somewhere else. Copying the element bytes verbatim leaves a file whose
+/// fixed-size members read back correctly and whose references dereference into
+/// whatever now occupies that address — which is why this test dereferences
+/// rather than merely reading the rows.
+#[test]
+fn repack_roundtrips_c_compound_with_object_reference_member() {
+    use hdf5::{ObjectReference, ObjectReference1, ReferencedObject};
+
+    #[derive(hdf5::H5Type, Clone, Debug)]
+    #[repr(C)]
+    struct Row {
+        id: i32,
+        target: ObjectReference1,
+    }
+
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("c_compound_ref.h5");
+    let dst = dir.path().join("compound_ref_repacked.h5");
+
+    {
+        let file = hdf5::File::create(&src).unwrap();
+        file.new_dataset::<i32>()
+            .shape((3,))
+            .create("alpha")
+            .unwrap()
+            .write(&[1i32, 2, 3])
+            .unwrap();
+        let grp = file.create_group("grp").unwrap();
+        grp.new_dataset::<i32>()
+            .shape((2,))
+            .create("beta")
+            .unwrap()
+            .write(&[40i32, 50])
+            .unwrap();
+        let vals = vec![
+            Row {
+                id: 7,
+                target: ObjectReference1::create(&file, "alpha").unwrap(),
+            },
+            Row {
+                id: 8,
+                target: ObjectReference1::create(&file, "grp/beta").unwrap(),
+            },
+        ];
+        file.new_dataset::<Row>()
+            .shape((vals.len(),))
+            .create("rows")
+            .unwrap()
+            .write(&vals)
+            .unwrap();
+        file.close().unwrap();
+    }
+
+    repack(&src, &dst, &RepackOptions::new()).unwrap();
+
+    let c = hdf5::File::open(&dst).unwrap();
+    let cvals = c.dataset("rows").unwrap().read_raw::<Row>().unwrap();
+    assert_eq!(cvals.len(), 2);
+    assert_eq!(cvals[0].id, 7);
+    assert_eq!(cvals[1].id, 8);
+
+    // Each embedded reference must resolve to its own target's *new* address, and
+    // that target must still hold the right data.
+    let expected: [&[i32]; 2] = [&[1, 2, 3], &[40, 50]];
+    for (i, row) in cvals.iter().enumerate() {
+        match row.target.dereference(&c).unwrap() {
+            ReferencedObject::Dataset(ds) => assert_eq!(
+                ds.read_raw::<i32>().unwrap(),
+                expected[i],
+                "row {i} reference resolves to the wrong dataset"
+            ),
+            other => panic!("row {i}: expected a dataset, got {other:?}"),
+        }
+    }
+}
+
+/// The refusals that guard the top-level object-reference path have to guard the
+/// embedded one too: a reference into a dropped subtree cannot be rewritten to
+/// anything meaningful, so the repack must fail by name rather than emit a
+/// dangling address.
+#[test]
+fn repack_refuses_compound_reference_to_dropped_object() {
+    use hdf5::{ObjectReference, ObjectReference1};
+
+    #[derive(hdf5::H5Type, Clone, Debug)]
+    #[repr(C)]
+    struct Row {
+        id: i32,
+        target: ObjectReference1,
+    }
+
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("c_compound_ref_dropped.h5");
+    let dst = dir.path().join("compound_ref_dropped_repacked.h5");
+
+    {
+        let file = hdf5::File::create(&src).unwrap();
+        file.new_dataset::<i32>()
+            .shape((2,))
+            .create("doomed")
+            .unwrap()
+            .write(&[1i32, 2])
+            .unwrap();
+        let vals = vec![Row {
+            id: 1,
+            target: ObjectReference1::create(&file, "doomed").unwrap(),
+        }];
+        file.new_dataset::<Row>()
+            .shape((1,))
+            .create("rows")
+            .unwrap()
+            .write(&vals)
+            .unwrap();
+        file.close().unwrap();
+    }
+
+    let err = repack(&src, &dst, &RepackOptions::new().drop_path("doomed")).unwrap_err();
+    match err {
+        hdf5_pure::Error::RepackUnsupported(msg) => assert!(
+            msg.contains("rows") && msg.contains("doomed"),
+            "error should name the dataset and its dropped target: {msg}"
+        ),
+        other => panic!("expected RepackUnsupported, got {other:?}"),
+    }
+    assert!(!dst.exists(), "dst must not be created when repack refuses");
+}

--- a/tests/repack_crosscheck.rs
+++ b/tests/repack_crosscheck.rs
@@ -1043,3 +1043,180 @@ fn repack_refuses_compound_reference_to_dropped_object() {
     }
     assert!(!dst.exists(), "dst must not be created when repack refuses");
 }
+
+/// A compound can carry a variable-length member *and* an object-reference
+/// member. Both kinds of embedded address go stale on rewrite, so rewriting only
+/// the first kind found leaves the other pointing into the source file — the
+/// original defect surviving for the one shape that reaches both paths.
+///
+/// The reference is dereferenced rather than merely read back, because a stale
+/// address reads as a perfectly ordinary 8 bytes.
+#[test]
+fn repack_roundtrips_c_compound_with_both_vlen_and_reference_members() {
+    use hdf5::types::VarLenUnicode;
+    use hdf5::{ObjectReference, ObjectReference1, ReferencedObject};
+    use std::str::FromStr;
+
+    #[derive(hdf5::H5Type, Clone, Debug)]
+    #[repr(C)]
+    struct Row {
+        label: VarLenUnicode,
+        id: i32,
+        target: ObjectReference1,
+    }
+
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("c_compound_both.h5");
+    let dst = dir.path().join("compound_both_repacked.h5");
+
+    let labels = ["alpha", "", "gamma"];
+    {
+        let file = hdf5::File::create(&src).unwrap();
+        file.new_dataset::<i32>()
+            .shape((3,))
+            .create("pointee")
+            .unwrap()
+            .write(&[11i32, 22, 33])
+            .unwrap();
+        let vals: Vec<Row> = labels
+            .iter()
+            .enumerate()
+            .map(|(i, l)| Row {
+                label: VarLenUnicode::from_str(l).unwrap(),
+                id: i as i32,
+                target: ObjectReference1::create(&file, "pointee").unwrap(),
+            })
+            .collect();
+        file.new_dataset::<Row>()
+            .shape((labels.len(),))
+            .create("rows")
+            .unwrap()
+            .write(&vals)
+            .unwrap();
+        file.close().unwrap();
+    }
+
+    repack(&src, &dst, &RepackOptions::new()).unwrap();
+
+    let c = hdf5::File::open(&dst).unwrap();
+    let cvals = c.dataset("rows").unwrap().read_raw::<Row>().unwrap();
+    assert_eq!(cvals.len(), labels.len());
+    for (i, row) in cvals.iter().enumerate() {
+        assert_eq!(row.label.as_str(), labels[i], "row {i} label differs");
+        assert_eq!(row.id, i as i32, "row {i} id differs");
+        match row.target.dereference(&c).unwrap() {
+            ReferencedObject::Dataset(ds) => assert_eq!(
+                ds.read_raw::<i32>().unwrap(),
+                vec![11, 22, 33],
+                "row {i} reference resolves to the wrong data"
+            ),
+            other => panic!("row {i}: expected a dataset, got {other:?}"),
+        }
+    }
+}
+
+/// The object-reference refusals must not be reachable-around by adding a
+/// variable-length member: a reference into a dropped subtree cannot be rewritten
+/// to anything meaningful whatever else the compound carries.
+#[test]
+fn repack_refuses_dropped_target_in_a_compound_that_also_has_a_vlen_member() {
+    use hdf5::types::VarLenUnicode;
+    use hdf5::{ObjectReference, ObjectReference1};
+    use std::str::FromStr;
+
+    #[derive(hdf5::H5Type, Clone, Debug)]
+    #[repr(C)]
+    struct Row {
+        label: VarLenUnicode,
+        target: ObjectReference1,
+    }
+
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("c_both_dropped.h5");
+    let dst = dir.path().join("both_dropped_repacked.h5");
+
+    {
+        let file = hdf5::File::create(&src).unwrap();
+        file.new_dataset::<i32>()
+            .shape((2,))
+            .create("doomed")
+            .unwrap()
+            .write(&[1i32, 2])
+            .unwrap();
+        let vals = vec![Row {
+            label: VarLenUnicode::from_str("x").unwrap(),
+            target: ObjectReference1::create(&file, "doomed").unwrap(),
+        }];
+        file.new_dataset::<Row>()
+            .shape((1,))
+            .create("rows")
+            .unwrap()
+            .write(&vals)
+            .unwrap();
+        file.close().unwrap();
+    }
+
+    let err = repack(&src, &dst, &RepackOptions::new().drop_path("doomed")).unwrap_err();
+    match err {
+        hdf5_pure::Error::RepackUnsupported(msg) => assert!(
+            msg.contains("rows") && msg.contains("doomed"),
+            "error should name the dataset and its dropped target: {msg}"
+        ),
+        other => panic!("expected RepackUnsupported, got {other:?}"),
+    }
+    assert!(!dst.exists(), "dst must not be created when repack refuses");
+}
+
+/// Likewise the chunked refusal: an object address inside a compressed chunk
+/// would need rewriting in place, and a variable-length member alongside it does
+/// not make that possible.
+#[test]
+fn repack_refuses_chunked_compound_with_both_vlen_and_reference_members() {
+    use hdf5::types::VarLenUnicode;
+    use hdf5::{ObjectReference, ObjectReference1};
+    use std::str::FromStr;
+
+    #[derive(hdf5::H5Type, Clone, Debug)]
+    #[repr(C)]
+    struct Row {
+        label: VarLenUnicode,
+        target: ObjectReference1,
+    }
+
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("c_both_chunked.h5");
+    let dst = dir.path().join("both_chunked_repacked.h5");
+
+    {
+        let file = hdf5::File::create(&src).unwrap();
+        file.new_dataset::<i32>()
+            .shape((2,))
+            .create("pointee")
+            .unwrap()
+            .write(&[1i32, 2])
+            .unwrap();
+        let vals: Vec<Row> = (0..8)
+            .map(|i| Row {
+                label: VarLenUnicode::from_str(&format!("r{i}")).unwrap(),
+                target: ObjectReference1::create(&file, "pointee").unwrap(),
+            })
+            .collect();
+        file.new_dataset::<Row>()
+            .shape((8,))
+            .chunk((4,))
+            .create("rows")
+            .unwrap()
+            .write(&vals)
+            .unwrap();
+        file.close().unwrap();
+    }
+
+    let err = repack(&src, &dst, &RepackOptions::new()).unwrap_err();
+    match err {
+        hdf5_pure::Error::RepackUnsupported(msg) => assert!(
+            msg.contains("rows") && msg.contains("object-reference"),
+            "error should name the dataset and the reason: {msg}"
+        ),
+        other => panic!("expected RepackUnsupported, got {other:?}"),
+    }
+}


### PR DESCRIPTION
Closes #201, closes #200, closes #202.

Three defects filed against 0.24.0, taken together because they are small enough to review as one and because the release is waiting on them. Two are silent-failure bugs; the third restores test coverage that a refactor dropped.

## #201 — `repack` corrupts a datatype containing a reference

`repack` reported success on a compound with a variable-length or object-reference member while writing a file the reference C library could not read. `check_datatype` recursed into the members and accepted them, but `emit_dataset` had no branch for a compound, so it fell through to the verbatim/re-encode path. That path moves element bytes unchanged, and for those members the bytes *are* the addresses: the destination inherited references into the source file's global heap and object headers, which it never allocates.

This crate read its own output back without complaint, so a round-trip test passed and nothing looked wrong from inside the crate. That made it data loss rather than a compatibility gap: clean exit codes at every step, discovered later from a different tool, possibly after the source is gone.

Investigating the variable-length case turned up its twin. An **object reference** embedded in a compound corrupts identically — `repack` returns `Ok`, the C library reads the row fine, then dereferences into garbage (`bad object header version number`). Same shape, also shipped in 0.24.0. Both are fixed here rather than one half of the family.

The core change is that the writer's two patch mechanisms now locate references by **explicit byte offset** instead of an implied stride, so a reference inside a larger element is rewritten in place while the fixed-size bytes around it are carried through untouched. `embedded_vlen_slots` / `embedded_reference_slots` walk a datatype for the references it reaches through compound members and array entries, recursing through nesting.

One detail worth flagging for review: for variable-length members the source's `length` field is kept verbatim and only the address and object index are rewritten. That field counts *bytes* for a string member and *base-type elements* for a sequence member, so a compound carrying both would be wrong if the two were collapsed. Not hypothetical — collapsing the per-member width fails the two-VL-member test and nothing else.

The refusals guarding the top-level object-reference path (chunked, resizable, userblock, dropped or dangling target) guard the embedded one too, sharing one resolver.

## #200 — calling into the same `File` from a builder closure deadlocks

```rust
let f = File::open_rw(&path)?;
f.root().create_dataset("d2", |b| {
    b.with_i32_data(&[1, 2, 3]);
    let _ = f.root();          // hangs here, forever
})?;
```

`with_child_session` locked the `Mutex<WriteEngine>` and then ran the user's closure while still holding it. Every mirror-backed read takes that same mutex, so re-entry blocked on a lock the calling thread already held.

Easy to hit and hard to diagnose. The deprecated `EditSession` took `&mut self`, so reaching for the file inside a closure was a borrow-check error; the owned-handle API is `&self` plus interior mutability, which turned a compiler diagnostic into a lockup. Staging a dataset whose contents depend on something already in the file reads as ordinary code.

Fixed with option 1 from the issue: the closures configure a builder that is not attached to the engine, and the lock is taken only to record the finished result. `StagedGroup` records into a `Vec<StagedOp>` replayed in call order, so a group is still staged before its own attributes and children.

Two deliberate extensions beyond the four APIs the issue named:

- `Dataset::write` is included, because `H5Element::write_into` is user-implementable and so was user code under the lock too.
- The engine's three `&mut`-handout methods are **removed**, replaced by `stage_created_dataset` / `stage_dataset_write` / `stage_dataset_append`, which take a finished builder. Lending a borrow into the engine was the root cause, so the pattern is gone rather than left unused for someone to reach for again.

`FileInner::check_staged_writable` gates read-only, bounded, and sealed files without locking, so those errors still surface before the closure runs rather than after. A closure reads the file as it was before the call, since staged edits resolve only on commit — the same rule that already applied outside one.

## #202 — restored crash-consistency tests

Removing `SwmrWriter` and `AppendWriter` in #197 deleted six crash-consistency tests with them. They tested the deleted wrappers, but the scenarios were never wrapper-specific: the surviving owned path drives the same shared `apply_ea_append` engine. What survived on `main` was pure-reader only, the weakest of the three things the deleted set covered.

The bar applied here was "does this catch something nothing else catches?", since a restored test that detects nothing is worse than no test. Each one earns its place:

| Restored test | Defect it alone catches |
| --- | --- |
| `..._c_library_reads_prefix` | Dropping the phase-3 end-of-file patch. **All four pure-reader crash tests still pass**; only this one fails (`addr overflow, addr = 1091, eoa = 1091`) |
| `..._paged_prefix` | Page-init bit written LSB-first instead of MSB-first. Fails this and nothing else in the 566-test lib suite |
| `..._recover_and_reappend_after_phase3_crash` | Seeding the chunk count from the on-disk EA header instead of the committed dimension |

The first row is the issue's central claim, demonstrated: this crate's reader bounds chunk reads by `min(EA count, dimension)` and so tolerates states the C library rejects. A regression readable here and unreadable in C is exactly what SWMR exists to prevent.

The C-library test covers the partial-tail layouts too, restoring the sixth deleted test; the pure-reader partial-tail case was already covered by the surviving `edit` / `bounded` harnesses. No production code changed for this part.

## Verification

Every new test is mutation-verified: the code is broken deliberately and the test watched to fail, then restored. The `#200` tests run each closure on a worker thread with a 20s watchdog, so reinstating the lock reproduces the original hang and reports it as a failure rather than a stuck CI job.

Full suite, `clippy -D warnings`, rustdoc, `no_std`, and `fmt` are green. No public API change; the manifest already reads 0.25.0 from the earlier breaking changes this cycle.

## Two findings left alone

- **`Dataset::visit_vlen_strings` still runs its callback under the engine lock** (`src/reader.rs`), with the same deadlock consequence as #200. It is documented rather than silent, and the fix is a different shape — buffering defeats the streaming purpose the method exists for. Outside #200's scope.
- **`docs/guide/repack.md` contradicts itself on filters.** The "Lossless filters only" admonition and the Filters table row both predate the verbatim chunk-copy path, which the module docs correctly describe as preserving every filter byte-exact, including lossy ones. Pre-existing and unrelated.

A follow-up worth noting rather than filing blind: the roll-forward invariant no longer lives where its comment sits. `Located::num_chunks` is not load-bearing for planning any more, so mutating it alone changes nothing; the property is actually held by `n_full = current_dim / chunk_elems` in the planner. The comment in `src/chunk_index_inplace.rs` describes a defunct mechanism.
