### PR TITLE
Update the reference-library dev-dependency to hdf5-metno 0.14 (#207)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,7 +288,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -389,9 +389,9 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hdf5-metno"
-version = "0.12.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5edd95aa03aba1a5072096ec656ed006d2d40a8e9e9f8267e61e0dd2fccabb0"
+checksum = "effaf90242ed59abcbed70e156cb1830dd29fad918990cdf3413fd25934b999c"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -400,20 +400,19 @@ dependencies = [
  "hdf5-metno-types",
  "libc",
  "ndarray",
- "paste",
+ "pastey",
 ]
 
 [[package]]
 name = "hdf5-metno-derive"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f5b353c797530e868881b12c1c307c0994cd3400195391d7021e6e6db02da6"
+checksum = "2368b6d71ab96708b91912af3a93f7b8be9b1ecfca082f2c0868ce327a1fe926"
 dependencies = [
  "proc-macro-crate",
- "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -428,9 +427,9 @@ dependencies = [
 
 [[package]]
 name = "hdf5-metno-sys"
-version = "0.11.2"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca8d73eed5f921d5fab0be7d3d49cae296d9b963ad555a86e5b0b591ec836b9"
+checksum = "ff52250062cf9ecd180ae4eccbb5e00b1f89ee44cb48046d1339c99f5fb6c169"
 dependencies = [
  "hdf5-metno-src",
  "libc",
@@ -446,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "hdf5-metno-types"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c994ebf205f9128cb490f01e1e41742842b7171b878caadb1a44abdc6a535a88"
+checksum = "b29041af7e5a0b5698d6607c5c8b67b5dfcab40eb89c2fcfec54bbf0c031b425"
 dependencies = [
  "ascii",
  "cfg-if",
@@ -511,7 +510,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -698,10 +697,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
+name = "pastey"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pkg-config"
@@ -740,7 +739,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -750,27 +749,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
-]
-
-[[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
 ]
 
 [[package]]
@@ -940,7 +918,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1003,7 +981,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1060,6 +1038,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,7 +1058,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1225,7 +1214,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1236,85 +1225,12 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -1327,13 +1243,13 @@ dependencies = [
 
 [[package]]
 name = "winreg"
-version = "0.55.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
+checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
  "serde",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1366,7 +1282,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -1382,7 +1298,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -1441,7 +1357,7 @@ checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ criterion = { version = "0.5", default-features = false }
 # crosscheck test files carry
 # the matching `#![cfg(not(target_pointer_width = "32"))]` gate.
 [target.'cfg(not(target_pointer_width = "32"))'.dev-dependencies]
-hdf5 = { package = "hdf5-metno", version = "0.12", features = ["static", "zlib"] }
+hdf5 = { package = "hdf5-metno", version = "0.14", features = ["static", "zlib"] }
 
 [[example]]
 name = "matlab_fixtures"

--- a/tests/c_absence_predicate.rs
+++ b/tests/c_absence_predicate.rs
@@ -1,0 +1,150 @@
+// Crosschecks link the reference HDF5 C library (the `hdf5-metno` dev-dependency),
+// gated to 64-bit-pointer targets.
+#![cfg(not(target_pointer_width = "32"))]
+//! Guards the discriminating power of [`common::assert_c_absent`], which the
+//! delete crosschecks use to prove a removed object is *absent* rather than
+//! merely unreachable.
+//!
+//! Without this file the helper could silently decay. Its conditions are tuned
+//! to which minor error codes the reference C library reports, and a libhdf5
+//! upgrade can change that: if a future version stopped reporting a load
+//! failure when metadata is damaged, the helper would keep passing while no
+//! longer distinguishing damage from absence, and every delete crosscheck would
+//! quietly weaken back to `is_err()`.
+//!
+//! So this asserts both directions, and asserts that the extra conditions are
+//! still doing work.
+//!
+//! Every call goes through the safe `hdf5-metno` API, which serializes its own C
+//! calls through an internal lock, so no extra guard is needed.
+
+use hdf5_pure::FileBuilder;
+use tempfile::tempdir;
+
+mod common;
+use common::{assert_c_absent, c_reports_absent};
+
+/// A file whose bytes are mostly metadata: 40 two-element datasets, so a
+/// corruption sweep lands on object headers and link tables rather than on raw
+/// data that nothing has to parse.
+fn metadata_heavy(path: &std::path::Path) {
+    let mut b = FileBuilder::new();
+    for i in 0..40i32 {
+        b.create_dataset(&format!("d{i}")).with_data(&[i, 7]);
+    }
+    b.write(path).unwrap();
+}
+
+/// The helper must accept a genuine absence in every shape a delete test can
+/// produce. A false negative here is a flaky crosscheck.
+#[test]
+fn genuine_absences_are_accepted() {
+    let dir = tempdir().unwrap();
+
+    // A compact group (<= 8 links, symbol-table/compact storage).
+    let compact = dir.path().join("compact.h5");
+    let mut b = FileBuilder::new();
+    for i in 0..3i32 {
+        b.create_dataset(&format!("c{i}")).with_data(&[i]);
+    }
+    b.write(&compact).unwrap();
+    {
+        let c = hdf5::File::open(&compact).unwrap();
+        assert_c_absent(&c.dataset("nope").unwrap_err(), "missing dataset");
+        assert_c_absent(&c.group("nope").unwrap_err(), "missing group");
+        assert_c_absent(
+            &c.dataset("c0").unwrap().attr("nope").unwrap_err(),
+            "missing attribute",
+        );
+    }
+
+    // A dense group (40 links).
+    let dense = dir.path().join("dense.h5");
+    metadata_heavy(&dense);
+    {
+        let c = hdf5::File::open(&dense).unwrap();
+        assert_c_absent(&c.dataset("nope").unwrap_err(), "missing dataset (dense)");
+    }
+
+    // Absence inside a subgroup, so traversal crosses a link first.
+    let nested = dir.path().join("nested.h5");
+    let mut b = FileBuilder::new();
+    let mut g = b.create_group("sub");
+    g.create_dataset("inner").with_data(&[1i32]);
+    let finished = g.finish();
+    b.add_group(finished);
+    b.write(&nested).unwrap();
+    {
+        let c = hdf5::File::open(&nested).unwrap();
+        assert_eq!(
+            c.dataset("sub/inner").unwrap().read_raw::<i32>().unwrap(),
+            vec![1]
+        );
+        assert_c_absent(&c.dataset("sub/nope").unwrap_err(), "missing in subgroup");
+    }
+}
+
+/// Corrupt a metadata-heavy file at every offset and several widths, then ask
+/// for datasets that *do* exist. The helper must reject every resulting failure:
+/// damage is not absence.
+///
+/// The second assertion is the one that keeps this test honest. A damaged link
+/// table reports `H5E_NOTFOUND` just as a missing link does, so if the bare code
+/// check ever stops producing false accepts, the helper's extra conditions have
+/// become untestable here and this file no longer proves anything.
+#[test]
+fn corruption_is_never_mistaken_for_absence() {
+    let dir = tempdir().unwrap();
+    let good = dir.path().join("good.h5");
+    metadata_heavy(&good);
+    let baseline = std::fs::read(&good).unwrap();
+
+    let mut damaged = 0;
+    let mut accepted_by_bare_code = 0;
+
+    // Past the superblock, since rewriting it is a different failure class the
+    // delete crosschecks never produce.
+    for width in [1usize, 4, 8, 32] {
+        for at in (96..baseline.len()).step_by(16) {
+            let mut bytes = baseline.clone();
+            for i in 0..width {
+                if at + i < bytes.len() {
+                    bytes[at + i] ^= 0xFF;
+                }
+            }
+            let path = dir.path().join(format!("corrupt_{width}_{at}.h5"));
+            std::fs::write(&path, &bytes).unwrap();
+
+            let failure = match hdf5::File::open(&path) {
+                Err(e) => Some(e),
+                Ok(c) => (0..40).find_map(|i| match c.dataset(&format!("d{i}")) {
+                    Ok(ds) => ds.read_raw::<i32>().err(),
+                    Err(e) => Some(e),
+                }),
+            };
+
+            let Some(err) = failure else { continue };
+            damaged += 1;
+            if err.contains_minor(hdf5::MinorErrorCode::NotFound) {
+                accepted_by_bare_code += 1;
+            }
+            assert!(
+                !c_reports_absent(&err),
+                "corrupting {width} byte(s) at offset {at} produced a failure the \
+                 absence helper accepted, so it cannot tell damage from absence: {err}"
+            );
+        }
+    }
+
+    assert!(
+        damaged > 100,
+        "the sweep must actually break the file to prove anything (only {damaged} \
+         of the corruptions were detectable)"
+    );
+    assert!(
+        accepted_by_bare_code > 0,
+        "no corruption reported H5E_NOTFOUND, so this sweep no longer exercises the \
+         helper's extra conditions — either the sweep or the helper needs revisiting \
+         ({damaged} corruptions were detectable)"
+    );
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,86 @@
+//! Helpers shared by the crosscheck tests. Not a test target itself (Cargo only
+//! builds `tests/*.rs`), so it is compiled into each binary that declares
+//! `mod common;`.
+//!
+//! Every item here touches the reference C library, so including files must
+//! carry the `#![cfg(not(target_pointer_width = "32"))]` gate the crosschecks
+//! use.
+#![allow(dead_code)]
+
+use hdf5::MinorErrorCode;
+
+/// Minor codes that mean the C library failed to *read* a metadata block, as
+/// opposed to reading it successfully and finding nothing.
+const LOAD_FAILURES: [MinorErrorCode; 6] = [
+    MinorErrorCode::CantLoad,
+    MinorErrorCode::ReadError,
+    MinorErrorCode::CantProtect,
+    MinorErrorCode::CantUnprotect,
+    MinorErrorCode::CantGet,
+    MinorErrorCode::CantDecode,
+];
+
+/// Assert that `err` is the C library reporting `what` **absent** from a file it
+/// could otherwise traverse — not merely failing for some unrelated reason.
+///
+/// This is the assertion a delete test wants, and `is_err()` is not it: a file
+/// so damaged the C library cannot walk the group at all also fails, so
+/// `is_err()` passes on the corruption a delete was supposed to avoid. That is
+/// the [#201] failure mode — a write path returning `Ok` on a file the C library
+/// cannot read.
+///
+/// `H5E_NOTFOUND` alone is not it either. A damaged link table reports
+/// `NotFound` too, because an unreadable index and a missing link are
+/// indistinguishable at the traversal layer. Sweeping single-byte through
+/// 32-byte corruptions across every metadata offset of a 40-dataset file, 885
+/// produced a detectable failure and **176 of those carried `NotFound`**.
+///
+/// What separates the two is the metadata cache: a genuine absence reads every
+/// block it needs and finds no matching link, so it never reports a load or
+/// decode failure. Adding that conjunction took the same sweep from 176 false
+/// accepts to zero, while still accepting a genuine absence in a compact group,
+/// a dense group, a subgroup, a missing group, and a missing attribute.
+///
+/// `tests/c_absence_predicate.rs` guards that this stays able to tell the two
+/// apart; read it before changing either condition.
+///
+/// [#201]: https://github.com/stephenberry/hdf5-pure/issues/201
+#[track_caller]
+pub fn assert_c_absent(err: &hdf5::Error, what: &str) {
+    if let Some(reason) = not_absent_because(err) {
+        let stack: Vec<String> = match err.stack() {
+            Some(s) => s.minor_codes().map(|c| format!("{c:?}")).collect(),
+            None => vec!["<no HDF5 error stack>".to_string()],
+        };
+        panic!("`{what}` {reason}: {err}\n  minor codes: {stack:?}");
+    }
+}
+
+/// Whether the C library reports a genuine absence, as a `bool`.
+///
+/// This and [`assert_c_absent`] must share one implementation, or the guard test
+/// in `tests/c_absence_predicate.rs` would be measuring a copy of the predicate
+/// rather than the one the delete crosschecks actually rely on.
+pub fn c_reports_absent(err: &hdf5::Error) -> bool {
+    not_absent_because(err).is_none()
+}
+
+/// `None` when `err` is a genuine absence, otherwise why it is not.
+fn not_absent_because(err: &hdf5::Error) -> Option<String> {
+    if !err.contains_minor(MinorErrorCode::NotFound) {
+        return Some(
+            "was expected to be absent, but the C library did not report it \
+                     as not found"
+                .to_string(),
+        );
+    }
+    for code in LOAD_FAILURES {
+        if err.contains_minor(code) {
+            return Some(format!(
+                "is reported missing, but the C library also failed to read metadata \
+                 ({code:?}) — that is damage, not absence"
+            ));
+        }
+    }
+    None
+}

--- a/tests/edit_append_inplace_crosscheck.rs
+++ b/tests/edit_append_inplace_crosscheck.rs
@@ -18,6 +18,9 @@ use hdf5::file::LibraryVersion;
 use hdf5_pure::{AttrValue, Error, File};
 use tempfile::tempdir;
 
+mod common;
+use common::assert_c_absent;
+
 /// Create a rank-1 unlimited (Extensible-Array indexed) i32 dataset `name` with the
 /// C library under the latest format, seeded with `0..n`, chunk length `chunk`.
 fn c_create_unlimited(path: &std::path::Path, name: &str, n: i32, chunk: usize) {
@@ -321,7 +324,7 @@ fn combined_mixed_edits_c_readable() {
         .unwrap();
     assert_eq!(checked, 1);
     assert!(c.group("run").is_ok(), "created group missing");
-    assert!(c.group("old").is_err(), "deleted group still present");
+    assert_c_absent(&c.group("old").unwrap_err(), "old");
     c.close().unwrap();
 
     // Pure reader agrees on the grown dataset.

--- a/tests/edit_crosscheck.rs
+++ b/tests/edit_crosscheck.rs
@@ -19,6 +19,9 @@ use hdf5::file::LibraryVersion;
 use hdf5_pure::{AttrValue, File, FileBuilder, ScaleOffset};
 use tempfile::tempdir;
 
+mod common;
+use common::assert_c_absent;
+
 /// Stage an add, an add-into-a-group, a delete, and a copy — the full op set.
 fn stage_edits(session: &File) {
     session
@@ -85,10 +88,7 @@ fn assert_edits_applied(path: &std::path::Path) {
         c.dataset("grp/gamma").unwrap().read_raw::<i32>().unwrap(),
         vec![1, 2, 3]
     );
-    assert!(
-        c.dataset("doomed").is_err(),
-        "deleted dataset still present (C library)"
-    );
+    assert_c_absent(&c.dataset("doomed").unwrap_err(), "doomed");
 }
 
 /// Write the starter file (two root datasets + a group with a dataset) with the
@@ -308,7 +308,7 @@ fn c_v0_symboltable_file_edited_then_read_by_c_library() {
         c.dataset("grp/gamma").unwrap().read_raw::<i32>().unwrap(),
         vec![1, 2, 3]
     );
-    assert!(c.dataset("doomed").is_err());
+    assert_c_absent(&c.dataset("doomed").unwrap_err(), "doomed");
 }
 
 #[test]
@@ -402,10 +402,7 @@ fn c_library_reads_group_attributes_edited_in_place() {
     let added: i64 = grp.attr("added").unwrap().read_scalar().unwrap();
     assert_eq!(count, 2);
     assert_eq!(added, 3);
-    assert!(
-        grp.attr("drop").is_err(),
-        "removed group attribute still present"
-    );
+    assert_c_absent(&grp.attr("drop").unwrap_err(), "grp/@drop");
     let tag: i64 = c
         .group("new_grp")
         .unwrap()
@@ -455,10 +452,7 @@ fn free_space_reuse_and_truncation_stay_c_readable() {
 
     // The reference C library reads the shrunken file and the survivors intact.
     let c = hdf5::File::open(&path).unwrap();
-    assert!(
-        c.dataset("bulk").is_err(),
-        "deleted dataset still present (C)"
-    );
+    assert_c_absent(&c.dataset("bulk").unwrap_err(), "bulk");
     assert_eq!(
         c.dataset("alpha").unwrap().read_raw::<f64>().unwrap(),
         vec![1.0, 2.0, 3.0]
@@ -683,10 +677,7 @@ fn deleting_chunked_datasets_in_place_stays_c_readable() {
 
     // The reference C library reads the reclaimed file too.
     let c = hdf5::File::open(&path).unwrap();
-    assert!(
-        c.dataset("c_chunked").is_err(),
-        "deleted chunked dataset still present (C)"
-    );
+    assert_c_absent(&c.dataset("c_chunked").unwrap_err(), "c_chunked");
     assert_eq!(
         c.dataset("keep").unwrap().read_raw::<f64>().unwrap(),
         vec![1.0, 2.0, 3.0]
@@ -1091,7 +1082,7 @@ fn deleting_one_of_several_hard_links_keeps_the_survivor() {
     );
 
     let c = hdf5::File::open(&path).unwrap();
-    assert!(c.dataset("chunked_orig").is_err());
+    assert_c_absent(&c.dataset("chunked_orig").unwrap_err(), "chunked_orig");
     assert_eq!(
         c.dataset("chunked_alias")
             .unwrap()

--- a/tests/edit_userblock_crosscheck.rs
+++ b/tests/edit_userblock_crosscheck.rs
@@ -13,6 +13,9 @@ use hdf5::file::LibraryVersion;
 use hdf5_pure::{File, FileBuilder};
 use tempfile::tempdir;
 
+mod common;
+use common::assert_c_absent;
+
 const UB: u64 = 512;
 
 /// Create a userblock file with the reference C library. The closure adds
@@ -428,8 +431,8 @@ fn userblock_delete_then_reuse_read_by_c_library() {
         c.dataset("keep").unwrap().read_raw::<f64>().unwrap(),
         vec![10.0, 20.0, 30.0]
     );
-    assert!(c.dataset("doomed").is_err());
-    assert!(c.dataset("c").is_err());
+    assert_c_absent(&c.dataset("doomed").unwrap_err(), "doomed");
+    assert_c_absent(&c.dataset("c").unwrap_err(), "c");
 }
 
 #[test]

--- a/tests/file_space_crosscheck.rs
+++ b/tests/file_space_crosscheck.rs
@@ -12,6 +12,9 @@ use hdf5_pure::{File, FileBuilder, FileSpaceStrategy};
 use std::sync::{Mutex, MutexGuard};
 use tempfile::tempdir;
 
+mod common;
+use common::assert_c_absent;
+
 // The reference free-space query, resolved at link time from the statically
 // linked libhdf5. Returns the total free space the C library tracks for the open
 // file, which it can only report by loading and parsing the on-disk
@@ -200,7 +203,7 @@ fn c_library_reads_our_persisted_free_space() {
         f.dataset("c").unwrap().read_raw::<i32>().unwrap(),
         vec![3; 100]
     );
-    assert!(f.dataset("big").is_err(), "the deleted dataset is gone");
+    assert_c_absent(&f.dataset("big").unwrap_err(), "big");
 
     // Loading the managers requires parsing our FSHD/FSSE blocks; the C library
     // reports at least the freed dataset's storage as free space.

--- a/tests/repack_crosscheck.rs
+++ b/tests/repack_crosscheck.rs
@@ -10,6 +10,9 @@
 use hdf5_pure::{File, RepackOptions, repack};
 use tempfile::tempdir;
 
+mod common;
+use common::assert_c_absent;
+
 #[test]
 fn c_file_repacked_then_read_by_c_library() {
     let dir = tempdir().unwrap();
@@ -66,10 +69,7 @@ fn c_file_repacked_then_read_by_c_library() {
         c.dataset("grp/beta").unwrap().read_raw::<i32>().unwrap(),
         vec![10, 20, 30, 40]
     );
-    assert!(
-        c.dataset("doomed").is_err(),
-        "dropped dataset still present (C library)"
-    );
+    assert_c_absent(&c.dataset("doomed").unwrap_err(), "doomed");
 }
 
 #[test]


### PR DESCRIPTION
Closes #207.

Moves the `hdf5-metno` dev-dependency from `0.12` to `0.14.0`, and spends the new error-code plumbing on the place this suite was weakest.

## The bump

`hdf5-metno` 0.12.3 -> 0.14.0, `hdf5-metno-sys` 0.11.2 -> 0.12.1, `hdf5-metno-types` 0.11.0 -> 0.11.1, `hdf5-metno-derive` 0.10.0 -> 0.10.2. All 28 crosscheck files compiled unchanged across both minor bumps.

Two things that could have bitten did not. 0.13.0's "reading incompatible enums is now an error" doesn't reach us, because the enum crosschecks read the *descriptor* (`H5Tget_super`, `H5Tget_member_value`) and never a typed value. And `hdf5-sys` marking its bindings `unsafe` doesn't reach the three files that declare their own `unsafe extern "C" { fn H5Fget_freespace }`. The derive bump drops `proc-macro-error2`, which was emitting a "will be rejected by a future version of Rust" future-incompat warning on every build.

`hdf5-metno-src` deliberately stays at 0.10.1, so the vendored reference library stays at the version this suite's byte-level expectations were established against. Moving it to 0.10.2 means libhdf5 2.0.0 -> 2.1.0, which changes ground truth for every crosscheck; that is a separate change with a separate blast radius.

No `CHANGELOG.md` entry: a dev-dependency is invisible to anything that depends on this crate.

## The hole the error codes close

Eleven sites asserted a deleted object was gone with `assert!(c.dataset("doomed").is_err())`. `is_err()` is satisfied by *any* failure — including the C library being unable to walk the group at all because the delete corrupted the file. The assertion meant to prove "absent" passes on "unreadable", which is precisely the #201 failure mode: a write path returning `Ok` on a file the C library cannot read.

**The obvious fix is wrong.** Asserting `H5E_NOTFOUND` is barely better, because a damaged link table reports `NotFound` too — an unreadable index and a missing link are indistinguishable at the traversal layer. Sweeping 1- to 32-byte corruptions across every metadata offset of a 40-dataset file, 885 produced a detectable failure and **176 of those carried `NotFound`**. Shipping the bare code check would have been decoration.

What separates them is the metadata cache. A genuine absence reads every block it needs and finds no matching link, so it never reports a load or decode failure; damage surfaces as `CantLoad`/`ReadError`/`CantProtect`/`CantGet`/`CantDecode` alongside the `NotFound`. `tests/common/mod.rs::assert_c_absent` asserts that conjunction, and it takes the same sweep from 176 false accepts to **zero**.

## The guard

The helper's conditions are tuned to what a particular libhdf5 reports, so a future upgrade could silently decay it back to `is_err()` while every test still passed. `tests/c_absence_predicate.rs` prevents that, asserting three things:

- the predicate accepts a genuine absence in every shape a delete test produces — compact group, dense group, subgroup, missing group, missing attribute (a false negative here would be a flaky crosscheck);
- across the corruption sweep it accepts **none** of the 885 damaged files;
- the bare code check still accepts **some** of them, so the extra conditions are demonstrably load-bearing. If that count ever reaches zero, the sweep has stopped exercising them and the test says so rather than passing vacuously.

`assert_c_absent` and the `bool` form share one implementation, so the guard measures the predicate the crosschecks actually use rather than a copy of it.

Mutation-verified: stubbing out the load-failure conjunction fails `corruption_is_never_mistaken_for_absence` at the first corrupted offset, and fails *only* that test — the other 24 tests in `edit_crosscheck.rs` stay green, so the guard is what catches it.

## Verification

`cargo fmt --check`, `clippy --all-features --all-targets -D warnings`, `cargo check --locked --no-default-features` (no_std), `RUSTDOCFLAGS=-D warnings cargo doc`, and the full suite.
