### PR TITLE
Validate against released libhdf5 2.1.0 instead of the 2.0.0 development snapshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "hdf5-metno-src"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5284a978be0edc848d21e7e3e903dbb0cab29267f63784f27997ed0628cd8289"
+checksum = "3e8dfed88a20aca1e594f0e2e2f2c9115e0812ba20bbea1ef7c99e0142dc84b9"
 dependencies = [
  "cmake",
  "libz-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,15 @@ criterion = { version = "0.5", default-features = false }
 # pure-Rust suite on a 32-bit pointer width without building any C code. The
 # crosscheck test files carry
 # the matching `#![cfg(not(target_pointer_width = "32"))]` gate.
+#
+# The suite validates against the current *released* libhdf5, not a development
+# snapshot. Which one that is comes from the `hdf5-metno-src` pin in
+# `Cargo.lock`, since every CI job runs `--locked`; read `H5_VERS_MAJOR/MINOR/
+# RELEASE` in that crate's `ext/hdf5/src/H5public.h` to see it. Judge a bump by
+# the crosschecks rather than by release notes: several of them assert constants
+# derived from libhdf5 internals that a version change could move, and
+# `tests/c_absence_predicate.rs` guards the assertion most sensitive to one by
+# re-measuring the C library's error codes against deliberately damaged files.
 [target.'cfg(not(target_pointer_width = "32"))'.dev-dependencies]
 hdf5 = { package = "hdf5-metno", version = "0.14", features = ["static", "zlib"] }
 


### PR DESCRIPTION
Moves the reference C library the crosscheck suite validates against from HDF5 2.0.0 to 2.1.0, by bumping the `hdf5-metno-src` pin in `Cargo.lock` from 0.10.1 to 0.10.2.

2.0.0 is not a release. The source `hdf5-metno-src` 0.10.1 vendors describes itself as currently under development in its own `ext/hdf5/README.md`, so until now every byte-level expectation in this repo was established against a development snapshot. 2.1.0 is a version users can install. Since every CI job runs `--locked`, this pin is what CI actually compiles and links, so it is the whole of the change: the two `hdf5-metno-src` releases differ only in the vendored submodule, and their `build.rs` files are byte-identical.

A dev-dependency is invisible to dependents, so there is no changelog entry and nothing here reaches anyone who depends on `hdf5-pure`.

## What this was judged on

Not the release notes. The suite bakes in a number of constants derived from libhdf5 internals, and those are what a library-version change would move:

- `tests/dense_attr_limits_crosscheck.rs` asserts the dense-attribute count limit is exactly 61,680, which falls out of the v2 B-tree leaf-capacity computation. The test's own comment records that 61,681 aborts the C library.
- `tests/file_space_crosscheck.rs` and `tests/file_space_fuzz_crosscheck.rs` demand exact equality with `H5Fget_freespace`, which runs through the free-space manager code that 2.1.0 reworked.
- `tests/extensible_array_crosscheck.rs` parses the C library's `EAHD` header at a fixed offset and stride, so a header-layout change would misparse silently rather than fail loudly.
- `tests/layout_introspection_crosscheck.rs` pins which chunk index the C library selects for a given layout.

All of them pass. Full suite against a freshly compiled 2.1.0: 91 binaries, 1536 passed, 0 failed, 2 ignored, matching the 2.0.0 baseline with no expectation moved. What actually linked was confirmed by reading `H5_VERSION` from the generated `H5pubconf.h` under `target/debug/build/hdf5-metno-src-*/out/include/`, rather than trusting the lockfile alone.

That run was macOS only. The point of opening this as a PR rather than pushing it to `main` is to let the Windows, Linux and i686 jobs say the same thing. The `matio-crosscheck` feature is maintainer-local and is not covered either way.

## The comment

PR #212 held `hdf5-metno-src` at 0.10.1 on purpose, and recorded why in its commit message alone. Removing the pin removes that explanation, so the second commit states the successor policy next to the dev-dependency in `Cargo.toml`: validate against the current released library, and judge a bump by the crosschecks rather than by release notes.
