### PR TITLE
Parse a heap's huge-object index once per walk (#195)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - An attribute of any size is written rather than refused: one too large for an object-header message selects fractal-heap storage on its own, and one too large for a managed heap object becomes a *huge* object. A name, datatype, or dataspace longer than the 2-byte field describing it is still refused, as the new `FormatError::AttributeFieldTooLong` ([#195](https://github.com/stephenberry/hdf5-pure/issues/195)).
 - `FormatError::TooManyHugeDenseAttributes` names the one bound the new huge-object path adds, on how many such attributes a single object may carry ([#195](https://github.com/stephenberry/hdf5-pure/issues/195)).
+- `FormatError::UnexpectedHugeObjectBTree` refuses a fractal heap whose huge-objects B-tree is not the record layout this reader decodes, instead of reading an object ID out of another field's bytes ([#195](https://github.com/stephenberry/hdf5-pure/issues/195)).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- Reading an object with many huge dense attributes now parses the heap's huge-object index once per walk instead of once per attribute, so the read is no longer quadratic in their number (1,600 such attributes drop from ~164 ms to ~75 ms) ([#195](https://github.com/stephenberry/hdf5-pure/issues/195)).
 - A variable-length attribute stored in a fractal heap keeps its values. Written into the heap before its global-heap references had addresses, it read back with its values lost, silently ([#214](https://github.com/stephenberry/hdf5-pure/pull/214)).
 - Dense (fractal-heap) attributes are readable in a file with a userblock, through `File::open`, `File::open_streaming`, `repack` and `copy` alike. The heap address was taken as an absolute file offset rather than one relative to the base address, so the read failed on a file the reference C library reads correctly ([#214](https://github.com/stephenberry/hdf5-pure/pull/214)).
 

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -565,22 +565,25 @@ mod tests {
         builder.finish().unwrap()
     }
 
-    /// The dense walk resolves every huge object against one parse of the
-    /// heap's huge-object index, not one parse per object.
-    ///
-    /// Costs, not answers, are what regress here: reading the index per object
-    /// returns exactly the same attributes while making the walk quadratic in
-    /// their number, so the count of reads is the only thing that catches it.
-    #[test]
-    fn a_dense_walk_parses_its_huge_object_index_once() {
-        const COUNT: usize = 6;
-        let bytes = file_with_huge_attributes(COUNT);
+    /// A file whose root carries `count` attributes small enough to be managed
+    /// heap objects, so the heap holds no huge object at all.
+    fn file_with_managed_attributes(count: usize) -> Vec<u8> {
+        let mut builder = crate::FileBuilder::new();
+        for i in 0..count {
+            builder.set_attr(&format!("a{i}"), crate::AttrValue::I64(i as i64));
+        }
+        builder.create_dataset("x").with_f64_data(&[1.0]);
+        builder.finish().unwrap()
+    }
 
-        let sig = crate::signature::find_signature(&bytes).unwrap();
-        let superblock = crate::superblock::Superblock::parse(&bytes, sig).unwrap();
+    /// The root group's dense-attribute storage: its info message, its heap
+    /// address, and the file's offset and length sizes.
+    fn dense_attribute_info(bytes: &[u8]) -> (AttributeInfoMessage, u64, u8, u8) {
+        let sig = crate::signature::find_signature(bytes).unwrap();
+        let superblock = crate::superblock::Superblock::parse(bytes, sig).unwrap();
         let (offset_size, length_size) = (superblock.offset_size, superblock.length_size);
         let root = ObjectHeader::parse(
-            &bytes,
+            bytes,
             superblock.root_group_address.to_usize().unwrap(),
             offset_size,
             length_size,
@@ -588,10 +591,26 @@ mod tests {
         .unwrap();
         let info = find_attribute_info(&root, offset_size)
             .unwrap()
-            .expect("this many oversized attributes are stored densely");
+            .expect("this many attributes are stored densely");
         let fh_addr = info
             .fractal_heap_address
             .expect("dense storage names its heap");
+        (info, fh_addr, offset_size, length_size)
+    }
+
+    /// The streaming dense walk resolves every huge object against one parse of
+    /// the heap's huge-object index, not one parse per object.
+    ///
+    /// Costs, not answers, are what regress here: reading the index per object
+    /// returns exactly the same attributes while making the walk quadratic in
+    /// their number, so the count of reads is the only thing that catches it.
+    /// This one counts them end to end, at the B-tree's own address, rather than
+    /// on the reader.
+    #[test]
+    fn a_dense_walk_parses_its_huge_object_index_once() {
+        const COUNT: usize = 6;
+        let bytes = file_with_huge_attributes(COUNT);
+        let (info, fh_addr, offset_size, length_size) = dense_attribute_info(&bytes);
         let heap = FractalHeapHeader::parse(
             &bytes,
             fh_addr.to_usize().unwrap(),
@@ -615,6 +634,62 @@ mod tests {
             source.reads_at(btree_addr),
             1,
             "the huge-object B-tree header was re-read per object"
+        );
+    }
+
+    /// The buffered dense walk holds to the same invariant, on the path
+    /// `File::open` takes.
+    ///
+    /// The reader caching the index is only half of it; the other half is each
+    /// walk building one reader for the whole heap rather than one per object,
+    /// and that half is per call site.
+    #[test]
+    fn a_buffered_dense_walk_parses_its_huge_object_index_once() {
+        const COUNT: usize = 6;
+        let bytes = file_with_huge_attributes(COUNT);
+        let (info, fh_addr, offset_size, length_size) = dense_attribute_info(&bytes);
+
+        crate::fractal_heap::reset_huge_index_decodes();
+        let attrs =
+            extract_dense_attributes(&bytes, &info, fh_addr, offset_size, length_size).unwrap();
+
+        assert_eq!(
+            attrs.len(),
+            COUNT,
+            "the walk must still read every attribute"
+        );
+        assert_eq!(
+            crate::fractal_heap::huge_index_decodes(),
+            1,
+            "the huge-object index was parsed per object rather than per walk"
+        );
+    }
+
+    /// A heap holding no huge object never parses a huge-object index, on either
+    /// backend. The index is parsed on demand, and every dense walk that reads
+    /// only managed objects is a walk that must not pay for one.
+    #[test]
+    fn a_managed_dense_walk_never_parses_a_huge_object_index() {
+        // Enough attributes to force dense storage, none of them large enough to
+        // exceed the heap's managed-object limit.
+        const COUNT: usize = 40;
+        let bytes = file_with_managed_attributes(COUNT);
+        let (info, fh_addr, offset_size, length_size) = dense_attribute_info(&bytes);
+
+        crate::fractal_heap::reset_huge_index_decodes();
+        let buffered =
+            extract_dense_attributes(&bytes, &info, fh_addr, offset_size, length_size).unwrap();
+        let source = BytesSource::new(bytes);
+        let streamed =
+            extract_dense_attributes_from_source(&source, &info, fh_addr, offset_size, length_size)
+                .unwrap();
+
+        assert_eq!(buffered.len(), COUNT, "the walk must read every attribute");
+        assert_eq!(streamed.len(), COUNT);
+        assert_eq!(
+            crate::fractal_heap::huge_index_decodes(),
+            0,
+            "a heap with no huge object parsed an index it has no use for"
         );
     }
 

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -452,6 +452,7 @@ fn extract_dense_attributes(
         BTreeV2Header::parse(file_data, btree_addr.to_usize()?, offset_size, length_size)?;
     let records = collect_btree_v2_records(file_data, &btree_hdr, offset_size, length_size)?;
 
+    let mut heap = fh.object_reader(offset_size, length_size);
     let mut attrs = Vec::new();
     for record in &records {
         // Per HDF5 spec, both type 8 and type 9 records start with heap_id:
@@ -465,7 +466,7 @@ fn extract_dense_attributes(
         let id_bytes = &record.data[id_offset..id_offset + fh.heap_id_length as usize];
 
         // Read the attribute message from the fractal heap (managed or huge object).
-        let attr_data = fh.read_object(file_data, id_bytes, offset_size, length_size)?;
+        let attr_data = heap.read(file_data, id_bytes)?;
 
         // The data in the heap is a complete attribute message
         let attr = AttributeMessage::parse(&attr_data, length_size)?;
@@ -496,6 +497,7 @@ fn extract_dense_attributes_from_source<S: Source + ?Sized>(
     let records =
         collect_btree_v2_records_from_source(source, &btree_hdr, offset_size, length_size)?;
 
+    let mut heap = fh.object_reader(offset_size, length_size);
     let mut attrs = Vec::new();
     for record in &records {
         // Both type 8 and type 9 records begin with the heap_id.
@@ -504,7 +506,7 @@ fn extract_dense_attributes_from_source<S: Source + ?Sized>(
             continue;
         }
         let id_bytes = &record.data[id_offset..id_offset + fh.heap_id_length as usize];
-        let attr_data = fh.read_object_from_source(source, id_bytes, offset_size, length_size)?;
+        let attr_data = heap.read_from_source(source, id_bytes)?;
         attrs.push(AttributeMessage::parse(&attr_data, length_size)?);
     }
 
@@ -514,6 +516,108 @@ fn extract_dense_attributes_from_source<S: Source + ?Sized>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::source::BytesSource;
+    use core::cell::RefCell;
+
+    /// A [`Source`] that records where each read started, so a walk can be asked
+    /// how often it went back to a particular structure.
+    struct CountingSource {
+        inner: BytesSource<Vec<u8>>,
+        reads: RefCell<Vec<u64>>,
+    }
+
+    impl CountingSource {
+        fn new(bytes: Vec<u8>) -> Self {
+            Self {
+                inner: BytesSource::new(bytes),
+                reads: RefCell::new(Vec::new()),
+            }
+        }
+
+        fn reads_at(&self, offset: u64) -> usize {
+            self.reads.borrow().iter().filter(|&&o| o == offset).count()
+        }
+    }
+
+    impl Source for CountingSource {
+        fn len(&self) -> u64 {
+            self.inner.len()
+        }
+
+        fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), FormatError> {
+            self.reads.borrow_mut().push(offset);
+            self.inner.read_at(offset, buf)
+        }
+    }
+
+    /// A file whose root carries `count` attributes, each too large for a
+    /// managed heap object, so every one of them resolves through the heap's
+    /// huge-object B-tree.
+    fn file_with_huge_attributes(count: usize) -> Vec<u8> {
+        let mut builder = crate::FileBuilder::new();
+        for i in 0..count {
+            builder.set_attr(
+                &format!("a{i}"),
+                crate::AttrValue::StringArray(vec![format!("{i:0700}"); 100]),
+            );
+        }
+        builder.create_dataset("x").with_f64_data(&[1.0]);
+        builder.finish().unwrap()
+    }
+
+    /// The dense walk resolves every huge object against one parse of the
+    /// heap's huge-object index, not one parse per object.
+    ///
+    /// Costs, not answers, are what regress here: reading the index per object
+    /// returns exactly the same attributes while making the walk quadratic in
+    /// their number, so the count of reads is the only thing that catches it.
+    #[test]
+    fn a_dense_walk_parses_its_huge_object_index_once() {
+        const COUNT: usize = 6;
+        let bytes = file_with_huge_attributes(COUNT);
+
+        let sig = crate::signature::find_signature(&bytes).unwrap();
+        let superblock = crate::superblock::Superblock::parse(&bytes, sig).unwrap();
+        let (offset_size, length_size) = (superblock.offset_size, superblock.length_size);
+        let root = ObjectHeader::parse(
+            &bytes,
+            superblock.root_group_address.to_usize().unwrap(),
+            offset_size,
+            length_size,
+        )
+        .unwrap();
+        let info = find_attribute_info(&root, offset_size)
+            .unwrap()
+            .expect("this many oversized attributes are stored densely");
+        let fh_addr = info
+            .fractal_heap_address
+            .expect("dense storage names its heap");
+        let heap = FractalHeapHeader::parse(
+            &bytes,
+            fh_addr.to_usize().unwrap(),
+            offset_size,
+            length_size,
+        )
+        .unwrap();
+        let btree_addr = heap.btree_huge_objects_address;
+
+        let source = CountingSource::new(bytes);
+        let attrs =
+            extract_dense_attributes_from_source(&source, &info, fh_addr, offset_size, length_size)
+                .unwrap();
+
+        assert_eq!(
+            attrs.len(),
+            COUNT,
+            "the walk must still read every attribute"
+        );
+        assert_eq!(
+            source.reads_at(btree_addr),
+            1,
+            "the huge-object B-tree header was re-read per object"
+        );
+    }
+
     /// Build a datatype header for testing (8 bytes).
     fn build_dt_header(class: u8, version: u8, bf: [u8; 3], size: u32) -> Vec<u8> {
         let mut buf = vec![0u8; 8];

--- a/src/error.rs
+++ b/src/error.rs
@@ -156,6 +156,19 @@ pub enum FormatError {
     /// A fractal-heap "huge" object's heap ID referenced a B-tree key that is
     /// not present in the heap's huge-objects v2 B-tree.
     HugeObjectNotFound(u64),
+    /// A fractal heap's huge-objects v2 B-tree is not the indirectly accessed,
+    /// non-filtered layout (record type 1) this reader decodes: either the tree
+    /// declares a different record type, or its records are too short to hold
+    /// that one. Reading its records as that layout would decode an object ID
+    /// out of another field's bytes.
+    UnexpectedHugeObjectBTree {
+        /// The record type the B-tree declares.
+        tree_type: u8,
+        /// The record size the B-tree declares, in bytes.
+        record_size: usize,
+        /// The bytes a type-1 record needs: address + length + object ID.
+        required: usize,
+    },
     /// A fractal-heap object lives in an I/O-filter-encoded heap (filtered
     /// managed or huge storage), whose filtered bytes this reader does not
     /// decode. Link and attribute heaps are never filtered, so this does not
@@ -609,6 +622,17 @@ impl fmt::Display for FormatError {
             }
             FormatError::HugeObjectNotFound(id) => {
                 write!(f, "fractal-heap huge object {id} not found in B-tree")
+            }
+            FormatError::UnexpectedHugeObjectBTree {
+                tree_type,
+                record_size,
+                required,
+            } => {
+                write!(
+                    f,
+                    "fractal-heap huge-objects B-tree is not the expected record type 1: \
+                     type {tree_type}, records of {record_size} bytes (type 1 needs {required})"
+                )
             }
             FormatError::UnsupportedFilteredHeapObject => {
                 write!(f, "filtered fractal-heap objects are not supported")

--- a/src/file_writer.rs
+++ b/src/file_writer.rs
@@ -258,7 +258,7 @@ const DENSE_ATTR_BTREE_RECORD: usize = 8 + 1 + 4 + 4;
 
 /// One huge-objects B-tree v2 record (type 1, indirectly accessed and
 /// non-filtered): address + length + huge object ID. Matches what
-/// `fractal_heap::find_huge_record` decodes on the way back in.
+/// `fractal_heap::HugeObjectIndex::decode` reads on the way back in.
 const DENSE_ATTR_HUGE_BTREE_RECORD: usize =
     OFFSET_SIZE as usize + LENGTH_SIZE as usize + LENGTH_SIZE as usize;
 

--- a/src/fractal_heap.rs
+++ b/src/fractal_heap.rs
@@ -168,23 +168,76 @@ fn read_object_at_source<S: Source + ?Sized>(
     source.read_metadata_at(addr, len)
 }
 
+/// The v2 B-tree record type for indirectly accessed, non-filtered "huge"
+/// fractal-heap objects: `address(offset_size) + length(length_size) +
+/// id(length_size)`. The only layout [`HugeObjectIndex`] decodes.
+const HUGE_OBJECT_BTREE_TYPE: u8 = 1;
+
+/// Confirm a heap's huge-objects B-tree is the one [`HugeObjectIndex::decode`]
+/// knows how to read, before its records are read as that layout.
+///
+/// The other huge-object record types are unreachable by construction — the
+/// directly accessed ones (3 and 4) resolve out of the heap ID without
+/// consulting any tree, and the filtered ones (2 and 4) belong to heaps refused
+/// at [`HeapObjectReader::huge_reference`] — but that is a fact about the heap
+/// header, and this is the tree's own declaration. A file whose two disagree
+/// would otherwise have its records decoded as a layout they are not, reading
+/// an id out of another field's bytes.
+fn check_huge_object_btree(
+    header: &BTreeV2Header,
+    offset_size: u8,
+    length_size: u8,
+) -> Result<(), FormatError> {
+    let required = offset_size as usize + 2 * length_size as usize;
+    if header.tree_type != HUGE_OBJECT_BTREE_TYPE || (header.record_size as usize) < required {
+        return Err(FormatError::UnexpectedHugeObjectBTree {
+            tree_type: header.tree_type,
+            record_size: header.record_size as usize,
+            required,
+        });
+    }
+    Ok(())
+}
+
 /// Every huge object a heap holds, decoded from its huge-objects v2 B-tree.
 ///
 /// Resolving even one huge object costs the whole index: that B-tree is read by
 /// collecting its records rather than by descending to a key. So the records are
 /// decoded here once, and kept by the [`HeapObjectReader`] that asked for them.
 ///
-/// Only the type-1 record layout appears here — `address(offset_size) +
-/// length(length_size) + id(length_size)`, indirectly accessed and
-/// non-filtered. The directly accessed types carry no id and are never
-/// consulted, since their address and length are in the heap ID itself (see
-/// [`FractalHeapHeader::huge_ids_direct`]), and the filtered types belong to
-/// heaps this reader refuses before reaching any object.
+/// Only the type-1 record layout appears here, which
+/// [`check_huge_object_btree`] establishes before any record reaches this.
 struct HugeObjectIndex {
     /// `(id, address, length)`, ordered by id so a lookup is a binary search.
     /// The B-tree already stores them in that order; sorting again costs one
     /// pass and means correctness here does not rest on that.
     entries: Vec<(u64, u64, u64)>,
+}
+
+#[cfg(test)]
+std::thread_local! {
+    /// How many huge-object indexes have been decoded on this thread.
+    ///
+    /// Parsing one index per object rather than one per walk returns exactly the
+    /// same objects while making the walk quadratic in their number, so the
+    /// count of decodes is the only thing a test can hold the invariant to. The
+    /// walks build their reader internally, so the count has to be reachable
+    /// from outside the reader that did the decoding; it is per-thread because
+    /// the test harness runs tests concurrently, and each test's walk runs on
+    /// its own thread.
+    static HUGE_INDEX_DECODES: core::cell::Cell<usize> = const { core::cell::Cell::new(0) };
+}
+
+/// Start counting huge-object index decodes on this thread from zero.
+#[cfg(test)]
+pub(crate) fn reset_huge_index_decodes() {
+    HUGE_INDEX_DECODES.with(|count| count.set(0));
+}
+
+/// How many huge-object indexes this thread has decoded since the last reset.
+#[cfg(test)]
+pub(crate) fn huge_index_decodes() -> usize {
+    HUGE_INDEX_DECODES.with(|count| count.get())
 }
 
 impl HugeObjectIndex {
@@ -193,6 +246,9 @@ impl HugeObjectIndex {
         offset_size: u8,
         length_size: u8,
     ) -> Result<Self, FormatError> {
+        #[cfg(test)]
+        HUGE_INDEX_DECODES.with(|count| count.set(count.get() + 1));
+
         let os = offset_size as usize;
         let ls = length_size as usize;
         let mut entries = Vec::with_capacity(records.len());
@@ -245,11 +301,18 @@ pub struct HeapObjectReader<'h> {
     length_size: u8,
     /// Parsed on demand, since most heaps hold no huge object at all.
     huge: Option<HugeObjectIndex>,
-    /// How many times that index has been parsed. The invariant this type
-    /// exists for is a cost, and a cost leaves no other trace in the objects it
-    /// returns, so the test that pins it counts the parses.
-    #[cfg(test)]
-    index_parses: usize,
+    /// Which backend the cached index was decoded from, once one has been.
+    huge_backend: Option<Backend>,
+}
+
+/// Which of the two ways of reading a file an object came through. Recorded
+/// only to hold a reader to one of them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Backend {
+    /// An in-memory image of the whole file.
+    Buffered,
+    /// A [`Source`], read from on demand.
+    Streaming,
 }
 
 impl HeapObjectReader<'_> {
@@ -313,7 +376,18 @@ impl HeapObjectReader<'_> {
 
     /// The `(address, length)` of huge object `huge_id`, parsing the heap's
     /// huge-object index out of `records` the first time one is asked for.
-    fn locate_huge<F>(&mut self, huge_id: u64, records: F) -> Result<(u64, u64), FormatError>
+    ///
+    /// What the index caches are file addresses, resolved against the image
+    /// `backend` names. Every caller reads a whole heap through one backend, so
+    /// a reader that saw both would be a caller that had changed which file it
+    /// meant mid-walk — addresses applied to the wrong image read the wrong
+    /// bytes and report no error, which is worth an assertion where the two meet.
+    fn locate_huge<F>(
+        &mut self,
+        huge_id: u64,
+        backend: Backend,
+        records: F,
+    ) -> Result<(u64, u64), FormatError>
     where
         F: FnOnce() -> Result<Vec<BTreeV2Record>, FormatError>,
     {
@@ -323,11 +397,13 @@ impl HeapObjectReader<'_> {
                 self.offset_size,
                 self.length_size,
             )?);
-            #[cfg(test)]
-            {
-                self.index_parses += 1;
-            }
+            self.huge_backend = Some(backend);
         }
+        debug_assert_eq!(
+            self.huge_backend,
+            Some(backend),
+            "a heap's huge-object index holds addresses into the image it was decoded from",
+        );
         self.huge
             .as_ref()
             .expect("filled immediately above")
@@ -341,9 +417,10 @@ impl HeapObjectReader<'_> {
             HugeReference::Indexed(huge_id) => {
                 let (offset_size, length_size) = (self.offset_size, self.length_size);
                 let btree_addr = self.header.btree_huge_objects_address.to_usize()?;
-                self.locate_huge(huge_id, || {
+                self.locate_huge(huge_id, Backend::Buffered, || {
                     let header =
                         BTreeV2Header::parse(file_data, btree_addr, offset_size, length_size)?;
+                    check_huge_object_btree(&header, offset_size, length_size)?;
                     collect_btree_v2_records(file_data, &header, offset_size, length_size)
                 })?
             }
@@ -362,13 +439,14 @@ impl HeapObjectReader<'_> {
             HugeReference::Indexed(huge_id) => {
                 let (offset_size, length_size) = (self.offset_size, self.length_size);
                 let btree_addr = self.header.btree_huge_objects_address;
-                self.locate_huge(huge_id, || {
+                self.locate_huge(huge_id, Backend::Streaming, || {
                     let header = BTreeV2Header::parse_from_source(
                         source,
                         btree_addr,
                         offset_size,
                         length_size,
                     )?;
+                    check_huge_object_btree(&header, offset_size, length_size)?;
                     collect_btree_v2_records_from_source(source, &header, offset_size, length_size)
                 })?
             }
@@ -701,8 +779,7 @@ impl FractalHeapHeader {
             offset_size,
             length_size,
             huge: None,
-            #[cfg(test)]
-            index_parses: 0,
+            huge_backend: None,
         }
     }
 
@@ -1483,8 +1560,49 @@ mod tests {
         }
     }
 
+    /// A huge-objects B-tree that is not the type-1 layout is refused before its
+    /// records are read as that layout.
+    ///
+    /// Type 2 is the filtered counterpart, whose records are longer and put the
+    /// object ID somewhere else: decoding one as type 1 reads an ID out of the
+    /// filter mask and returns some other object, or none, without complaint.
+    #[test]
+    fn a_huge_object_btree_of_another_type_is_refused() {
+        let btree = |tree_type: u8, record_size: u16| BTreeV2Header {
+            tree_type,
+            node_size: 512,
+            record_size,
+            depth: 0,
+            root_node_address: 0x100,
+            num_records_in_root: 1,
+            total_records: 1,
+        };
+
+        assert_eq!(
+            check_huge_object_btree(&btree(2, 36), 8, 8),
+            Err(FormatError::UnexpectedHugeObjectBTree {
+                tree_type: 2,
+                record_size: 36,
+                required: 24,
+            }),
+            "a filtered huge-object tree is long enough to pass a length check alone"
+        );
+        assert_eq!(
+            check_huge_object_btree(&btree(1, 16), 8, 8),
+            Err(FormatError::UnexpectedHugeObjectBTree {
+                tree_type: 1,
+                record_size: 16,
+                required: 24,
+            }),
+            "records too short for the layout the type claims"
+        );
+        assert_eq!(check_huge_object_btree(&btree(1, 24), 8, 8), Ok(()));
+    }
+
     /// A record too short for the type-1 layout is a heap this reader has
-    /// misread, not one object to skip past.
+    /// misread, not one object to skip past. The backstop behind
+    /// [`check_huge_object_btree`], which refuses such a tree by its declared
+    /// record size before any record reaches the decode.
     #[test]
     fn huge_object_index_refuses_a_truncated_record() {
         let records = vec![BTreeV2Record {
@@ -1538,13 +1656,19 @@ mod tests {
         };
         let ids: Vec<Vec<u8>> = (1..=COUNT).map(heap_id).collect();
 
+        reset_huge_index_decodes();
         let mut reader = heap.object_reader(8, 8);
         let buffered: Vec<Vec<u8>> = ids
             .iter()
             .map(|id| reader.read(&bytes, id).unwrap())
             .collect();
-        assert_eq!(reader.index_parses, 1, "buffered reads re-parsed the index");
+        assert_eq!(
+            huge_index_decodes(),
+            1,
+            "buffered reads re-parsed the index"
+        );
 
+        reset_huge_index_decodes();
         let source = BytesSource::new(bytes.clone());
         let mut reader = heap.object_reader(8, 8);
         let streamed: Vec<Vec<u8>> = ids
@@ -1552,7 +1676,8 @@ mod tests {
             .map(|id| reader.read_from_source(&source, id).unwrap())
             .collect();
         assert_eq!(
-            reader.index_parses, 1,
+            huge_index_decodes(),
+            1,
             "streaming reads re-parsed the index"
         );
 

--- a/src/fractal_heap.rs
+++ b/src/fractal_heap.rs
@@ -168,30 +168,213 @@ fn read_object_at_source<S: Source + ?Sized>(
     source.read_metadata_at(addr, len)
 }
 
-/// Find the (address, length) of a huge object in the heap's huge-objects v2
-/// B-tree records. Each record (type 1, indirectly accessed, non-filtered) is
-/// `address(offset_size) + length(length_size) + id(length_size)`, sorted by id.
-fn find_huge_record(
-    records: &[BTreeV2Record],
-    huge_id: u64,
-    offset_size: u8,
-    length_size: u8,
-) -> Result<(u64, u64), FormatError> {
-    let os = offset_size as usize;
-    let ls = length_size as usize;
-    for record in records {
-        let data = &record.data;
-        if data.len() < os + 2 * ls {
-            continue;
-        }
-        let id = read_offset(data, os + ls, length_size)?;
-        if id == huge_id {
+/// Every huge object a heap holds, decoded from its huge-objects v2 B-tree.
+///
+/// Resolving even one huge object costs the whole index: that B-tree is read by
+/// collecting its records rather than by descending to a key. So the records are
+/// decoded here once, and kept by the [`HeapObjectReader`] that asked for them.
+///
+/// Only the type-1 record layout appears here — `address(offset_size) +
+/// length(length_size) + id(length_size)`, indirectly accessed and
+/// non-filtered. The directly accessed types carry no id and are never
+/// consulted, since their address and length are in the heap ID itself (see
+/// [`FractalHeapHeader::huge_ids_direct`]), and the filtered types belong to
+/// heaps this reader refuses before reaching any object.
+struct HugeObjectIndex {
+    /// `(id, address, length)`, ordered by id so a lookup is a binary search.
+    /// The B-tree already stores them in that order; sorting again costs one
+    /// pass and means correctness here does not rest on that.
+    entries: Vec<(u64, u64, u64)>,
+}
+
+impl HugeObjectIndex {
+    fn decode(
+        records: &[BTreeV2Record],
+        offset_size: u8,
+        length_size: u8,
+    ) -> Result<Self, FormatError> {
+        let os = offset_size as usize;
+        let ls = length_size as usize;
+        let mut entries = Vec::with_capacity(records.len());
+        for record in records {
+            let data = &record.data;
             let addr = read_offset(data, 0, offset_size)?;
             let len = read_offset(data, os, length_size)?;
-            return Ok((addr, len));
+            let id = read_offset(data, os + ls, length_size)?;
+            entries.push((id, addr, len));
+        }
+        entries.sort_unstable();
+        Ok(Self { entries })
+    }
+
+    /// The `(address, length)` of the object with `huge_id`.
+    fn locate(&self, huge_id: u64) -> Result<(u64, u64), FormatError> {
+        match self
+            .entries
+            .binary_search_by_key(&huge_id, |&(id, _, _)| id)
+        {
+            Ok(i) => {
+                let (_, addr, len) = self.entries[i];
+                Ok((addr, len))
+            }
+            Err(_) => Err(FormatError::HugeObjectNotFound(huge_id)),
         }
     }
-    Err(FormatError::HugeObjectNotFound(huge_id))
+}
+
+/// What a huge object's heap ID resolves to: its location outright, or the id
+/// the heap's huge-object index knows it by.
+enum HugeReference {
+    Inline { addr: u64, len: u64 },
+    Indexed(u64),
+}
+
+/// Reads objects out of one fractal heap, holding the indexes that resolving
+/// them needs.
+///
+/// A managed or tiny object is resolved against the heap header alone, but a
+/// huge one needs the heap's huge-objects B-tree, which costs the same to
+/// consult for one object as for all of them. Every caller here walks a whole
+/// heap rather than reading a single object, so parsing that index per object
+/// made the walk quadratic in the number of huge objects. This type is where the
+/// index lives instead: parsed on the first huge object, reused for the rest,
+/// and never parsed at all by a heap that has none.
+pub struct HeapObjectReader<'h> {
+    header: &'h FractalHeapHeader,
+    offset_size: u8,
+    length_size: u8,
+    /// Parsed on demand, since most heaps hold no huge object at all.
+    huge: Option<HugeObjectIndex>,
+    /// How many times that index has been parsed. The invariant this type
+    /// exists for is a cost, and a cost leaves no other trace in the objects it
+    /// returns, so the test that pins it counts the parses.
+    #[cfg(test)]
+    index_parses: usize,
+}
+
+impl HeapObjectReader<'_> {
+    /// Read the object `id_bytes` names from an in-memory file image,
+    /// dispatching on the heap-ID type. Managed objects live in the doubling
+    /// table's blocks; huge objects are stored directly in the file (resolved
+    /// through the huge-objects v2 B-tree); tiny objects are encoded in the ID.
+    pub fn read(&mut self, file_data: &[u8], id_bytes: &[u8]) -> Result<Vec<u8>, FormatError> {
+        match FractalHeapHeader::heap_id_type(id_bytes)? {
+            HeapIdType::Managed => {
+                self.header
+                    .read_managed_object(file_data, id_bytes, self.offset_size)
+            }
+            HeapIdType::Huge => self.read_huge(file_data, id_bytes),
+            HeapIdType::Tiny => read_tiny_object(self.header.heap_id_length, id_bytes),
+        }
+    }
+
+    /// Streaming counterpart to [`HeapObjectReader::read`].
+    pub fn read_from_source<S: Source + ?Sized>(
+        &mut self,
+        source: &S,
+        id_bytes: &[u8],
+    ) -> Result<Vec<u8>, FormatError> {
+        match FractalHeapHeader::heap_id_type(id_bytes)? {
+            HeapIdType::Managed => {
+                self.header
+                    .read_managed_object_from_source(source, id_bytes, self.offset_size)
+            }
+            HeapIdType::Huge => self.read_huge_from_source(source, id_bytes),
+            HeapIdType::Tiny => read_tiny_object(self.header.heap_id_length, id_bytes),
+        }
+    }
+
+    /// What the huge heap ID `id_bytes` refers to. The part of the decode both
+    /// backends share, since it reads only the ID and the heap header.
+    fn huge_reference(&self, id_bytes: &[u8]) -> Result<HugeReference, FormatError> {
+        if self.header.io_filter_encoded_length > 0 {
+            return Err(FormatError::UnsupportedFilteredHeapObject);
+        }
+        let payload = &id_bytes[1..];
+
+        if self
+            .header
+            .huge_ids_direct(self.offset_size, self.length_size)
+        {
+            // The address and length are stored inline in the heap ID.
+            let addr = read_offset(payload, 0, self.offset_size)?;
+            let len = read_offset(payload, self.offset_size as usize, self.length_size)?;
+            return Ok(HugeReference::Inline { addr, len });
+        }
+
+        // Indirect: the heap ID holds a B-tree key (the huge object ID); the
+        // huge-objects v2 B-tree maps it to (address, length).
+        let huge_id = read_var_le(payload);
+        if is_undefined(self.header.btree_huge_objects_address, self.offset_size) {
+            return Err(FormatError::HugeObjectNotFound(huge_id));
+        }
+        Ok(HugeReference::Indexed(huge_id))
+    }
+
+    /// The `(address, length)` of huge object `huge_id`, parsing the heap's
+    /// huge-object index out of `records` the first time one is asked for.
+    fn locate_huge<F>(&mut self, huge_id: u64, records: F) -> Result<(u64, u64), FormatError>
+    where
+        F: FnOnce() -> Result<Vec<BTreeV2Record>, FormatError>,
+    {
+        if self.huge.is_none() {
+            self.huge = Some(HugeObjectIndex::decode(
+                &records()?,
+                self.offset_size,
+                self.length_size,
+            )?);
+            #[cfg(test)]
+            {
+                self.index_parses += 1;
+            }
+        }
+        self.huge
+            .as_ref()
+            .expect("filled immediately above")
+            .locate(huge_id)
+    }
+
+    /// Resolve and read a "huge" object given its heap ID.
+    fn read_huge(&mut self, file_data: &[u8], id_bytes: &[u8]) -> Result<Vec<u8>, FormatError> {
+        let (addr, len) = match self.huge_reference(id_bytes)? {
+            HugeReference::Inline { addr, len } => (addr, len),
+            HugeReference::Indexed(huge_id) => {
+                let (offset_size, length_size) = (self.offset_size, self.length_size);
+                let btree_addr = self.header.btree_huge_objects_address.to_usize()?;
+                self.locate_huge(huge_id, || {
+                    let header =
+                        BTreeV2Header::parse(file_data, btree_addr, offset_size, length_size)?;
+                    collect_btree_v2_records(file_data, &header, offset_size, length_size)
+                })?
+            }
+        };
+        slice_object(file_data, addr, len.to_usize()?)
+    }
+
+    /// Resolve and read a "huge" object via a [`Source`].
+    fn read_huge_from_source<S: Source + ?Sized>(
+        &mut self,
+        source: &S,
+        id_bytes: &[u8],
+    ) -> Result<Vec<u8>, FormatError> {
+        let (addr, len) = match self.huge_reference(id_bytes)? {
+            HugeReference::Inline { addr, len } => (addr, len),
+            HugeReference::Indexed(huge_id) => {
+                let (offset_size, length_size) = (self.offset_size, self.length_size);
+                let btree_addr = self.header.btree_huge_objects_address;
+                self.locate_huge(huge_id, || {
+                    let header = BTreeV2Header::parse_from_source(
+                        source,
+                        btree_addr,
+                        offset_size,
+                        length_size,
+                    )?;
+                    collect_btree_v2_records_from_source(source, &header, offset_size, length_size)
+                })?
+            }
+        };
+        read_object_at_source(source, addr, len.to_usize()?)
+    }
 }
 
 /// Decode a "tiny" object whose bytes are stored directly inside the heap ID.
@@ -507,57 +690,20 @@ impl FractalHeapHeader {
         }
     }
 
-    /// Read an object from the heap given its raw heap ID bytes, dispatching on
-    /// the heap-ID type. Managed objects live in the doubling-table blocks; huge
-    /// objects are stored directly in the file (resolved here through the
-    /// huge-objects v2 B-tree); tiny objects are encoded in the ID itself.
-    pub fn read_object(
-        &self,
-        file_data: &[u8],
-        id_bytes: &[u8],
-        offset_size: u8,
-        length_size: u8,
-    ) -> Result<Vec<u8>, FormatError> {
-        match Self::heap_id_type(id_bytes)? {
-            HeapIdType::Managed => self.read_managed_object(file_data, id_bytes, offset_size),
-            HeapIdType::Huge => {
-                self.read_huge_object(file_data, id_bytes, offset_size, length_size)
-            }
-            HeapIdType::Tiny => read_tiny_object(self.heap_id_length, id_bytes),
+    /// A reader for the objects in this heap.
+    ///
+    /// Objects are read through one of these rather than one at a time off the
+    /// header, so that a walk over a heap parses its huge-object index once
+    /// instead of once per object. See [`HeapObjectReader`].
+    pub fn object_reader(&self, offset_size: u8, length_size: u8) -> HeapObjectReader<'_> {
+        HeapObjectReader {
+            header: self,
+            offset_size,
+            length_size,
+            huge: None,
+            #[cfg(test)]
+            index_parses: 0,
         }
-    }
-
-    /// Resolve and read a "huge" object given its heap ID.
-    fn read_huge_object(
-        &self,
-        file_data: &[u8],
-        id_bytes: &[u8],
-        offset_size: u8,
-        length_size: u8,
-    ) -> Result<Vec<u8>, FormatError> {
-        if self.io_filter_encoded_length > 0 {
-            return Err(FormatError::UnsupportedFilteredHeapObject);
-        }
-        let payload = &id_bytes[1..];
-
-        if self.huge_ids_direct(offset_size, length_size) {
-            // The address and length are stored inline in the heap ID.
-            let addr = read_offset(payload, 0, offset_size)?;
-            let len = read_offset(payload, offset_size as usize, length_size)?;
-            return slice_object(file_data, addr, len.to_usize()?);
-        }
-
-        // Indirect: the heap ID holds a B-tree key (the huge object ID); the
-        // huge-objects v2 B-tree maps it to (address, length).
-        let huge_id = read_var_le(payload);
-        if is_undefined(self.btree_huge_objects_address, offset_size) {
-            return Err(FormatError::HugeObjectNotFound(huge_id));
-        }
-        let btree_addr = self.btree_huge_objects_address.to_usize()?;
-        let header = BTreeV2Header::parse(file_data, btree_addr, offset_size, length_size)?;
-        let records = collect_btree_v2_records(file_data, &header, offset_size, length_size)?;
-        let (addr, len) = find_huge_record(&records, huge_id, offset_size, length_size)?;
-        slice_object(file_data, addr, len.to_usize()?)
     }
 
     /// Read an object from a direct block.
@@ -825,60 +971,6 @@ impl FractalHeapHeader {
                 64,
             )
         }
-    }
-
-    /// Streaming counterpart to [`FractalHeapHeader::read_object`].
-    pub fn read_object_from_source<S: Source + ?Sized>(
-        &self,
-        source: &S,
-        id_bytes: &[u8],
-        offset_size: u8,
-        length_size: u8,
-    ) -> Result<Vec<u8>, FormatError> {
-        match Self::heap_id_type(id_bytes)? {
-            HeapIdType::Managed => {
-                self.read_managed_object_from_source(source, id_bytes, offset_size)
-            }
-            HeapIdType::Huge => {
-                self.read_huge_object_from_source(source, id_bytes, offset_size, length_size)
-            }
-            HeapIdType::Tiny => read_tiny_object(self.heap_id_length, id_bytes),
-        }
-    }
-
-    /// Resolve and read a "huge" object via a [`Source`].
-    fn read_huge_object_from_source<S: Source + ?Sized>(
-        &self,
-        source: &S,
-        id_bytes: &[u8],
-        offset_size: u8,
-        length_size: u8,
-    ) -> Result<Vec<u8>, FormatError> {
-        if self.io_filter_encoded_length > 0 {
-            return Err(FormatError::UnsupportedFilteredHeapObject);
-        }
-        let payload = &id_bytes[1..];
-
-        if self.huge_ids_direct(offset_size, length_size) {
-            let addr = read_offset(payload, 0, offset_size)?;
-            let len = read_offset(payload, offset_size as usize, length_size)?;
-            return read_object_at_source(source, addr, len.to_usize()?);
-        }
-
-        let huge_id = read_var_le(payload);
-        if is_undefined(self.btree_huge_objects_address, offset_size) {
-            return Err(FormatError::HugeObjectNotFound(huge_id));
-        }
-        let header = BTreeV2Header::parse_from_source(
-            source,
-            self.btree_huge_objects_address,
-            offset_size,
-            length_size,
-        )?;
-        let records =
-            collect_btree_v2_records_from_source(source, &header, offset_size, length_size)?;
-        let (addr, len) = find_huge_record(&records, huge_id, offset_size, length_size)?;
-        read_object_at_source(source, addr, len.to_usize()?)
     }
 
     fn read_from_direct_block_from_source<S: Source + ?Sized>(
@@ -1346,27 +1438,132 @@ mod tests {
         ));
     }
 
+    /// Type-1 record: address(8) + length(8) + id(8), little-endian.
+    fn huge_record(addr: u64, len: u64, id: u64) -> BTreeV2Record {
+        let mut d = Vec::new();
+        d.extend_from_slice(&addr.to_le_bytes());
+        d.extend_from_slice(&len.to_le_bytes());
+        d.extend_from_slice(&id.to_le_bytes());
+        BTreeV2Record { data: d }
+    }
+
     #[test]
-    fn find_huge_record_matches_by_id() {
-        // Type-1 record: address(8) + length(8) + id(8), little-endian.
-        let rec = |addr: u64, len: u64, id: u64| {
-            let mut d = Vec::new();
-            d.extend_from_slice(&addr.to_le_bytes());
-            d.extend_from_slice(&len.to_le_bytes());
-            d.extend_from_slice(&id.to_le_bytes());
-            BTreeV2Record { data: d }
-        };
+    fn huge_object_index_locates_by_id() {
         let records = vec![
-            rec(0x1000, 5000, 1),
-            rec(0x2000, 6000, 2),
-            rec(0x3000, 7000, 5),
+            huge_record(0x1000, 5000, 1),
+            huge_record(0x2000, 6000, 2),
+            huge_record(0x3000, 7000, 5),
         ];
-        assert_eq!(find_huge_record(&records, 2, 8, 8).unwrap(), (0x2000, 6000));
-        assert_eq!(find_huge_record(&records, 5, 8, 8).unwrap(), (0x3000, 7000));
+        let index = HugeObjectIndex::decode(&records, 8, 8).unwrap();
+        assert_eq!(index.locate(2).unwrap(), (0x2000, 6000));
+        assert_eq!(index.locate(5).unwrap(), (0x3000, 7000));
         assert_eq!(
-            find_huge_record(&records, 9, 8, 8),
-            Err(FormatError::HugeObjectNotFound(9))
+            index.locate(9),
+            Err(FormatError::HugeObjectNotFound(9)),
+            "an id no record carries is not found rather than mismatched"
         );
+    }
+
+    /// The lookup is a binary search, so the index has to impose the ordering
+    /// itself rather than inherit whatever order the records arrived in.
+    #[test]
+    fn huge_object_index_orders_records_it_receives_out_of_order() {
+        let records = vec![
+            huge_record(0x3000, 7000, 5),
+            huge_record(0x1000, 5000, 1),
+            huge_record(0x2000, 6000, 2),
+        ];
+        let index = HugeObjectIndex::decode(&records, 8, 8).unwrap();
+        for (id, want) in [
+            (1, (0x1000, 5000)),
+            (2, (0x2000, 6000)),
+            (5, (0x3000, 7000)),
+        ] {
+            assert_eq!(index.locate(id).unwrap(), want);
+        }
+    }
+
+    /// A record too short for the type-1 layout is a heap this reader has
+    /// misread, not one object to skip past.
+    #[test]
+    fn huge_object_index_refuses_a_truncated_record() {
+        let records = vec![BTreeV2Record {
+            data: vec![0u8; 20],
+        }];
+        assert!(matches!(
+            HugeObjectIndex::decode(&records, 8, 8),
+            Err(FormatError::UnexpectedEof { .. })
+        ));
+    }
+
+    /// One reader parses the heap's huge-object index once, however many huge
+    /// objects are read through it, on both backends.
+    ///
+    /// Parsing it per object returns exactly the same bytes while making a walk
+    /// over the heap quadratic in the number of huge objects, so only the parse
+    /// count separates the two.
+    #[test]
+    fn a_reader_parses_the_huge_object_index_once() {
+        use crate::source::BytesSource;
+        const COUNT: u64 = 5;
+
+        // Attributes too large for a managed heap object, so the heap holds
+        // nothing but huge ones.
+        let mut builder = crate::FileBuilder::new();
+        for i in 0..COUNT {
+            builder.set_attr(
+                &format!("a{i}"),
+                crate::AttrValue::StringArray(vec![format!("{i:0700}"); 100]),
+            );
+        }
+        builder.create_dataset("x").with_f64_data(&[1.0]);
+        let bytes = builder.finish().unwrap();
+
+        let frhp = bytes
+            .windows(4)
+            .position(|w| w == b"FRHP")
+            .expect("dense storage writes a fractal heap");
+        let heap = FractalHeapHeader::parse(&bytes, frhp, 8, 8).unwrap();
+
+        // A huge heap ID: type 1 in bits 4-5 of byte 0, then the object's id,
+        // little-endian, across the rest of the ID. The writer's own encoding,
+        // which lets this reach the objects without walking the name index.
+        let heap_id = |id: u64| {
+            let mut bytes = vec![0u8; heap.heap_id_length as usize];
+            bytes[0] = 0x10;
+            for (i, slot) in bytes[1..].iter_mut().take(8).enumerate() {
+                *slot = ((id >> (i * 8)) & 0xFF) as u8;
+            }
+            bytes
+        };
+        let ids: Vec<Vec<u8>> = (1..=COUNT).map(heap_id).collect();
+
+        let mut reader = heap.object_reader(8, 8);
+        let buffered: Vec<Vec<u8>> = ids
+            .iter()
+            .map(|id| reader.read(&bytes, id).unwrap())
+            .collect();
+        assert_eq!(reader.index_parses, 1, "buffered reads re-parsed the index");
+
+        let source = BytesSource::new(bytes.clone());
+        let mut reader = heap.object_reader(8, 8);
+        let streamed: Vec<Vec<u8>> = ids
+            .iter()
+            .map(|id| reader.read_from_source(&source, id).unwrap())
+            .collect();
+        assert_eq!(
+            reader.index_parses, 1,
+            "streaming reads re-parsed the index"
+        );
+
+        assert_eq!(buffered, streamed);
+        assert_eq!(buffered.len(), COUNT as usize);
+        for (i, object) in buffered.iter().enumerate() {
+            assert!(
+                object.windows(2).any(|w| w == format!("a{i}").as_bytes()),
+                "object {i} is not the attribute message it should be"
+            );
+        }
     }
 
     #[test]

--- a/src/group_v2.rs
+++ b/src/group_v2.rs
@@ -564,3 +564,113 @@ mod tests {
         assert!(matches!(err, FormatError::PathNotFound(_)));
     }
 }
+
+/// The dense-link walks hold to the same one-parse-per-walk invariant as the
+/// dense-attribute ones. Gated to 64-bit targets with the reference C library,
+/// which is the only writer that produces a huge *link*: this crate's writer
+/// stores even a 60,000-byte link name as a managed heap object, so the huge
+/// path these tests cover is unreachable from a file it wrote.
+#[cfg(all(test, not(target_pointer_width = "32")))]
+mod huge_link_tests {
+    use super::*;
+    use crate::fractal_heap::{huge_index_decodes, reset_huge_index_decodes};
+    use crate::signature;
+    use crate::source::BytesSource;
+
+    /// A file with one group of `count` links, each name long enough that its
+    /// link message exceeds the heap's managed-object limit and is stored as a
+    /// huge object.
+    fn file_with_huge_links(count: usize) -> Vec<u8> {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("huge_links.h5");
+        {
+            let file = hdf5::FileBuilder::new()
+                .with_fapl(|fapl| fapl.libver_latest())
+                .create(&path)
+                .unwrap();
+            let group = file.create_group("g").unwrap();
+            for i in 0..count {
+                let name = format!("d{i}_{}", "x".repeat(5000));
+                group
+                    .new_dataset::<i32>()
+                    .shape((1,))
+                    .create(name.as_str())
+                    .unwrap()
+                    .write(&[i as i32])
+                    .unwrap();
+            }
+            file.close().unwrap();
+        }
+        std::fs::read(&path).unwrap()
+    }
+
+    /// Group `g`'s dense-link storage: its info message, its heap address, and
+    /// the file's offset and length sizes.
+    fn dense_link_info(bytes: &[u8]) -> (LinkInfoMessage, u64, u8, u8) {
+        let sig = signature::find_signature(bytes).unwrap();
+        let superblock = Superblock::parse(bytes, sig).unwrap();
+        let (offset_size, length_size) = (superblock.offset_size, superblock.length_size);
+        let group_addr = resolve_path_any(bytes, &superblock, "g").unwrap();
+        let header = ObjectHeader::parse(
+            bytes,
+            group_addr.to_usize().unwrap(),
+            offset_size,
+            length_size,
+        )
+        .unwrap();
+        let link_info = find_link_info(&header, offset_size).unwrap();
+        let fh_addr = link_info
+            .fractal_heap_address
+            .expect("this many long-named links are stored densely");
+        (link_info, fh_addr, offset_size, length_size)
+    }
+
+    /// Both dense-link walks resolve every huge object against one parse of the
+    /// heap's huge-object index, not one parse per link.
+    ///
+    /// Costs, not answers, are what regress here: parsing the index per object
+    /// returns exactly the same links while making the walk quadratic in their
+    /// number, so the count of parses is the only thing that catches it.
+    #[test]
+    fn a_dense_link_walk_parses_its_huge_object_index_once() {
+        // Above the C library's max_compact of 8, so the links are stored densely.
+        const COUNT: usize = 12;
+        let bytes = file_with_huge_links(COUNT);
+        let (link_info, fh_addr, offset_size, length_size) = dense_link_info(&bytes);
+
+        reset_huge_index_decodes();
+        let buffered =
+            resolve_dense_entries(&bytes, &link_info, fh_addr, offset_size, length_size).unwrap();
+        assert_eq!(buffered.len(), COUNT, "the walk must still read every link");
+        assert_eq!(
+            huge_index_decodes(),
+            1,
+            "the buffered walk parsed the huge-object index per link rather than per walk"
+        );
+
+        reset_huge_index_decodes();
+        let source = BytesSource::new(bytes);
+        let streamed = resolve_dense_entries_from_source(
+            &source,
+            &link_info,
+            fh_addr,
+            offset_size,
+            length_size,
+        )
+        .unwrap();
+        assert_eq!(streamed.len(), COUNT);
+        assert_eq!(
+            huge_index_decodes(),
+            1,
+            "the streaming walk parsed the huge-object index per link rather than per walk"
+        );
+
+        let names: Vec<&str> = buffered.iter().map(|e| e.name.as_str()).collect();
+        for (i, entry) in streamed.iter().enumerate() {
+            assert!(
+                names.contains(&entry.name.as_str()),
+                "link {i} differs between the two backends"
+            );
+        }
+    }
+}

--- a/src/group_v2.rs
+++ b/src/group_v2.rs
@@ -86,6 +86,7 @@ fn resolve_dense_entries(
         BTreeV2Header::parse(file_data, btree_addr.to_usize()?, offset_size, length_size)?;
     let records = collect_btree_v2_records(file_data, &btree_hdr, offset_size, length_size)?;
 
+    let mut heap = fh.object_reader(offset_size, length_size);
     let mut entries = Vec::new();
     for record in &records {
         // For type 5 (name index): hash(4) + heap_id(heap_id_length)
@@ -102,7 +103,7 @@ fn resolve_dense_entries(
         let id_bytes = &record.data[id_offset..id_offset + fh.heap_id_length as usize];
 
         // Read the link message from the fractal heap (managed or huge object).
-        let link_data = fh.read_object(file_data, id_bytes, offset_size, length_size)?;
+        let link_data = heap.read(file_data, id_bytes)?;
 
         // Parse as Link message
         let link = LinkMessage::parse(&link_data, offset_size)?;
@@ -355,6 +356,7 @@ fn resolve_dense_entries_from_source<S: Source + ?Sized>(
     let records =
         collect_btree_v2_records_from_source(source, &btree_hdr, offset_size, length_size)?;
 
+    let mut heap = fh.object_reader(offset_size, length_size);
     let mut entries = Vec::new();
     for record in &records {
         let id_offset = if btree_hdr.tree_type == 5 { 4 } else { 8 };
@@ -362,7 +364,7 @@ fn resolve_dense_entries_from_source<S: Source + ?Sized>(
             continue;
         }
         let id_bytes = &record.data[id_offset..id_offset + fh.heap_id_length as usize];
-        let link_data = fh.read_object_from_source(source, id_bytes, offset_size, length_size)?;
+        let link_data = heap.read_from_source(source, id_bytes)?;
         let link = LinkMessage::parse(&link_data, offset_size)?;
         if let LinkTarget::Hard {
             object_header_address,


### PR DESCRIPTION
Reading an object's dense attributes resolved each huge one by parsing the heap's huge-objects B-tree from scratch, so a walk over N huge attributes parsed that index N times. Quadratic in the count, on a path that only became reachable in #214: 1,600 huge attributes took ~164 ms to read in release, ~557 ms in debug.

Objects now come out of a `HeapObjectReader` that holds the heap header together with the indexes resolving them needs, rather than one at a time off `FractalHeapHeader`. The index is decoded on the first huge object and binary-searched by id after that, a heap without huge objects never parses one at all, and all four dense walks (attributes and links, buffered and streaming) build one reader for the whole walk. The same 1,600 attributes now read in ~75 ms, and the growth is linear.

The old per-object entry points are removed rather than kept as wrappers, so the quadratic shape has nowhere to come back from.

The heap's huge-objects B-tree is also now checked to be the record layout it is read as. Type 1 was inferred from the heap header's own fields, which is a fact about the heap rather than about the tree; a file whose two disagree had an object ID decoded out of a filtered record's mask bytes. `FormatError::UnexpectedHugeObjectBTree` covers both a wrong record type and records too short for type 1, replacing an `UnexpectedEof` that read as truncation.

A reader's cached index holds addresses resolved against one image of the file, so which backend filled it is recorded and asserted on reuse. No caller mixes them; this is where that would surface, rather than in silently wrong bytes.

## Tests

The invariant is a cost, and a cost leaves no trace in the objects returned, so the tests that pin it count parses instead of comparing answers. The count is a thread-local counter incremented in the decode itself, so a walk that builds its reader internally can still be held to it.

Four tests cover it: the reader's own memo across both backends, the buffered dense-attribute walk (the path `File::open` takes), the streaming one (counted end to end at the B-tree's own address through a counting `Source`), and both dense-link walks. A fifth pins the laziness — a heap with no huge object must never parse an index. The link test writes its file with the reference C library, since this crate's writer stores even a 60,000-byte link name as a managed object and so cannot produce the case.

Mutation-verified: reverting the memo fails exactly those four of 579 lib tests and nothing else in the suite, and reverting the hoist at any single walk fails that walk's test alone.

Follow-on to #214; the remaining shapes in #195 (deeper name index, indirect blocks) are untouched, so this leaves that issue open.
