### PR TITLE
Say why the options types are not property lists (#198)

### DIFF
--- a/src/file_create_options.rs
+++ b/src/file_create_options.rs
@@ -10,6 +10,11 @@ use crate::libver::LibVer;
 /// can define a file layout once and reuse it everywhere it writes, instead of
 /// repeating a builder call chain and keeping the copies in sync.
 ///
+/// It is named for what it is rather than after the C type: a plain `Copy`
+/// value, with no handle to create or close, no runtime property registry, and
+/// no setter that can fail. The C spellings are doc aliases instead, so a search
+/// for `fcpl` or for an individual `H5Pset_*` still lands here.
+///
 /// Pass it to [`FileBuilder::with_create_options`](crate::FileBuilder::with_create_options)
 /// or [`File::create_with_options`](crate::File::create_with_options). The
 /// equivalent [`FileBuilder`](crate::FileBuilder) methods set the same fields one
@@ -45,7 +50,6 @@ use crate::libver::LibVer;
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[doc(alias = "fcpl")]
-#[doc(alias = "H5Pcreate")]
 pub struct FileCreateOptions {
     userblock: u64,
     libver_bounds: Option<(LibVer, LibVer)>,

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -161,6 +161,11 @@ fn frame(bytes: &[u8], base: u64) -> Result<&[u8], FormatError> {
 /// `H5Fopen`. Every `*_with_options` constructor on [`File`] accepts it, so a
 /// read path and a read-write path can share one configuration.
 ///
+/// It is named for what it is rather than after the C type: a plain `Copy`
+/// value, with no handle to create or close, no runtime property registry, and
+/// no setter that can fail. The C spellings are doc aliases instead, so a search
+/// for `fapl` or for an individual `H5Pset_*` still lands here.
+///
 /// - The metadata cache (`H5Pset_mdc_config`) applies to the streaming and
 ///   bounded backends; an in-memory open already holds the whole file in one
 ///   buffer.
@@ -175,7 +180,6 @@ fn frame(bytes: &[u8], base: u64) -> Result<&[u8], FormatError> {
 /// [property-support reference]: https://github.com/stephenberry/hdf5-pure/blob/main/docs/reference/property-support.md
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[doc(alias = "fapl")]
-#[doc(alias = "H5Pset_fapl")]
 pub struct FileAccessOptions {
     metadata_cache: MetadataCacheConfig,
     chunk_cache: ChunkCacheConfig,


### PR DESCRIPTION
`FileAccessOptions` and `FileCreateOptions` are this crate's `fapl` and `fcpl` analogues, and the question of why they are not named after the C types has now come up twice in #198. Both now answer it where it gets asked, in their own rustdoc: they are named for what they are, plain `Copy` values with no handle to create or close, no runtime property registry, and no setter that can fail, and the C spellings stay reachable as doc aliases.

Two of those aliases were removed, both naming the handle lifecycle the types just disclaimed:

- `H5Pset_fapl` is not a C function. The real `H5Pset_fapl_*` calls select a virtual file driver, which this crate does not implement.
- `H5Pcreate` is real but does not discriminate: it constructs every property list class, so aliasing it to `FileCreateOptions` answered a search for a dataset or link property list with file-creation options.

`fapl` and `fcpl` name the two types exactly, and the per-property `H5Pset_*` aliases cover the operations, so neither removal costs a search that lands correctly.

Documentation only. No public API changes, so no changelog entry and no version bump.
