### PR TITLE
Edit the file through a FileImage rather than a Vec mirror (#198)

### DIFF
--- a/src/edit.rs
+++ b/src/edit.rs
@@ -356,8 +356,8 @@ append_typed! {
 /// The in-place write engine behind the owned read-write [`File`](crate::File)
 /// (its `Backend::Mirror`).
 ///
-/// Mirrors the file in memory and keeps a writable handle; every mutation is
-/// applied to both so the on-disk file stays consistent. It carries two commit
+/// Reads and edits the file through a [`FileImage`], which owns the writable
+/// handle and decides how much of the file is resident. It carries two commit
 /// models: staged tree edits applied by [`commit`](Self::commit), and immediate
 /// crash-atomic in-place appends ([`append_inplace`](Self::append_inplace)).
 pub(crate) struct WriteEngine {
@@ -642,6 +642,20 @@ impl WriteEngine {
         Self::open_inner(path.as_ref(), Some(locking))
     }
 
+    /// Open exactly as [`open_with_locking`](Self::open_with_locking) does, but
+    /// behind an image that withholds its whole-file slice, so every read takes
+    /// the [`Source`] path rather than the slice fast path.
+    ///
+    /// A test opening the same file both ways and comparing results is what
+    /// keeps the two forms of each read from drifting apart before a mirrorless
+    /// backing exists to exercise the second one (issue #198).
+    #[cfg(test)]
+    pub(crate) fn open_source_only(path: &Path) -> Result<Self, Error> {
+        Self::open_imaged(path, Some(FileLocking::Enabled), |mirror| {
+            Box::new(crate::image::SourceOnlyImage::new(mirror))
+        })
+    }
+
     /// Open an existing file for SWMR (single-writer/multiple-reader) writing:
     /// take **no** OS lock at all and raise the superblock's SWMR-write
     /// consistency flag. Backs [`File::open_swmr_writer`](crate::File::open_swmr_writer).
@@ -684,6 +698,21 @@ impl WriteEngine {
     /// that policy (the ordinary read-write session); `lock = None` takes no lock
     /// at all (the SWMR writer — see [`open_swmr_writer`](Self::open_swmr_writer)).
     fn open_inner(path: &Path, lock: Option<FileLocking>) -> Result<Self, Error> {
+        Self::open_imaged(path, lock, |mirror| Box::new(mirror))
+    }
+
+    /// Open a session, letting the caller choose how the mirror is presented to
+    /// the engine.
+    ///
+    /// `wrap` exists so a test can substitute an image that withholds its slice
+    /// (`SourceOnlyImage`) and drive the engine's mirrorless read paths, which
+    /// no production backing selects yet (issue #198). The production path
+    /// passes the identity.
+    fn open_imaged(
+        path: &Path,
+        lock: Option<FileLocking>,
+        wrap: impl FnOnce(MirrorImage) -> Box<dyn FileImage>,
+    ) -> Result<Self, Error> {
         let mut handle = fs::OpenOptions::new()
             .read(true)
             .write(true)
@@ -724,7 +753,7 @@ impl WriteEngine {
         }
         // Normalize the root group address to an absolute file offset, exactly as
         // the reader does (`reader::parse_superblock`), so `resolve_path_any` and
-        // the link-graph walk index `self.data` correctly. It is converted back to a
+        // the link-graph walk index the image correctly. It is converted back to a
         // stored (base-relative) address only when the superblock is serialized on
         // commit.
         superblock.root_group_address = superblock
@@ -736,7 +765,7 @@ impl WriteEngine {
             })?;
 
         let mut session = Self {
-            image: Box::new(MirrorImage::new(handle, data)),
+            image: wrap(MirrorImage::new(handle, data)),
             sb_sig_off,
             superblock,
             pending_datasets: Vec::new(),
@@ -1246,7 +1275,7 @@ impl WriteEngine {
 
     /// Apply a gathered in-place append (typed / generic / raw bytes) to `dataset`,
     /// immediately and crash-atomically, driving the shared Extensible-Array engine
-    /// against the session's own mirror through an [`EditMirror`] adapter. Runs only
+    /// against the session's own image through an [`EditStore`] adapter. Runs only
     /// the first `max_phase` durability phases; production callers pass 4, the
     /// crash-consistency tests stop at a boundary to simulate a crash.
     fn append_inplace_gathered(
@@ -1367,8 +1396,8 @@ impl WriteEngine {
 
         // Read/plan phase (immutable borrows only, nothing published yet), then the
         // ordered, fsync-barriered write phase — both shared with `Dataset::append`
-        // through the chunk-index engine. `EditMirror` borrows only the
-        // mirror-carrying fields, so `self.located` stays independently borrowable.
+        // through the chunk-index engine. `EditStore` borrows only the
+        // image-carrying fields, so `self.located` stays independently borrowable.
         let plan_result = {
             let st = &self.located[&oh_addr];
             let mirror = EditStore {
@@ -4633,7 +4662,7 @@ impl WriteEngine {
     /// padded to a page boundary, the padding being recorded as free space of the
     /// outgoing type.
     ///
-    /// Call this **before** reading [`self.data.len()`](Self::data) to compute an
+    /// Call this **before** reading the image's end-of-file ([`Source::len`]) to compute an
     /// address that will be embedded in the bytes being built: several callers
     /// (the chunk blob, the extensible-array index, the dense-attribute blob)
     /// build content whose interior addresses assume it lands at the current

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -157,7 +157,7 @@
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs;
-use std::io::{Read, Seek, SeekFrom, Write};
+use std::io::Read;
 use std::path::Path;
 
 use crate::checksum::jenkins_lookup3;
@@ -191,6 +191,7 @@ use crate::free_space_manager::{
     plan_paged_managers, serialize_file_fsm,
 };
 use crate::group_v2::resolve_group_entries_from_source;
+use crate::image::{FileImage, MirrorImage};
 use crate::link_message::{LinkMessage, LinkTarget};
 use crate::message_type::MessageType;
 use crate::object_header::ObjectHeader;
@@ -360,16 +361,16 @@ append_typed! {
 /// models: staged tree edits applied by [`commit`](Self::commit), and immediate
 /// crash-atomic in-place appends ([`append_inplace`](Self::append_inplace)).
 pub(crate) struct WriteEngine {
-    handle: fs::File,
-    /// In-memory mirror of the file, kept byte-for-byte in sync with `handle`.
+    /// The file bytes this session reads and edits, behind the [`FileImage`]
+    /// abstraction: reads go through its [`Source`] impl, and the write side —
+    /// the end-of-file cursor, `append`, `write_at`, `truncate`, and the
+    /// durability barriers — through its own primitives.
     ///
-    /// Every *read* the engine performs against the file image goes through
-    /// [`image`](Self::image), which lends this out as a [`Source`] — no parser
-    /// is handed the whole-file slice any more (issue #198). What still reaches
-    /// in directly is the write side: the end-of-file cursor, `append`,
-    /// `write_at`, and `truncate`, plus [`mirror_bytes`](Self::mirror_bytes) for
-    /// the owned read-write [`File`](crate::File)'s reads.
-    data: Vec<u8>,
+    /// Nothing in the engine assumes the whole file is resident, so one engine
+    /// serves both a whole-file mirror and a file-backed image that holds only
+    /// what it is reading (issue #198). [`image_slice`](Self::image_slice)
+    /// exposes the mirror's buffer where a caller can exploit it.
+    image: Box<dyn FileImage>,
     /// Absolute offset of the superblock signature in the file.
     sb_sig_off: usize,
     /// Parsed superblock. On-disk addresses are stored relative to `base_address`;
@@ -674,13 +675,8 @@ impl WriteEngine {
     pub(crate) fn set_consistency_flags(&mut self, flags: u32) -> Result<(), Error> {
         self.superblock.consistency_flags = flags;
         let bytes = self.superblock.serialize();
-        self.data[self.sb_sig_off..self.sb_sig_off + bytes.len()].copy_from_slice(&bytes);
-        self.handle
-            .seek(SeekFrom::Start(self.sb_sig_off as u64))
-            .map_err(Error::Io)?;
-        self.handle.write_all(&bytes).map_err(Error::Io)?;
-        self.handle.flush().map_err(Error::Io)?;
-        self.handle.sync_data().map_err(Error::Io)?;
+        self.write_at(self.sb_sig_off, &bytes)?;
+        self.image.sync_data()?;
         Ok(())
     }
 
@@ -740,8 +736,7 @@ impl WriteEngine {
             })?;
 
         let mut session = Self {
-            handle,
-            data,
+            image: Box::new(MirrorImage::new(handle, data)),
             sb_sig_off,
             superblock,
             pending_datasets: Vec::new(),
@@ -831,7 +826,7 @@ impl WriteEngine {
             return;
         }
         let os = self.superblock.offset_size;
-        let file_len = self.data.len() as u64;
+        let file_len = self.image.len();
 
         // Seed the free list(s) with every persisted section (addresses are stored
         // relative to the base address, which this editor requires to be 0).
@@ -1173,22 +1168,33 @@ impl WriteEngine {
             || !self.pending_cross_copies.is_empty()
     }
 
-    /// The session's whole-file in-memory mirror, reflecting committed state plus
-    /// immediate in-place appends (not edits still staged for `commit`). Used by
-    /// the owned read-write [`File`](crate::File) to serve reads on a mirror
-    /// backend.
-    pub(crate) fn mirror_bytes(&self) -> &[u8] {
-        &self.data
+    /// This session's file image as one slice, when its backing holds the whole
+    /// file in memory; `None` for a file-backed image.
+    ///
+    /// The slice reflects committed state plus immediate in-place appends, not
+    /// edits still staged for `commit`. The owned read-write
+    /// [`File`](crate::File) uses it to serve reads by borrowing rather than
+    /// copying, and falls back to [`image`](Self::image) when it is absent.
+    pub(crate) fn image_slice(&self) -> Option<&[u8]> {
+        self.image.as_slice()
     }
 
     /// A random-access [`Source`] view of this session's file image, for the
     /// parsers the edit engine drives.
     ///
     /// Every read the engine performs against the file goes through this, so the
-    /// image can become something other than a whole-file mirror without touching
-    /// the parsers themselves (issue #198).
-    fn image(&self) -> BytesSource<&[u8]> {
-        BytesSource::new(&self.data[..])
+    /// image needs to be no more than a source of bytes — whole-file mirror or
+    /// not — without the parsers knowing which (issue #198).
+    pub(crate) fn image(&self) -> &dyn Source {
+        self.image.as_ref()
+    }
+
+    /// This session's parsed superblock, with `root_group_address` normalized to
+    /// an absolute file offset (the open-time convention) and `base_address` the
+    /// userblock size. A relocating commit updates it, so a caller holding a
+    /// clone from an earlier moment may be reading a stale root.
+    pub(crate) fn superblock(&self) -> &Superblock {
+        &self.superblock
     }
 
     /// A snapshot of this session's live space usage — the current file size and
@@ -1232,7 +1238,7 @@ impl WriteEngine {
         };
         let reusable_free_bytes = reusable_free_space.iter().map(|(_, len)| len).sum();
         SpaceAccounting {
-            logical_size: self.data.len() as u64,
+            logical_size: self.image.len(),
             reusable_free_bytes,
             reusable_free_space,
         }
@@ -1319,9 +1325,8 @@ impl WriteEngine {
         // Locate the dataset on the first append (cache miss) against the session's
         // own borrowed mirror — no second lock, no second mirror, no re-read.
         if !self.located.contains_key(&oh_addr) {
-            let mirror = EditMirror {
-                handle: &mut self.handle,
-                data: &mut self.data,
+            let mirror = EditStore {
+                image: self.image.as_mut(),
                 superblock: &mut self.superblock,
                 sb_sig_off: self.sb_sig_off,
             };
@@ -1366,9 +1371,8 @@ impl WriteEngine {
         // mirror-carrying fields, so `self.located` stays independently borrowable.
         let plan_result = {
             let st = &self.located[&oh_addr];
-            let mirror = EditMirror {
-                handle: &mut self.handle,
-                data: &mut self.data,
+            let mirror = EditStore {
+                image: self.image.as_mut(),
                 superblock: &mut self.superblock,
                 sb_sig_off: self.sb_sig_off,
             };
@@ -1388,9 +1392,8 @@ impl WriteEngine {
             .located
             .get_mut(&oh_addr)
             .expect("dataset located above");
-        let mut mirror = EditMirror {
-            handle: &mut self.handle,
-            data: &mut self.data,
+        let mut mirror = EditStore {
+            image: self.image.as_mut(),
             superblock: &mut self.superblock,
             sb_sig_off: self.sb_sig_off,
         };
@@ -1934,7 +1937,7 @@ impl WriteEngine {
             for (data_addr, raw) in &inplace_writes {
                 self.write_at(*data_addr, raw)?;
             }
-            self.handle.sync_all().map_err(Error::Io)?;
+            self.image.sync_all()?;
             return Ok(());
         }
 
@@ -2319,7 +2322,7 @@ impl WriteEngine {
         // as a whole-commit invariant against the pre-commit end-of-file. Any
         // dropped span (which should not occur for a well-formed file) only
         // leaks, never corrupts.
-        retain_disjoint_in_bounds(&mut to_free, self.data.len() as u64);
+        retain_disjoint_in_bounds(&mut to_free, self.image.len());
 
         // --- Apply: process deepest groups first so each parent sees its
         // children's new addresses, then repoint the superblock last.
@@ -2521,11 +2524,11 @@ impl WriteEngine {
         for (a, l, _) in to_free.drain(..) {
             self.free.free(a, l);
         }
-        let cur_eof = self.data.len() as u64;
+        let cur_eof = self.image.len();
         let trunc_to = self.free.take_trailing(cur_eof);
         let new_eof = trunc_to.unwrap_or(cur_eof);
 
-        self.handle.sync_all().map_err(Error::Io)?;
+        self.image.sync_all()?;
         // The root address is stored relative to the base address; the end-of-file
         // address is absolute. After writing the relative root to disk, keep the
         // in-memory `root_group_address` absolute (the open-time convention).
@@ -2543,12 +2546,12 @@ impl WriteEngine {
             new_sb.consistency_flags = 0;
             let sb_bytes = new_sb.serialize();
             self.write_at(self.sb_sig_off, &sb_bytes)?;
-            self.handle.sync_all().map_err(Error::Io)?;
+            self.image.sync_all()?;
             new_sb.root_group_address = new_root;
             self.superblock = new_sb;
         } else {
             self.repoint_v0v1_root(new_root - base, new_eof)?;
-            self.handle.sync_all().map_err(Error::Io)?;
+            self.image.sync_all()?;
             self.superblock.root_group_address = new_root;
             self.superblock.eof_address = new_eof;
         }
@@ -2559,14 +2562,8 @@ impl WriteEngine {
         // mere unreferenced slack, which the next open ignores; the reverse order
         // could advertise an end-of-file past the actual file length.
         if let Some(cut) = trunc_to {
-            self.handle.set_len(cut).map_err(Error::Io)?;
-            #[expect(
-                clippy::cast_possible_truncation,
-                reason = "cut is a shrink target <= the current file length, which equals \
-                          self.data.len() (a usize)"
-            )]
-            self.data.truncate(cut as usize);
-            self.handle.sync_all().map_err(Error::Io)?;
+            self.image.truncate(cut)?;
+            self.image.sync_all()?;
         }
         Ok(())
     }
@@ -2647,7 +2644,7 @@ impl WriteEngine {
             build_v2_object_header(&self.rewrite_extension_region(old_ext_addr, &placeholder)?)
                 .len() as u64;
 
-        let ext_addr = self.data.len() as u64;
+        let ext_addr = self.image.len();
         let fshd_addr = ext_addr + ext_len;
 
         // Build the real extension and the FSM blocks. With no free space to
@@ -2705,7 +2702,7 @@ impl WriteEngine {
 
         // Barrier, then repoint the superblock (root, eof, and the new extension)
         // — the linearization point — and sync it.
-        self.handle.sync_all().map_err(Error::Io)?;
+        self.image.sync_all()?;
         let mut new_sb = self.superblock.clone();
         new_sb.root_group_address = new_root;
         new_sb.eof_address = final_eof;
@@ -2715,7 +2712,7 @@ impl WriteEngine {
         new_sb.consistency_flags = 0;
         let sb_bytes = new_sb.serialize();
         self.write_at(self.sb_sig_off, &sb_bytes)?;
-        self.handle.sync_all().map_err(Error::Io)?;
+        self.image.sync_all()?;
         self.superblock = new_sb;
 
         // The repoint is durable: the prior free list plus this commit's vacated
@@ -2835,7 +2832,7 @@ impl WriteEngine {
             build_v2_object_header(&self.rewrite_extension_region(old_ext_addr, &placeholder)?)
                 .len() as u64;
 
-        let ext_addr = self.data.len() as u64;
+        let ext_addr = self.image.len();
         debug_assert_eq!(
             ext_addr % page_size,
             0,
@@ -2899,7 +2896,7 @@ impl WriteEngine {
 
         // Barrier, then repoint the superblock (root, eof, and the new extension)
         // — the linearization point — and sync it.
-        self.handle.sync_all().map_err(Error::Io)?;
+        self.image.sync_all()?;
         let mut new_sb = self.superblock.clone();
         new_sb.root_group_address = new_root;
         new_sb.eof_address = final_eof;
@@ -2907,7 +2904,7 @@ impl WriteEngine {
         new_sb.consistency_flags = 0;
         let sb_bytes = new_sb.serialize();
         self.write_at(self.sb_sig_off, &sb_bytes)?;
-        self.handle.sync_all().map_err(Error::Io)?;
+        self.image.sync_all()?;
         self.superblock = new_sb;
 
         // The repoint is durable. Only now are this commit's vacated regions
@@ -2936,7 +2933,7 @@ impl WriteEngine {
     /// recording the padding as free space of the tail page's type. A no-op on a
     /// non-paged file or an already-aligned one.
     fn pad_to_page(&mut self) -> Result<(), Error> {
-        let len = self.data.len() as u64;
+        let len = self.image.len();
         let pad = match &self.paged {
             Some(pg) if len % pg.page_size != 0 => {
                 Some((pg.last, pg.page_size - len % pg.page_size))
@@ -2964,12 +2961,12 @@ impl WriteEngine {
     /// Extend the file with zeros up to `target` (>= the current length), used by
     /// the paged tail to pad the final metadata page to its boundary.
     fn pad_zeros_to(&mut self, target: u64) -> Result<(), Error> {
-        let len = self.data.len() as u64;
+        let len = self.image.len();
         if target > len {
             let pad = (target - len).to_usize()?;
             self.append(&vec![0u8; pad])?;
         }
-        debug_assert_eq!(self.data.len() as u64, target);
+        debug_assert_eq!(self.image.len(), target);
         Ok(())
     }
 
@@ -4346,7 +4343,7 @@ impl WriteEngine {
         // The blob is raw data, and its embedded addresses are computed from the
         // end-of-file it lands at, so open a raw page *before* reading that offset.
         self.begin_page(PageType::Raw)?;
-        let eof = self.data.len() as u64;
+        let eof = self.image.len();
         // Build with the *stored* (base-relative) address the blob will occupy, so
         // its embedded addresses resolve to its real file offset once the reader adds
         // the userblock base back (see `build_chunked_dataset`). On a base-0 file this
@@ -4406,7 +4403,7 @@ impl WriteEngine {
         // computed from the end-of-file it lands at, so open a metadata page
         // *before* reading that offset.
         self.begin_page(PageType::Meta)?;
-        let eof = self.data.len() as u64;
+        let eof = self.image.len();
         // Build with the *stored* (base-relative) address the blob will occupy, so
         // every address it embeds resolves to its real file offset once the reader
         // adds the userblock base back (see `build_chunked_dataset`). On a base-0
@@ -4587,7 +4584,7 @@ impl WriteEngine {
         // the page before reading the offset keeps `begin_page`'s contract: no pad
         // may be inserted after an address the built bytes embed.
         self.begin_page(PageType::Raw)?;
-        let ea_base = self.data.len() as u64 - base;
+        let ea_base = self.image.len() - base;
         let ea_bytes =
             build_extensible_array_at(&combined, OFFSET_SIZE, LENGTH_SIZE, has_filters, ea_base)
                 .map_err(Error::Format)?;
@@ -4616,28 +4613,16 @@ impl WriteEngine {
         self.alloc_or_append_typed(&oh, PageType::Meta)
     }
 
-    /// Append `bytes` at end-of-file, updating both the mirror and the file.
-    /// Returns the absolute address the bytes were written at.
+    /// Append `bytes` at end-of-file, returning the absolute address they were
+    /// written at.
     fn append(&mut self, bytes: &[u8]) -> Result<u64, Error> {
-        // Write to disk before updating the in-memory mirror, so a failed write
-        // never leaves the mirror ahead of the file on disk.
-        let addr = self.data.len() as u64;
-        self.handle.seek(SeekFrom::Start(addr)).map_err(Error::Io)?;
-        self.handle.write_all(bytes).map_err(Error::Io)?;
-        self.data.extend_from_slice(bytes);
-        Ok(addr)
+        self.image.append(bytes)
     }
 
-    /// Overwrite bytes in place at `offset`, updating both the mirror and the
-    /// file. The caller guarantees the range already exists.
+    /// Overwrite bytes in place at `offset`. The caller guarantees the range
+    /// already exists.
     fn write_at(&mut self, offset: usize, bytes: &[u8]) -> Result<(), Error> {
-        // Write to disk before updating the in-memory mirror (see `append`).
-        self.handle
-            .seek(SeekFrom::Start(offset as u64))
-            .map_err(Error::Io)?;
-        self.handle.write_all(bytes).map_err(Error::Io)?;
-        self.data[offset..offset + bytes.len()].copy_from_slice(bytes);
-        Ok(())
+        self.image.write_at(offset as u64, bytes)
     }
 
     /// Ensure the next allocation begins in a page holding page type `ty`, on a
@@ -4658,7 +4643,7 @@ impl WriteEngine {
         // Decide the pad without holding a borrow of `self.paged` across the append.
         // `prev` is the outgoing page type to record the padding under, or `None`
         // for a crash-recovery pad whose tail-page type is unknown.
-        let len = self.data.len() as u64;
+        let len = self.image.len();
         let pad = match &self.paged {
             Some(pg) if len % pg.page_size != 0 => {
                 let pad_len = pg.page_size - len % pg.page_size;
@@ -4679,7 +4664,7 @@ impl WriteEngine {
             _ => None,
         };
         if let Some((prev, pad_len)) = pad {
-            let pad_at = self.data.len() as u64;
+            let pad_at = self.image.len();
             self.append(&vec![0u8; pad_len.to_usize()?])?;
             if let Some(pg) = self.paged.as_mut() {
                 match prev {
@@ -4922,7 +4907,7 @@ impl WriteEngine {
         // The blob is raw data whose embedded addresses are computed from the
         // end-of-file it lands at, so open a raw page *before* reading that offset.
         self.begin_page(PageType::Raw)?;
-        let eof = self.data.len() as u64;
+        let eof = self.image.len();
         // The blob embeds *stored* (base-relative) addresses, so the planner base is
         // the stored address the blob will occupy: its end-of-file offset minus the
         // userblock base. The reader recovers each as `stored + base_address`, which
@@ -5239,7 +5224,7 @@ impl WriteEngine {
             spans.push((addr.checked_add(base)?, len, PageType::Raw));
         }
         let mut plain: Vec<(u64, u64)> = spans.iter().map(|&(a, l, _)| (a, l)).collect();
-        if !spans_disjoint_in_bounds(&mut plain, self.data.len() as u64) {
+        if !spans_disjoint_in_bounds(&mut plain, self.image.len()) {
             return None;
         }
         Some(spans)
@@ -5290,7 +5275,7 @@ impl WriteEngine {
         for (a, _) in &mut spans {
             *a = a.checked_add(base)?;
         }
-        if !spans_disjoint_in_bounds(&mut spans, self.data.len() as u64) {
+        if !spans_disjoint_in_bounds(&mut spans, self.image.len()) {
             return None;
         }
         Some(spans)
@@ -5591,32 +5576,46 @@ struct FlatDataset {
 }
 
 /// A borrow adapter that drives the shared Extensible-Array append engine
-/// ([`crate::chunk_index_inplace`]) against the engine's *own* mirror,
-/// handle, and superblock, so a session runs an immediate O(1) in-place append
-/// without constructing a second writable handle (which would take a second exclusive
-/// lock and keep a divergent mirror). It borrows only the mirror-carrying fields,
-/// leaving [`WriteEngine::located`] independently borrowable. Its primitives write
-/// to disk *before* the mirror — the session's discipline, the opposite of the
-/// append/SWMR writers' mirror-before-disk order; the [`Store`] trait lets
-/// each owner keep its own failure-path discipline while sharing the checksummed
-/// slot/block mechanics.
-struct EditMirror<'a> {
-    handle: &'a mut fs::File,
-    data: &'a mut Vec<u8>,
+/// ([`crate::chunk_index_inplace`]) against the engine's *own* image and
+/// superblock, so a session runs an immediate O(1) in-place append without
+/// constructing a second writable handle (which would take a second exclusive
+/// lock and keep a divergent view of the file). It borrows only those two
+/// fields, leaving [`WriteEngine::located`] independently borrowable.
+///
+/// [`Store`] is the append engine's view of a file — an image *plus* the
+/// superblock, which the image itself knows nothing about. Pairing them here is
+/// all this adapter does; every primitive delegates, so the image's own
+/// write-ordering discipline is what applies.
+///
+/// It takes [`Store`]'s default `append_raw`/`append_meta` — plain end-of-file
+/// appends that do not keep a page homogeneous — because the immediate in-place
+/// append refuses every paged file before reaching here: a non-persisting one
+/// explicitly, and a persisting one through the persist guard that routes it to
+/// the staged commit. The paged-aware appends live on [`WriteEngine`] itself,
+/// which is where a paged file is grown.
+struct EditStore<'a> {
+    image: &'a mut dyn FileImage,
     superblock: &'a mut Superblock,
     sb_sig_off: usize,
 }
 
-impl crate::source::Source for EditMirror<'_> {
+impl crate::source::Source for EditStore<'_> {
     fn len(&self) -> u64 {
-        self.data.len() as u64
+        self.image.len()
     }
     fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), crate::error::FormatError> {
-        crate::source::BytesSource::new(&self.data[..]).read_at(offset, buf)
+        self.image.read_at(offset, buf)
+    }
+    fn read_metadata_at(
+        &self,
+        offset: u64,
+        len: usize,
+    ) -> Result<Vec<u8>, crate::error::FormatError> {
+        self.image.read_metadata_at(offset, len)
     }
 }
 
-impl Store for EditMirror<'_> {
+impl Store for EditStore<'_> {
     fn offset_size(&self) -> u8 {
         self.superblock.offset_size
     }
@@ -5624,23 +5623,10 @@ impl Store for EditMirror<'_> {
         self.superblock.length_size
     }
     fn append_bytes(&mut self, bytes: &[u8]) -> Result<u64, Error> {
-        // Disk before mirror, so a failed write never leaves the mirror ahead of
-        // the file (matching `WriteEngine::append`).
-        let addr = self.data.len() as u64;
-        self.handle.seek(SeekFrom::Start(addr)).map_err(Error::Io)?;
-        self.handle.write_all(bytes).map_err(Error::Io)?;
-        self.data.extend_from_slice(bytes);
-        Ok(addr)
+        self.image.append(bytes)
     }
     fn write_at(&mut self, offset: u64, bytes: &[u8]) -> Result<(), Error> {
-        // Disk before mirror (see `append_bytes`).
-        self.handle
-            .seek(SeekFrom::Start(offset))
-            .map_err(Error::Io)?;
-        self.handle.write_all(bytes).map_err(Error::Io)?;
-        let offset = offset.to_usize()?;
-        self.data[offset..offset + bytes.len()].copy_from_slice(bytes);
-        Ok(())
+        self.image.write_at(offset, bytes)
     }
     fn patch_superblock_eof(&mut self) -> Result<(), Error> {
         // Advance only the recorded end-of-file and re-serialize the superblock in
@@ -5648,15 +5634,13 @@ impl Store for EditMirror<'_> {
         // consistency flags and does NOT repoint the root group: base_address is 0
         // for every in-place-append-eligible file, so the normalized-absolute root
         // address serializes back to the same stored value.
-        let eof = self.data.len() as u64;
+        let eof = self.image.len();
         self.superblock.eof_address = eof;
         let bytes = self.superblock.serialize();
         self.write_at(self.sb_sig_off as u64, &bytes)
     }
     fn sync(&mut self) -> Result<(), Error> {
-        self.handle.flush().map_err(Error::Io)?;
-        self.handle.sync_data().map_err(Error::Io)?;
-        Ok(())
+        self.image.sync_data()
     }
 }
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -13,9 +13,15 @@
 //! different backings (issue #198). Historically `File::open_rw` held the whole
 //! file in a `Vec<u8>` mirror and carried the full staged-edit vocabulary,
 //! while `File::open_rw_bounded` held no mirror and could therefore only read
-//! and append. The difference between them is entirely a property of *where the
-//! bytes live*, not of what edits are expressible, so it belongs behind this
-//! trait rather than in two engines.
+//! and append. *That* limitation is a property of where the bytes live, not of
+//! what edits are expressible, so it belongs behind this trait rather than in
+//! two engines.
+//!
+//! The trait abstracts residency and nothing else. The two backends still
+//! differ in ways this seam does not reach and does not claim to: which files
+//! they will open at all (the bounded backend refuses a v0/v1 superblock,
+//! 4-byte offsets, and any userblock), and when they rewrite persisted
+//! free-space managers. Those are separate reconciliations.
 //!
 //! # Reads
 //!
@@ -28,11 +34,16 @@
 //!
 //! # The end-of-file cursor
 //!
-//! [`Source::len`] is the image's *logical* length, and appends extend it. For
-//! the mirror that is the buffer length; for a file-backed image it is a
-//! counter, which may be shorter than the real file if a previous session died
-//! mid-append (its trailing bytes are unreferenced slack, exactly as after a
-//! crash).
+//! [`Source::len`] is the image's end-of-file: [`append`](FileImage::append)
+//! places bytes there and extends it by exactly their length. For the mirror
+//! that is the buffer length; for a file-backed image it is a counter seeded
+//! from the file's real length at open.
+//!
+//! Callers depend on the exact-extension part, not just on monotonicity: the
+//! engine reads `len()`, builds a blob whose interior addresses assume it will
+//! land at that address, and only then appends. An implementation that inserted
+//! padding inside `append` would silently relocate every such blob, so padding
+//! belongs in a layer above this one.
 
 use std::fs;
 use std::io::{Seek, SeekFrom, Write};
@@ -48,14 +59,27 @@ use crate::source::{BytesSource, Source};
 /// mirror writes to disk first.
 pub(crate) trait FileImage: Source + Send + Sync {
     /// Append `bytes` at end-of-file, returning the absolute address they were
-    /// written at. Extends [`Source::len`] by `bytes.len()`.
+    /// written at — which is the pre-call [`Source::len`]. Extends `len` by
+    /// exactly `bytes.len()`; see the module docs for why callers rely on that.
+    ///
+    /// An implementation that caches reads must invalidate any entry covering
+    /// the appended range: a preceding [`truncate`](Self::truncate) can make an
+    /// address readable, then cached, then appended over.
     fn append(&mut self, bytes: &[u8]) -> Result<u64, Error>;
 
-    /// Overwrite `[offset, offset + bytes.len())` in place. The caller
-    /// guarantees the range already exists.
+    /// Overwrite `[offset, offset + bytes.len())` in place. The range must
+    /// already exist; the engine computes it from its own allocation, so a
+    /// range past end-of-file is a bug rather than a bad file, and
+    /// implementations may assert it.
     fn write_at(&mut self, offset: u64, bytes: &[u8]) -> Result<(), Error>;
 
-    /// Shrink the image to `len` bytes, physically shortening the file.
+    /// Shrink the image to `len` bytes, physically shortening the file. `len`
+    /// must not exceed the current [`Source::len`]: this cannot grow an image,
+    /// and implementations may assert that rather than define a growth
+    /// semantics no caller wants.
+    ///
+    /// The same cache-invalidation obligation as [`append`](Self::append)
+    /// applies to the discarded range.
     fn truncate(&mut self, len: u64) -> Result<(), Error>;
 
     /// Flush buffered writes and force the file's *data* to durable storage.
@@ -64,6 +88,12 @@ pub(crate) trait FileImage: Source + Send + Sync {
     /// Flush buffered writes and force the file's data **and metadata** to
     /// durable storage. Distinct from [`sync_data`](Self::sync_data) because a
     /// commit changes the file's length, which lives in that metadata.
+    ///
+    /// The distinction is not observable in this crate's test suite, which
+    /// simulates a crash by copying the file rather than by losing the page
+    /// cache. Weakening a call site from `sync_all` to `sync_data` would pass
+    /// every test and lose a committed file's length on power loss, so the
+    /// choice at each call site has to be preserved by inspection.
     fn sync_all(&mut self) -> Result<(), Error>;
 
     /// The whole image as one slice, for parsers that walk bytes directly.
@@ -119,18 +149,35 @@ impl FileImage for MirrorImage {
     }
 
     fn write_at(&mut self, offset: u64, bytes: &[u8]) -> Result<(), Error> {
+        debug_assert!(
+            offset.saturating_add(bytes.len() as u64) <= self.len(),
+            "write_at past end-of-file: {offset}+{} > {}",
+            bytes.len(),
+            self.len()
+        );
+        // Convert before touching the file so a failure leaves both sides
+        // untouched rather than the mirror behind the disk.
+        let offset_usize = offset.to_usize()?;
         self.handle
             .seek(SeekFrom::Start(offset))
             .map_err(Error::Io)?;
         self.handle.write_all(bytes).map_err(Error::Io)?;
-        let offset = offset.to_usize()?;
-        self.data[offset..offset + bytes.len()].copy_from_slice(bytes);
+        self.data[offset_usize..offset_usize + bytes.len()].copy_from_slice(bytes);
         Ok(())
     }
 
     fn truncate(&mut self, len: u64) -> Result<(), Error> {
+        debug_assert!(
+            len <= self.len(),
+            "truncate would grow the image: {len} > {}",
+            self.len()
+        );
+        // `set_len` grows a file where `Vec::truncate` no-ops, and a failed
+        // conversion after `set_len` would leave the mirror longer than the
+        // file. Convert first so neither side moves unless both can.
+        let len_usize = len.to_usize()?;
         self.handle.set_len(len).map_err(Error::Io)?;
-        self.data.truncate(len.to_usize()?);
+        self.data.truncate(len_usize);
         Ok(())
     }
 
@@ -141,11 +188,199 @@ impl FileImage for MirrorImage {
     }
 
     fn sync_all(&mut self) -> Result<(), Error> {
+        // `Write::flush` is a no-op for `fs::File`, so this matches the bare
+        // `sync_all` it replaced; it is here so the trait's documented "flush
+        // buffered writes" holds for an implementation that does buffer.
+        self.handle.flush().map_err(Error::Io)?;
         self.handle.sync_all().map_err(Error::Io)?;
         Ok(())
     }
 
     fn as_slice(&self) -> Option<&[u8]> {
         Some(&self.data)
+    }
+}
+
+/// A [`MirrorImage`] that withholds its slice, so every read routed through it
+/// takes the [`Source`] path instead of the whole-file fast path.
+///
+/// This exists to make the mirrorless read paths reachable before a mirrorless
+/// backing does. Each read the engine serves has two forms — one walking a
+/// borrowed slice, one going through `Source` — and until `File::open_rw_bounded`
+/// runs on this engine (issue #198), only the first would ever execute. Opening
+/// a file through this image runs the same tests down the other form and lets
+/// them be compared, which is the only thing that keeps the two from drifting.
+#[cfg(test)]
+pub(crate) struct SourceOnlyImage(MirrorImage);
+
+#[cfg(test)]
+impl SourceOnlyImage {
+    pub(crate) fn new(inner: MirrorImage) -> Self {
+        Self(inner)
+    }
+}
+
+#[cfg(test)]
+impl Source for SourceOnlyImage {
+    fn len(&self) -> u64 {
+        self.0.len()
+    }
+
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), FormatError> {
+        self.0.read_at(offset, buf)
+    }
+}
+
+#[cfg(test)]
+impl FileImage for SourceOnlyImage {
+    fn append(&mut self, bytes: &[u8]) -> Result<u64, Error> {
+        self.0.append(bytes)
+    }
+
+    fn write_at(&mut self, offset: u64, bytes: &[u8]) -> Result<(), Error> {
+        self.0.write_at(offset, bytes)
+    }
+
+    fn truncate(&mut self, len: u64) -> Result<(), Error> {
+        self.0.truncate(len)
+    }
+
+    fn sync_data(&mut self) -> Result<(), Error> {
+        self.0.sync_data()
+    }
+
+    fn sync_all(&mut self) -> Result<(), Error> {
+        self.0.sync_all()
+    }
+
+    // Deliberately inherits the `None` default: that is the whole point.
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Open a fresh file holding `initial`, wrapped as a mirror image.
+    fn image(dir: &std::path::Path, initial: &[u8]) -> (std::path::PathBuf, MirrorImage) {
+        let path = dir.join("image.bin");
+        std::fs::write(&path, initial).unwrap();
+        let handle = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&path)
+            .unwrap();
+        (path, MirrorImage::new(handle, initial.to_vec()))
+    }
+
+    /// The invariant the whole type exists to hold: after any primitive, the
+    /// mirror and the bytes on disk agree. Every case below asserts it, because
+    /// a primitive that updates only one side is exactly the defect that would
+    /// otherwise surface as a corrupt file much later.
+    fn assert_in_sync(path: &std::path::Path, img: &MirrorImage) {
+        let on_disk = std::fs::read(path).unwrap();
+        assert_eq!(
+            img.as_slice().unwrap(),
+            &on_disk[..],
+            "mirror and file disagree"
+        );
+        assert_eq!(img.len(), on_disk.len() as u64, "len disagrees with file");
+    }
+
+    #[test]
+    fn append_returns_the_pre_append_end_and_extends_by_exactly_the_length() {
+        let dir = tempfile::tempdir().unwrap();
+        let (path, mut img) = image(dir.path(), b"abcd");
+
+        let addr = img.append(b"XYZ").unwrap();
+
+        assert_eq!(addr, 4, "append must report the address it wrote at");
+        assert_eq!(
+            img.len(),
+            7,
+            "append must extend len by exactly bytes.len()"
+        );
+        assert_in_sync(&path, &img);
+    }
+
+    #[test]
+    fn write_at_overwrites_both_sides_in_place() {
+        let dir = tempfile::tempdir().unwrap();
+        let (path, mut img) = image(dir.path(), b"abcdef");
+
+        img.write_at(2, b"ZZ").unwrap();
+
+        assert_eq!(img.as_slice().unwrap(), b"abZZef");
+        assert_eq!(img.len(), 6, "an in-place write must not move end-of-file");
+        assert_in_sync(&path, &img);
+    }
+
+    #[test]
+    fn truncate_shrinks_both_sides() {
+        let dir = tempfile::tempdir().unwrap();
+        let (path, mut img) = image(dir.path(), b"abcdef");
+
+        img.truncate(2).unwrap();
+
+        assert_eq!(img.as_slice().unwrap(), b"ab");
+        assert_eq!(img.len(), 2);
+        assert_in_sync(&path, &img);
+    }
+
+    /// A write following a truncate must land at the shortened end-of-file, not
+    /// wherever the previous operation left the handle's cursor.
+    #[test]
+    fn append_after_truncate_lands_at_the_new_end() {
+        let dir = tempfile::tempdir().unwrap();
+        let (path, mut img) = image(dir.path(), b"abcdef");
+
+        img.truncate(3).unwrap();
+        let addr = img.append(b"Z").unwrap();
+
+        assert_eq!(addr, 3);
+        assert_eq!(img.as_slice().unwrap(), b"abcZ");
+        assert_in_sync(&path, &img);
+    }
+
+    /// Reads go through `Source`, so they must observe writes immediately —
+    /// the engine plans its next edit against bytes it just wrote.
+    #[test]
+    fn reads_observe_writes_immediately() {
+        let dir = tempfile::tempdir().unwrap();
+        let (_path, mut img) = image(dir.path(), b"abcdef");
+        img.write_at(0, b"ZY").unwrap();
+        img.append(b"!").unwrap();
+
+        let mut buf = [0u8; 3];
+        img.read_at(0, &mut buf).unwrap();
+        assert_eq!(&buf, b"ZYc");
+        img.read_at(6, &mut buf[..1]).unwrap();
+        assert_eq!(buf[0], b'!');
+    }
+
+    #[test]
+    fn reads_past_end_of_file_are_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let (_path, img) = image(dir.path(), b"abcd");
+
+        let mut buf = [0u8; 2];
+        assert!(img.read_at(3, &mut buf).is_err());
+    }
+
+    /// `SourceOnlyImage` must differ from the mirror in exactly one respect.
+    #[test]
+    fn source_only_withholds_the_slice_but_reads_the_same() {
+        let dir = tempfile::tempdir().unwrap();
+        let (_path, mirror) = image(dir.path(), b"abcdef");
+        let mut only = SourceOnlyImage::new(mirror);
+
+        assert!(only.as_slice().is_none(), "the slice must be withheld");
+
+        only.write_at(1, b"Z").unwrap();
+        only.append(b"gh").unwrap();
+        assert_eq!(only.len(), 8);
+
+        let mut buf = [0u8; 8];
+        only.read_at(0, &mut buf).unwrap();
+        assert_eq!(&buf, b"aZcdefgh");
     }
 }

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,0 +1,151 @@
+//! The byte image a mutating session edits: the [`FileImage`] trait and its
+//! whole-file mirror backend.
+//!
+//! # Why this exists
+//!
+//! [`Source`] describes how the *reader* gets bytes out of a file. This is its
+//! write-side counterpart: what a [`WriteEngine`](crate::edit::WriteEngine)
+//! needs of the bytes it is editing — the same random-access reads, plus the
+//! four primitives a commit performs (append at end-of-file, overwrite in
+//! place, truncate, and force durability).
+//!
+//! Separating it from the engine is what lets one engine drive two very
+//! different backings (issue #198). Historically `File::open_rw` held the whole
+//! file in a `Vec<u8>` mirror and carried the full staged-edit vocabulary,
+//! while `File::open_rw_bounded` held no mirror and could therefore only read
+//! and append. The difference between them is entirely a property of *where the
+//! bytes live*, not of what edits are expressible, so it belongs behind this
+//! trait rather than in two engines.
+//!
+//! # Reads
+//!
+//! [`FileImage`] extends [`Source`], so every parser the edit engine drives
+//! reads through the same interface it already uses. [`as_slice`](FileImage::as_slice)
+//! is the one concession to backing: a mirror can hand out its whole buffer,
+//! letting a slice-walking parser borrow rather than copy, and a file-backed
+//! image cannot. Callers that can exploit a slice should, and must have a
+//! `Source` path for when there is none.
+//!
+//! # The end-of-file cursor
+//!
+//! [`Source::len`] is the image's *logical* length, and appends extend it. For
+//! the mirror that is the buffer length; for a file-backed image it is a
+//! counter, which may be shorter than the real file if a previous session died
+//! mid-append (its trailing bytes are unreferenced slack, exactly as after a
+//! crash).
+
+use std::fs;
+use std::io::{Seek, SeekFrom, Write};
+
+use crate::convert::TryToUsize;
+use crate::error::{Error, FormatError};
+use crate::source::{BytesSource, Source};
+
+/// The file bytes a mutating session works on.
+///
+/// Implementors keep the image and the file on disk consistent, and are free to
+/// choose the order in which they update them; see [`MirrorImage`] for why the
+/// mirror writes to disk first.
+pub(crate) trait FileImage: Source + Send + Sync {
+    /// Append `bytes` at end-of-file, returning the absolute address they were
+    /// written at. Extends [`Source::len`] by `bytes.len()`.
+    fn append(&mut self, bytes: &[u8]) -> Result<u64, Error>;
+
+    /// Overwrite `[offset, offset + bytes.len())` in place. The caller
+    /// guarantees the range already exists.
+    fn write_at(&mut self, offset: u64, bytes: &[u8]) -> Result<(), Error>;
+
+    /// Shrink the image to `len` bytes, physically shortening the file.
+    fn truncate(&mut self, len: u64) -> Result<(), Error>;
+
+    /// Flush buffered writes and force the file's *data* to durable storage.
+    fn sync_data(&mut self) -> Result<(), Error>;
+
+    /// Flush buffered writes and force the file's data **and metadata** to
+    /// durable storage. Distinct from [`sync_data`](Self::sync_data) because a
+    /// commit changes the file's length, which lives in that metadata.
+    fn sync_all(&mut self) -> Result<(), Error>;
+
+    /// The whole image as one slice, for parsers that walk bytes directly.
+    ///
+    /// `Some` only for a backing that already holds the file in memory. A
+    /// caller must always have a [`Source`] path for the `None` case; this is a
+    /// fast path, not a capability check.
+    fn as_slice(&self) -> Option<&[u8]> {
+        None
+    }
+}
+
+/// A whole-file in-memory mirror plus the read/write handle it mirrors, kept
+/// byte-for-byte in sync. This is the backing behind [`File::open_rw`](crate::File::open_rw):
+/// reads are slice accesses and never touch the disk, at the cost of holding
+/// the entire file resident.
+///
+/// Every mutation writes to disk *before* updating the mirror, so a failed
+/// write can leave the mirror behind the file but never ahead of it. That
+/// direction is the safe one: the session re-reads its own mirror to plan
+/// later edits, and planning against bytes that are not yet on disk would
+/// commit a structure pointing at content that does not exist.
+pub(crate) struct MirrorImage {
+    handle: fs::File,
+    data: Vec<u8>,
+}
+
+impl MirrorImage {
+    /// Wrap an open read/write `handle` and the `data` already read from it.
+    /// The caller is responsible for the two agreeing.
+    pub(crate) fn new(handle: fs::File, data: Vec<u8>) -> Self {
+        Self { handle, data }
+    }
+}
+
+impl Source for MirrorImage {
+    fn len(&self) -> u64 {
+        self.data.len() as u64
+    }
+
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), FormatError> {
+        BytesSource::new(&self.data[..]).read_at(offset, buf)
+    }
+}
+
+impl FileImage for MirrorImage {
+    fn append(&mut self, bytes: &[u8]) -> Result<u64, Error> {
+        let addr = self.data.len() as u64;
+        self.handle.seek(SeekFrom::Start(addr)).map_err(Error::Io)?;
+        self.handle.write_all(bytes).map_err(Error::Io)?;
+        self.data.extend_from_slice(bytes);
+        Ok(addr)
+    }
+
+    fn write_at(&mut self, offset: u64, bytes: &[u8]) -> Result<(), Error> {
+        self.handle
+            .seek(SeekFrom::Start(offset))
+            .map_err(Error::Io)?;
+        self.handle.write_all(bytes).map_err(Error::Io)?;
+        let offset = offset.to_usize()?;
+        self.data[offset..offset + bytes.len()].copy_from_slice(bytes);
+        Ok(())
+    }
+
+    fn truncate(&mut self, len: u64) -> Result<(), Error> {
+        self.handle.set_len(len).map_err(Error::Io)?;
+        self.data.truncate(len.to_usize()?);
+        Ok(())
+    }
+
+    fn sync_data(&mut self) -> Result<(), Error> {
+        self.handle.flush().map_err(Error::Io)?;
+        self.handle.sync_data().map_err(Error::Io)?;
+        Ok(())
+    }
+
+    fn sync_all(&mut self) -> Result<(), Error> {
+        self.handle.sync_all().map_err(Error::Io)?;
+        Ok(())
+    }
+
+    fn as_slice(&self) -> Option<&[u8]> {
+        Some(&self.data)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,6 +206,8 @@ pub(crate) mod file_lock;
 #[cfg(feature = "std")]
 pub(crate) mod free_space;
 #[cfg(feature = "std")]
+pub(crate) mod image;
+#[cfg(feature = "std")]
 pub(crate) mod reader;
 #[cfg(feature = "std")]
 pub(crate) mod repack;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1611,6 +1611,24 @@ impl File {
         })
     }
 
+    /// Open exactly as [`open_rw`](Self::open_rw) does, but behind an image that
+    /// withholds its whole-file slice, so every read takes the `Source` path
+    /// rather than the slice fast path.
+    ///
+    /// Each read this file serves has two forms (see `with_engine`), and only
+    /// the slice form runs in production until a mirrorless backing lands
+    /// (issue #198). Opening the same file both ways and comparing is what
+    /// holds the other form to the same answers in the meantime.
+    #[cfg(test)]
+    pub(crate) fn open_rw_source_only(path: &std::path::Path) -> Result<Self, Error> {
+        Ok(File {
+            inner: Arc::new(FileInner::from_rw_session(
+                WriteEngine::open_source_only(path)?,
+                FileAccessProperties::new(),
+            )?),
+        })
+    }
+
     /// Open an existing file for **SWMR** (single-writer/multiple-reader)
     /// appending: take **no** OS lock (so concurrent readers, and Windows'
     /// mandatory locks, are never blocked) and raise the superblock's SWMR-write
@@ -3901,6 +3919,133 @@ fn is_group(header: &ObjectHeader) -> bool {
 mod tests {
     use super::*;
     use crate::FileBuilder;
+
+    /// Read everything a read-write file can serve through the paired read
+    /// paths, as comparable text.
+    ///
+    /// Each entry exercises a different `with_engine` call site: path
+    /// resolution, object-header parsing, group listing, attribute reads (both
+    /// the compact and the dense form), a whole-dataset read, and a row-range
+    /// read. Errors are formatted rather than unwrapped so that a *divergence in
+    /// which error* is reported also fails the comparison.
+    fn read_everything(file: &File) -> Vec<String> {
+        let mut out = Vec::new();
+        out.push(format!("root groups: {:?}", file.root().groups()));
+        out.push(format!("root datasets: {:?}", file.root().datasets()));
+        out.push(format!("root attrs: {:?}", sorted(file.root().attrs())));
+
+        for path in ["plain", "g/nested", "many_attrs", "missing", "g/missing"] {
+            match file.dataset(path) {
+                Ok(ds) => {
+                    out.push(format!("{path}: shape {:?}", ds.shape()));
+                    out.push(format!("{path}: attrs {:?}", sorted(ds.attrs())));
+                    out.push(format!("{path}: all {:?}", ds.read_i32()));
+                    out.push(format!("{path}: rows {:?}", ds.read_i32_rows(1, 2)));
+                    out.push(format!("{path}: raw rows {:?}", ds.read_raw_rows(0, 1)));
+                }
+                Err(e) => out.push(format!("{path}: error {e}")),
+            }
+        }
+        out
+    }
+
+    /// Attribute maps compare only after ordering; `HashMap`'s `Debug` is not
+    /// deterministic, and an ordering difference here would be noise rather
+    /// than the divergence this is looking for.
+    fn sorted(attrs: Result<HashMap<String, AttrValue>, Error>) -> Vec<String> {
+        match attrs {
+            Ok(map) => {
+                let mut v: Vec<String> =
+                    map.iter().map(|(k, val)| format!("{k}={val:?}")).collect();
+                v.sort();
+                v
+            }
+            Err(e) => vec![format!("error {e}")],
+        }
+    }
+
+    /// Drive `bytes` down both forms of every read a read-write file serves and
+    /// require identical answers.
+    ///
+    /// Every read has a slice form (walking the whole-file mirror) and a
+    /// `Source` form, and until a mirrorless backing lands (issue #198) only the
+    /// slice form ever runs. This makes the other form reachable now, so it
+    /// cannot quietly drift as its twin is edited.
+    fn assert_both_read_paths_agree(bytes: &[u8], what: &str) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("both.h5");
+        std::fs::write(&path, bytes).unwrap();
+
+        // One session at a time: `open_rw` takes an exclusive lock, and holding
+        // two over one path fails outright where OS locks are mandatory.
+        let via_mirror = {
+            let f = File::open_rw(&path).unwrap();
+            read_everything(&f)
+        };
+        let via_source = {
+            let f = File::open_rw_source_only(&path).unwrap();
+            read_everything(&f)
+        };
+
+        assert_eq!(
+            via_mirror.len(),
+            via_source.len(),
+            "{what}: the two read paths produced different numbers of results"
+        );
+        for (m, s) in via_mirror.iter().zip(&via_source) {
+            assert_eq!(m, s, "{what}: slice and Source read paths disagree");
+        }
+        // Guard the guard: a helper that read nothing would make the comparison
+        // vacuous, and a file whose datasets all failed to open would too.
+        assert!(
+            via_mirror.iter().any(|r| r.contains("all Ok(")),
+            "{what}: no dataset read succeeded, so this compared nothing"
+        );
+    }
+
+    /// A file exercising each paired read: a plain dataset, a nested one behind
+    /// a group (path resolution), and one carrying enough attributes to force
+    /// the dense (fractal-heap) attribute layout rather than compact messages.
+    fn both_paths_file_bytes(userblock: Option<u64>) -> Vec<u8> {
+        let mut b = FileBuilder::new();
+        if let Some(ub) = userblock {
+            b.with_userblock(ub);
+        }
+        b.create_dataset("plain")
+            .with_i32_data(&(0..24).collect::<Vec<i32>>())
+            .with_shape(&[6, 4])
+            .set_attr("units", AttrValue::String("m".into()));
+        // Well past the eight-attribute compact limit, so the header converts to
+        // the dense layout and the dense extraction path is the one that runs.
+        {
+            let ds = b
+                .create_dataset("many_attrs")
+                .with_i32_data(&(0..8).collect::<Vec<i32>>());
+            for i in 0..24 {
+                ds.set_attr(&format!("attr_{i:02}"), AttrValue::I64(i));
+            }
+        }
+        let mut g = b.create_group("g");
+        g.create_dataset("nested")
+            .with_i32_data(&(100..112).collect::<Vec<i32>>())
+            .with_shape(&[3, 4]);
+        b.add_group(g.finish());
+        b.finish().unwrap()
+    }
+
+    #[test]
+    fn both_read_paths_agree() {
+        assert_both_read_paths_agree(&both_paths_file_bytes(None), "no userblock");
+    }
+
+    /// The userblock case is the one where the two forms are built differently:
+    /// the slice form reframes by slicing at the base address, the `Source` form
+    /// wraps in a `BaseOffsetSource`. A file with a nonzero base is the only way
+    /// to compare them.
+    #[test]
+    fn both_read_paths_agree_with_a_userblock() {
+        assert_both_read_paths_agree(&both_paths_file_bytes(Some(512)), "512-byte userblock");
+    }
 
     /// One 256-element i32 dataset, chunked into 32-element chunks, in memory.
     fn chunked_file_bytes() -> Vec<u8> {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -507,7 +507,10 @@ impl FileInner {
         session: WriteEngine,
         properties: FileAccessProperties,
     ) -> Result<Self, Error> {
-        let (superblock, addr_offset) = Self::parse_superblock(session.mirror_bytes())?;
+        // The engine parsed and normalized this at open; take it rather than
+        // re-parsing, so the image need not be able to hand out a slice.
+        let superblock = session.superblock().clone();
+        let addr_offset = superblock.base_address;
         Ok(Self::from_parts(
             Backend::Mirror(Box::new(Mutex::new(session))),
             superblock,
@@ -605,12 +608,34 @@ impl FileInner {
             Backend::Streaming(s) => f(s.as_ref()),
             Backend::Mirror(m) => {
                 let core = m.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-                f(&BytesSource::new(core.mirror_bytes()))
+                f(core.image())
             }
             Backend::Bounded(m) => {
                 let engine = m.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
                 f(engine.store())
             }
+        }
+    }
+
+    /// Run a read against a read-write session's file image, choosing the form
+    /// its backing can serve: `on_slice` when the session holds the whole file
+    /// in memory, so a slice-walking parser borrows the bytes instead of copying
+    /// them, and `on_source` otherwise.
+    ///
+    /// Both closures must compute the same thing. The pair exists because a
+    /// mirror can hand out a whole-file slice and a file-backed image cannot,
+    /// not because the two backings answer differently (issue #198).
+    fn with_engine<R>(
+        engine: &Mutex<WriteEngine>,
+        on_slice: impl FnOnce(&[u8]) -> R,
+        on_source: impl FnOnce(&dyn Source) -> R,
+    ) -> R {
+        let core = engine
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        match core.image_slice() {
+            Some(data) => on_slice(data),
+            None => on_source(core.image()),
         }
     }
 
@@ -762,15 +787,16 @@ impl FileInner {
             Backend::Streaming(s) => {
                 group_v2::resolve_path_any_from_source(s.as_ref(), &self.superblock, path)?
             }
+            // A staged commit can relocate the object tree's root, so this
+            // file's cached superblock may name a stale one; resolve against the
+            // session's own superblock, which the commit updates.
             Backend::Mirror(m) => {
                 let core = m.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-                let data = core.mirror_bytes();
-                // A staged commit can relocate the object tree's root, so the
-                // cached superblock's root address may be stale; re-parse the
-                // (small, fixed) superblock from the live mirror to resolve
-                // against the committed root.
-                let (sb, _base) = Self::parse_superblock(data)?;
-                group_v2::resolve_path_any(data, &sb, path)?
+                let sb = core.superblock().clone();
+                match core.image_slice() {
+                    Some(data) => group_v2::resolve_path_any(data, &sb, path)?,
+                    None => group_v2::resolve_path_any_from_source(core.image(), &sb, path)?,
+                }
             }
             Backend::Bounded(m) => {
                 // Bounded appends never relocate object headers, so the cached
@@ -783,14 +809,12 @@ impl FileInner {
 
     /// The current root-group address (base-adjusted, absolute). For a read-write
     /// [`Backend::Mirror`] file a prior relocating commit can have moved the
-    /// root, so re-parse the live mirror's superblock; other backends use the
-    /// cached superblock. Falls back to the cached address if the re-parse fails.
+    /// root, so take the session's own superblock, which the commit updates;
+    /// other backends use this file's cached one.
     fn mirror_root_address(&self) -> u64 {
         if let Backend::Mirror(m) = &self.backend {
             let core = m.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-            if let Ok((sb, _base)) = Self::parse_superblock(core.mirror_bytes()) {
-                return sb.root_group_address;
-            }
+            return core.superblock().root_group_address;
         }
         self.superblock.root_group_address
     }
@@ -891,7 +915,7 @@ impl FileInner {
         match &self.backend {
             Backend::Mirror(m) => {
                 let core = m.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-                core.mirror_bytes().len() as u64
+                core.image().len()
             }
             Backend::Bounded(m) => {
                 let engine = m.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -920,16 +944,11 @@ impl FileInner {
             Backend::Streaming(s) => {
                 ObjectHeader::parse_from_source(s.as_ref(), address, os, ls, self.addr_offset)
             }
-            Backend::Mirror(m) => {
-                let core = m.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-                ObjectHeader::parse_with_base(
-                    core.mirror_bytes(),
-                    address.to_usize()?,
-                    os,
-                    ls,
-                    self.addr_offset,
-                )
-            }
+            Backend::Mirror(m) => Self::with_engine(
+                m,
+                |d| ObjectHeader::parse_with_base(d, address.to_usize()?, os, ls, self.addr_offset),
+                |s| ObjectHeader::parse_from_source(s, address, os, ls, self.addr_offset),
+            ),
             Backend::Bounded(m) => {
                 let engine = m.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
                 ObjectHeader::parse_from_source(engine.store(), address, os, ls, self.addr_offset)
@@ -993,10 +1012,11 @@ impl FileInner {
             Backend::Streaming(s) => {
                 group_v2::resolve_group_entries_from_source(s.as_ref(), hdr, os, ls, base)
             }
-            Backend::Mirror(m) => {
-                let core = m.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-                group_v2::resolve_group_entries(core.mirror_bytes(), hdr, os, ls, base)
-            }
+            Backend::Mirror(m) => Self::with_engine(
+                m,
+                |d| group_v2::resolve_group_entries(d, hdr, os, ls, base),
+                |s| group_v2::resolve_group_entries_from_source(s, hdr, os, ls, base),
+            ),
             Backend::Bounded(m) => {
                 let engine = m.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
                 group_v2::resolve_group_entries_from_source(engine.store(), hdr, os, ls, base)
@@ -1023,16 +1043,11 @@ impl FileInner {
         let (os, ls, base) = (self.offset_size(), self.length_size(), self.addr_offset);
         let attr_msgs = self.attr_messages_of(hdr)?;
         match &self.backend {
-            Backend::Mirror(m) => {
-                let core = m.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-                Ok(attrs_to_map(
-                    &attr_msgs,
-                    &BytesSource::new(core.mirror_bytes()),
-                    os,
-                    ls,
-                    base,
-                ))
-            }
+            Backend::Mirror(m) => Ok(Self::with_engine(
+                m,
+                |d| attrs_to_map(&attr_msgs, &BytesSource::new(d), os, ls, base),
+                |s| attrs_to_map(&attr_msgs, s, os, ls, base),
+            )),
             Backend::Bounded(m) => {
                 let engine = m.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
                 Ok(attrs_to_map(&attr_msgs, engine.store(), os, ls, base))
@@ -1083,15 +1098,18 @@ impl FileInner {
                 };
                 Ok(extract_attributes_full_from_source(&framed, hdr, os, ls)?)
             }
-            Backend::Mirror(m) => {
-                let core = m.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-                Ok(extract_attributes_full(
-                    frame(core.mirror_bytes(), base)?,
-                    hdr,
-                    os,
-                    ls,
-                )?)
-            }
+            Backend::Mirror(m) => Self::with_engine(
+                m,
+                |d| Ok(extract_attributes_full(frame(d, base)?, hdr, os, ls)?),
+                |s| {
+                    if base == 0 {
+                        Ok(extract_attributes_full_from_source(s, hdr, os, ls)?)
+                    } else {
+                        let framed = BaseOffsetSource { inner: s, base };
+                        Ok(extract_attributes_full_from_source(&framed, hdr, os, ls)?)
+                    }
+                },
+            ),
             Backend::Bounded(m) => {
                 let engine = m.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
                 let store = engine.store();
@@ -1153,20 +1171,27 @@ impl FileInner {
                     &framed, dl, ds, dt, pipeline, os, ls, cache,
                 )
             }
-            Backend::Mirror(m) => {
-                let core = m.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-                let data = core.mirror_bytes();
-                let frame = if base == 0 {
-                    data
-                } else {
-                    let start = base.to_usize()?;
-                    data.get(start..).ok_or(FormatError::UnexpectedEof {
-                        expected: start,
-                        available: data.len(),
-                    })?
-                };
-                data_read::read_raw_data_cached(frame, dl, ds, dt, pipeline, os, ls, cache)
-            }
+            Backend::Mirror(m) => Self::with_engine(
+                m,
+                |data| {
+                    let frame = if base == 0 {
+                        data
+                    } else {
+                        let start = base.to_usize()?;
+                        data.get(start..).ok_or(FormatError::UnexpectedEof {
+                            expected: start,
+                            available: data.len(),
+                        })?
+                    };
+                    data_read::read_raw_data_cached(frame, dl, ds, dt, pipeline, os, ls, cache)
+                },
+                |s| {
+                    let framed = BaseOffsetSource { inner: s, base };
+                    data_read::read_raw_data_cached_from_source(
+                        &framed, dl, ds, dt, pipeline, os, ls, cache,
+                    )
+                },
+            ),
             Backend::Bounded(m) => {
                 // A bounded file's base address is validated to 0 at open, so
                 // the store's absolute offsets serve base-relative addresses
@@ -1293,32 +1318,40 @@ impl FileInner {
                     &framed, dl, ds, dt, pipeline, os, ls, cache, start_row, num_rows, row_bytes,
                 )
             }
-            Backend::Mirror(m) => {
-                let core = m.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-                let data = core.mirror_bytes();
-                let frame = if base == 0 {
-                    data
-                } else {
-                    let start = base.to_usize()?;
-                    data.get(start..).ok_or(FormatError::UnexpectedEof {
-                        expected: start,
-                        available: data.len(),
-                    })?
-                };
-                read_rows_framed(
-                    &BytesSource::new(frame),
-                    dl,
-                    ds,
-                    dt,
-                    pipeline,
-                    os,
-                    ls,
-                    cache,
-                    start_row,
-                    num_rows,
-                    row_bytes,
-                )
-            }
+            Backend::Mirror(m) => Self::with_engine(
+                m,
+                |data| {
+                    let frame = if base == 0 {
+                        data
+                    } else {
+                        let start = base.to_usize()?;
+                        data.get(start..).ok_or(FormatError::UnexpectedEof {
+                            expected: start,
+                            available: data.len(),
+                        })?
+                    };
+                    read_rows_framed(
+                        &BytesSource::new(frame),
+                        dl,
+                        ds,
+                        dt,
+                        pipeline,
+                        os,
+                        ls,
+                        cache,
+                        start_row,
+                        num_rows,
+                        row_bytes,
+                    )
+                },
+                |s| {
+                    let framed = BaseOffsetSource { inner: s, base };
+                    read_rows_framed(
+                        &framed, dl, ds, dt, pipeline, os, ls, cache, start_row, num_rows,
+                        row_bytes,
+                    )
+                },
+            ),
             Backend::Bounded(m) => {
                 // A bounded file's base address is validated to 0 at open, so the
                 // store's absolute offsets serve base-relative addresses directly.


### PR DESCRIPTION
The staged-edit engine's write side reached straight into a whole-file `Vec<u8>`: the end-of-file cursor was `self.data.len()`, `append` pushed onto the vector, `write_at` indexed it, `truncate` shortened it, and `mirror_bytes` lent it whole to the reader. That is what confines staged edits to `File::open_rw` — `open_rw_bounded` keeps no such vector, so its whole staged surface is refused with `BoundedStagedUnsupported`.

The engine now holds a `Box<dyn FileImage>` instead. `FileImage` extends `Source` with the four primitives a commit performs (append, overwrite, truncate, force durability) plus an `as_slice` fast path for a backing that happens to hold the file in memory. `MirrorImage` is that backing today, so nothing observable changes; the point is that nothing in the engine assumes it any more.

## What follows from the seam

**`EditMirror` becomes `EditStore`.** The adapter that drove the shared Extensible-Array append engine against the session's own handle and vector now pairs an image with the superblock, which is all `Store` ever needed of it. Every primitive delegates, so the image's own write-ordering discipline applies rather than the adapter restating it.

**`File`'s read paths take a duality.** On a read-write backend they go through `with_engine`: `on_slice` when the session can hand out its buffer, `on_source` otherwise. Both closures compute the same thing — the pair exists because a mirror can lend a whole-file slice and a file-backed image cannot, not because the two backings answer differently.

**Path resolution takes the session's superblock.** It previously re-parsed one out of the mirror on every call. A relocating commit updates the session's superblock, which is what that re-parse was reaching for; taking it directly also drops a swallowed parse failure that silently fell back to a stale root address.

## Coverage

A green suite proves little about a refactor, so the seam was exercised directly rather than inferred.

| Experiment | Result |
| --- | --- |
| Force `with_engine` to take `on_source` for **every** read — the branch no backing selects yet | 1591 tests still pass |
| `MirrorImage::truncate` skips the mirror | caught by exactly one test, `edit_crosscheck::deleting_chunked_datasets_in_place_stays_c_readable` |
| `MirrorImage::append` skips the mirror | breaks the in-place append and variable-length paths |
| Resolve against the file's cached superblock instead of the session's | breaks five `owned_edit` tests |

The first line is the one that matters. The mirrorless read paths have no caller yet, so without forcing them they would ship untested; running the whole suite through them shows they are equivalent to the slice paths by measurement rather than by inspection.

Gates: fmt, clippy `-D warnings`, no_std, rustdoc, and the full suite at 1591 passed / 0 failed.

## Scope

No user-visible change, so no changelog entry — the same call made for #219.

This is the first half of issue #198's step 2's write side. Running the bounded backend on this engine and deleting the six `BoundedStagedUnsupported` sites follows in its own PR, which also has to reconcile two designs for one job: `BoundedEngine` rewrites its free-space managers once at close, valid because it only appends and never reuses a hole, while `WriteEngine` rewrites them at every commit. That PR is breaking (it removes `Error::BoundedStagedUnsupported`) and so carries the minor bump.

Object-header addresses remain `usize` in several engine-internal signatures. That caps a bounded session at a 4 GiB file on a 32-bit host, which is moot while the image is a `Vec<u8>` but becomes real once a file-backed one exists; it belongs with that follow-up.

Refs #198.