### PR TITLE
Write MAT complex arrays with integer components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Dropping a read-write `File` without `close` now re-homes the on-disk free-space managers of a persisting file and flushes, matching what `close` does; previously only `File::open_rw_bounded` handles did this. Staged edits are still discarded on drop ([#198](https://github.com/stephenberry/hdf5-pure/issues/198)).
 - **Breaking:** `Error::BoundedStagedUnsupported` is removed, along with the refusals that returned it ([#198](https://github.com/stephenberry/hdf5-pure/issues/198)).
+- A MAT complex vector written through `to_bytes_with_options` now takes the configured `OneDimensionalMode` like every other 1-D array; it was always a MATLAB row vector before, so existing callers of that path get columns under the default and their stored shape changes.
+- A MAT complex dataset whose `MATLAB_class` disagrees with its `{real, imag}` compound is refused instead of decoded. The integer classes previously errored here and briefly decoded as wrong values during this cycle's work.
 
 ### Fixed
-
-- A MAT complex vector now takes the configured `OneDimensionalMode` like every other 1-D array. Written through `to_bytes_with_options` it was always a MATLAB row vector, contradicting both the option and the shape the default `to_bytes` path gives it.
 - A one-element MAT complex array deserializes into a `Vec<Complex*>`, matching the allowance the real numeric path already makes for a one-element numeric array.
 - An empty MAT complex array of an integer class reads back as an empty complex array of that class rather than as an untyped empty vector.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Dropping a read-write `File` without `close` now re-homes the on-disk free-space managers of a persisting file and flushes, matching what `close` does; previously only `File::open_rw_bounded` handles did this. Staged edits are still discarded on drop ([#198](https://github.com/stephenberry/hdf5-pure/issues/198)).
 - **Breaking:** `Error::BoundedStagedUnsupported` is removed, along with the refusals that returned it ([#198](https://github.com/stephenberry/hdf5-pure/issues/198)).
 
+### Fixed
+
+- A MAT complex vector now takes the configured `OneDimensionalMode` like every other 1-D array. Written through `to_bytes_with_options` it was always a MATLAB row vector, contradicting both the option and the shape the default `to_bytes` path gives it.
+- A one-element MAT complex array deserializes into a `Vec<Complex*>`, matching the allowance the real numeric path already makes for a one-element numeric array.
+- An empty MAT complex array of an integer class reads back as an empty complex array of that class rather than as an untyped empty vector.
+
 ## [0.26.0] - 2026-07-27
 
 Attributes lose their size ceiling: one too large for an object-header message selects fractal-heap storage on its own, and one too large even for a managed heap object becomes a *huge* object, so `FormatError::DenseAttributeTooLarge` is gone rather than refusing a shape the reference library writes ([#195](https://github.com/stephenberry/hdf5-pure/issues/195)). Three defects on that path are fixed with it: a variable-length attribute stored in a fractal heap silently lost its values, dense attributes were unreadable in a file with a userblock, and reading many of them was quadratic in their number ([#214](https://github.com/stephenberry/hdf5-pure/pull/214), [#195](https://github.com/stephenberry/hdf5-pure/issues/195)). The property-list types are renamed to say what they stand in for — `FileAccessProperties`, `FileCreateProperties`, `DatasetAccessProperties` — and checking each one's settings against the official group pages caught two properties documented under the wrong class ([#198](https://github.com/stephenberry/hdf5-pure/issues/198)). Breaking, but every break is a one-line call-site edit, and deprecated aliases keep 0.25.0 code compiling for this cycle.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `File::open_rw_bounded` offers the full staged edit surface — `Dataset::write`, attribute edits, `create_*`/`delete`, `copy`, `commit`, `space_accounting` — at bounded memory: a commit holds only what it is building rather than a whole-file mirror. It still requires a latest-format file with 8-byte offsets and no userblock ([#198](https://github.com/stephenberry/hdf5-pure/issues/198)).
 - `Dataset::append` grows a file that persists its free space, including a paged one, from `File::open_rw` as well as `File::open_rw_bounded`; the on-disk free-space managers are re-homed when the file is closed ([#198](https://github.com/stephenberry/hdf5-pure/issues/198)).
 - A `Dataset` reached by object reference can append on either read-write open, not only `File::open_rw_bounded`. It is refused once the session stages or commits an edit, because a commit can move the object header the handle names ([#198](https://github.com/stephenberry/hdf5-pure/issues/198)).
+- MAT v7.3 complex arrays with integer components: `mat::ComplexI8`/`I16`/`I32`/`I64` and the `ComplexU*` counterparts join `Complex64`/`Complex32` across the serde, `Matrix<T>`, and `MatBuilder::write_complex_*` surfaces, so a capture that samples as 16-bit integer pairs stores four bytes per sample instead of eight. Components are never converted between widths: an `int16` complex dataset deserializes into `ComplexI16` and nothing else, in either direction.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -532,7 +532,7 @@ becomes a MATLAB variable. Mapping:
 | `f64`, `f32`, `i*`, `u*` | scalar dataset `[1,1]`, `MATLAB_class = "double"` / `"single"` / `"int*"` / `"uint*"` |
 | `bool` | `uint8` scalar, `MATLAB_class = "logical"` |
 | `String` / `&str` | `uint16` `[1, N]` UTF-16LE, `MATLAB_class = "char"` |
-| `Vec<T>` of numeric `T` | MATLAB `[N, 1]` column vector (HDF5 shape `[1, N]`); `OneDimensionalMode::RowVector` for `[1, N]` |
+| `Vec<T>` of numeric `T` | MATLAB `[N, 1]` column vector (HDF5 shape `[1, N]`); `OneDimensionalMode::RowVector` makes it a MATLAB `[1, N]` row |
 | `Matrix<T>` or `Vec<Vec<T>>` of same length | column-major 2-D dataset, HDF5 shape `[cols, rows]` |
 | `Complex64` / `Complex32` / `ComplexI16` / … | compound `{real, imag}` dataset, `MATLAB_class` = the *component* class |
 | nested struct | HDF5 group with `MATLAB_class = "struct"`, `MATLAB_fields` |

--- a/README.md
+++ b/README.md
@@ -534,7 +534,7 @@ becomes a MATLAB variable. Mapping:
 | `String` / `&str` | `uint16` `[1, N]` UTF-16LE, `MATLAB_class = "char"` |
 | `Vec<T>` of numeric `T` | `[1, N]` row vector |
 | `Matrix<T>` or `Vec<Vec<T>>` of same length | column-major 2-D dataset, HDF5 shape `[cols, rows]` |
-| `Complex32` / `Complex64` | compound `{real, imag}` dataset |
+| `Complex64` / `Complex32` / `ComplexI16` / … | compound `{real, imag}` dataset, `MATLAB_class` = the *component* class |
 | nested struct | HDF5 group with `MATLAB_class = "struct"`, `MATLAB_fields` |
 | `Option<T>` (struct field) | omitted if `None` |
 | unit enum variant | UTF-16 char dataset holding the variant name |

--- a/README.md
+++ b/README.md
@@ -532,7 +532,7 @@ becomes a MATLAB variable. Mapping:
 | `f64`, `f32`, `i*`, `u*` | scalar dataset `[1,1]`, `MATLAB_class = "double"` / `"single"` / `"int*"` / `"uint*"` |
 | `bool` | `uint8` scalar, `MATLAB_class = "logical"` |
 | `String` / `&str` | `uint16` `[1, N]` UTF-16LE, `MATLAB_class = "char"` |
-| `Vec<T>` of numeric `T` | `[1, N]` row vector |
+| `Vec<T>` of numeric `T` | MATLAB `[N, 1]` column vector (HDF5 shape `[1, N]`); `OneDimensionalMode::RowVector` for `[1, N]` |
 | `Matrix<T>` or `Vec<Vec<T>>` of same length | column-major 2-D dataset, HDF5 shape `[cols, rows]` |
 | `Complex64` / `Complex32` / `ComplexI16` / … | compound `{real, imag}` dataset, `MATLAB_class` = the *component* class |
 | nested struct | HDF5 group with `MATLAB_class = "struct"`, `MATLAB_fields` |

--- a/docs/interop/matlab.md
+++ b/docs/interop/matlab.md
@@ -11,7 +11,7 @@ A MATLAB v7.3 `.mat` file is an HDF5 file dressed in MATLAB conventions: a 512-b
 
 ## Requires the `serde` feature
 
-The high-level `.mat` API is gated on the `serde` feature, which is off by default. The `mat::Matrix`, `mat::Complex32`, `mat::Complex64`, and `mat::MatElement` items, along with `mat::to_file` / `mat::from_file`, are only available when it is enabled. See the [features reference](../reference/features.md) for the full list.
+The high-level `.mat` API is gated on the `serde` feature, which is off by default. The `mat::Matrix`, the `mat::Complex*` types, and `mat::MatElement`, along with `mat::to_file` / `mat::from_file`, are only available when it is enabled. See the [features reference](../reference/features.md) for the full list.
 
 ```toml
 [dependencies]
@@ -66,7 +66,7 @@ The serializer maps Rust types to HDF5 datasets and the MATLAB classes MATLAB ex
 | `String` / `&str` | `uint16` `[1, N]` UTF-16LE, `MATLAB_class = "char"` |
 | `Vec<T>` of numeric `T` | `[1, N]` row vector |
 | `Matrix<T>` or `Vec<Vec<T>>` of same length | column-major 2-D dataset, HDF5 shape `[cols, rows]` |
-| `Complex32` / `Complex64` | compound `{real, imag}` dataset |
+| `Complex64` / `Complex32` / `ComplexI16` / … | compound `{real, imag}` dataset, `MATLAB_class` = the *component* class |
 | nested struct | HDF5 group with `MATLAB_class = "struct"`, `MATLAB_fields` |
 | `Option<T>` (struct field) | omitted if `None` |
 | unit `()` / unit struct / `serde_json::Value::Null` (struct field) | omitted, same as `None` (see caveat below) |
@@ -93,11 +93,30 @@ let v = Frame {
 mat::to_file(&v, "matrix.mat").unwrap();
 ```
 
-A bare `Vec<Vec<T>>` whose rows all share a length is also recognized as a 2-D matrix, but `Matrix` is the unambiguous API. The element type `T` is bounded by the sealed `mat::MatElement` trait, which is implemented for `f32`/`f64`, the 8/16/32/64-bit signed and unsigned integers, `bool`, `Complex32`, and `Complex64`. The trait is sealed because MAT v7.3 admits only this fixed set of numeric classes; you cannot implement it for other types.
+A bare `Vec<Vec<T>>` whose rows all share a length is also recognized as a 2-D matrix, but `Matrix` is the unambiguous API. The element type `T` is bounded by the sealed `mat::MatElement` trait, which is implemented for `f32`/`f64`, the 8/16/32/64-bit signed and unsigned integers, `bool`, and every complex type. The trait is sealed because MAT v7.3 admits only this fixed set of numeric classes; you cannot implement it for other types.
 
 ### Complex numbers
 
-`Complex32` and `Complex64` are compound `{real, imag}` newtypes constructed with `Complex64::new(re, im)` (or the `re` / `im` fields directly). A bare value becomes a compound scalar `[1, 1]`; a `Vec<Complex64>` becomes a compound dataset `[1, N]`. The on-disk layout is the same `{real, imag}` compound MATLAB uses for complex arrays. For a deeper treatment of HDF5 compound datasets see the [compound types guide](../guide/compound-types.md).
+There is one complex newtype per component class — `Complex64` and `Complex32` for the float classes, `ComplexI8` / `ComplexI16` / `ComplexI32` / `ComplexI64` and the `ComplexU*` counterparts for the integer ones — each constructed with `ComplexI16::new(re, im)` (or the `re` / `im` fields directly). A bare value becomes a compound scalar `[1, 1]`; a `Vec<ComplexI16>` becomes a compound dataset `[1, N]`. The on-disk layout is the same `{real, imag}` compound MATLAB uses for complex arrays. For a deeper treatment of HDF5 compound datasets see the [compound types guide](../guide/compound-types.md).
+
+`MATLAB_class` names the *component* class, not anything complex-specific, which is how MATLAB tells `complex(int16(re), int16(im))` from a complex `double`. Picking the component your data actually has is worth doing: a capture that samples as pairs of 16-bit integers takes four bytes per sample as `ComplexI16` and eight as `Complex32`, and the extra four carry nothing.
+
+```rust
+use hdf5_pure::mat::{self, ComplexI16};
+use serde::{Serialize, Deserialize};
+
+#[derive(Serialize, Deserialize)]
+struct Capture { samples: Vec<ComplexI16> }
+
+let v = Capture {
+    samples: vec![ComplexI16::new(-32768, 32767), ComplexI16::new(0, -1)],
+};
+mat::to_file(&v, "capture.mat").unwrap();
+```
+
+One consumer-side caveat worth knowing before choosing an integer component: MATLAB stores and loads complex integer arrays, but it refuses *arithmetic* on them — `a * b` on two complex `int16` values raises "Complex integer arithmetic is not supported", and the caller has to `double(...)` them first (or use Fixed-Point Designer's `fi` objects). That is a property of MATLAB, not of the file: the array arrives intact and `isa(x, 'int16')` and `iscomplex(x)` both hold. It costs nothing for a capture format that is stored compactly and widened once at the point of use, which is the case this exists for.
+
+Components are never converted between widths, in either direction. An `int16` complex dataset deserializes into `ComplexI16` and nothing else: reading it as `Complex64` would be lossless and is still refused, because the component width is part of what the file says it holds. Reading a `double` capture into `ComplexI16` is refused for the same reason, and would truncate. A caller holding float data that it knows to be exact integers is the one that can decide whether narrowing is meaningful, so do the conversion before serializing.
 
 ## Cell arrays
 

--- a/docs/interop/matlab.md
+++ b/docs/interop/matlab.md
@@ -64,7 +64,7 @@ The serializer maps Rust types to HDF5 datasets and the MATLAB classes MATLAB ex
 | `f64`, `f32`, `i*`, `u*` | scalar dataset `[1,1]`, `MATLAB_class = "double"` / `"single"` / `"int*"` / `"uint*"` |
 | `bool` | `uint8` scalar, `MATLAB_class = "logical"` |
 | `String` / `&str` | `uint16` `[1, N]` UTF-16LE, `MATLAB_class = "char"` |
-| `Vec<T>` of numeric `T` | `[1, N]` row vector |
+| `Vec<T>` of numeric `T` | MATLAB `[N, 1]` column vector (HDF5 shape `[1, N]`); see [1-D vector orientation](#1-d-vector-orientation) |
 | `Matrix<T>` or `Vec<Vec<T>>` of same length | column-major 2-D dataset, HDF5 shape `[cols, rows]` |
 | `Complex64` / `Complex32` / `ComplexI16` / … | compound `{real, imag}` dataset, `MATLAB_class` = the *component* class |
 | nested struct | HDF5 group with `MATLAB_class = "struct"`, `MATLAB_fields` |
@@ -75,6 +75,26 @@ The serializer maps Rust types to HDF5 datasets and the MATLAB classes MATLAB ex
 
 !!! note "Unit and `null` fields round-trip with `#[serde(default)]`"
     A struct field that serializes as a Rust unit `()` is dropped from the output, exactly like `Option::None`. The most common case is a `serde_json::Value::Null` field, since `serde_json` serializes `Value::Null` via `serialize_unit`. Because the field is absent on disk, reading it back needs `#[serde(default)]` on the field (or an `Option<T>` field, which serde defaults to `None` automatically); with a default, a `serde_json::Value` field reconstructs as `Value::Null`. A non-`Option` field that has no serde default fails to deserialize the dropped field with a missing-field error, so add `#[serde(default)]` (or use `Option<T>`) if the field can be absent.
+
+### 1-D vector orientation
+
+A `Vec<T>` becomes a MATLAB **column** vector — MATLAB `[N, 1]`, stored as HDF5 shape `[1, N]`, since HDF5 storage is the transpose of the MATLAB shape. Every 1-D array follows this rule, complex ones included.
+
+[`to_bytes`](https://docs.rs/hdf5-pure/latest/hdf5_pure/mat/fn.to_bytes.html) is fixed at that default. To get MATLAB `[1, N]` rows instead, write through `to_bytes_with_options` with `one_dimensional_mode: OneDimensionalMode::RowVector`:
+
+```rust
+use hdf5_pure::mat::{self, OneDimensionalMode, Options};
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct Capture { samples: Vec<f64> }
+
+let mut opts = Options::default();
+opts.one_dimensional_mode = OneDimensionalMode::RowVector;
+let bytes = mat::to_bytes_with_options(&Capture { samples: vec![1.0, 2.0, 3.0] }, &opts).unwrap();
+```
+
+This matters when the same data reaches MATLAB by more than one route. [BEVE](https://github.com/beve-org/beve)'s MATLAB loader (`matlab/load_beve.m`) reconstructs a complex array as `complex(raw(1,:), raw(2,:))`, a `1×N` **row**; a pipeline that writes the same captures as both BEVE and `.mat` should set `RowVector` here so the two agree in the MATLAB workspace rather than differing by a transpose.
 
 ### Matrices and the column-major convention
 

--- a/docs/interop/matlab.md
+++ b/docs/interop/matlab.md
@@ -117,7 +117,7 @@ A bare `Vec<Vec<T>>` whose rows all share a length is also recognized as a 2-D m
 
 ### Complex numbers
 
-There is one complex newtype per component class — `Complex64` and `Complex32` for the float classes, `ComplexI8` / `ComplexI16` / `ComplexI32` / `ComplexI64` and the `ComplexU*` counterparts for the integer ones — each constructed with `ComplexI16::new(re, im)` (or the `re` / `im` fields directly). A bare value becomes a compound scalar `[1, 1]`; a `Vec<ComplexI16>` becomes a compound dataset `[1, N]`. The on-disk layout is the same `{real, imag}` compound MATLAB uses for complex arrays. For a deeper treatment of HDF5 compound datasets see the [compound types guide](../guide/compound-types.md).
+There is one complex newtype per component class — `Complex64` and `Complex32` for the float classes, `ComplexI8` / `ComplexI16` / `ComplexI32` / `ComplexI64` and the `ComplexU*` counterparts for the integer ones — each constructed with `ComplexI16::new(re, im)` (or the `re` / `im` fields directly). A bare value becomes a compound scalar of HDF5 shape `[1, 1]`; a `Vec<ComplexI16>` becomes a compound dataset of HDF5 shape `[1, N]`, which is a MATLAB column (see [1-D vector orientation](#1-d-vector-orientation)). The on-disk layout is the same `{real, imag}` compound MATLAB uses for complex arrays. For a deeper treatment of HDF5 compound datasets see the [compound types guide](../guide/compound-types.md).
 
 `MATLAB_class` names the *component* class, not anything complex-specific, which is how MATLAB tells `complex(int16(re), int16(im))` from a complex `double`. Picking the component your data actually has is worth doing: a capture that samples as pairs of 16-bit integers takes four bytes per sample as `ComplexI16` and eight as `Complex32`, and the extra four carry nothing.
 
@@ -137,6 +137,12 @@ mat::to_file(&v, "capture.mat").unwrap();
 One consumer-side caveat worth knowing before choosing an integer component: MATLAB stores and loads complex integer arrays, but it refuses *arithmetic* on them — `a * b` on two complex `int16` values raises "Complex integer arithmetic is not supported", and the caller has to `double(...)` them first (or use Fixed-Point Designer's `fi` objects). That is a property of MATLAB, not of the file: the array arrives intact and `isa(x, 'int16')` and `iscomplex(x)` both hold. It costs nothing for a capture format that is stored compactly and widened once at the point of use, which is the case this exists for.
 
 Components are never converted between widths, in either direction. An `int16` complex dataset deserializes into `ComplexI16` and nothing else: reading it as `Complex64` would be lossless and is still refused, because the component width is part of what the file says it holds. Reading a `double` capture into `ComplexI16` is refused for the same reason, and would truncate. A caller holding float data that it knows to be exact integers is the one that can decide whether narrowing is meaningful, so do the conversion before serializing.
+
+The same rule is enforced against the file itself: `MATLAB_class` names the component width, the `{real, imag}` compound carries the bytes, and a file where those two disagree is refused rather than decoded. This matters because the disagreement is not always visible — a complex `int64` array with no class attribute at all falls back to `double`, whose element size is identical, so the payload length alone cannot tell them apart.
+
+### Empty complex arrays
+
+An empty complex array is written here as a zero-element `{real, imag}` compound that keeps its component class, and it round-trips through this crate. MATLAB writes empties differently: `Mat_VarWriteEmpty` stores the dimensions *as data* under `MATLAB_empty = 1`, keeping the plain class name, and the `EmptyMarkerEncoding` option selects that form for real arrays. Complex arrays do not currently follow the option. libmatio reads both forms; if you need the MATLAB-native shape for an empty complex array specifically, write it as an empty real array of the component class instead.
 
 ## Cell arrays
 

--- a/examples/matlab_fixtures.rs
+++ b/examples/matlab_fixtures.rs
@@ -14,7 +14,7 @@
 //! % Then run the commands printed by the example.
 //! ```
 
-use hdf5_pure::mat::{self, Complex32, Complex64, Matrix};
+use hdf5_pure::mat::{self, Complex32, Complex64, ComplexI16, Matrix};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
@@ -306,6 +306,9 @@ fn write_options(dir: &Path) {
 struct ComplexData {
     z: Complex64,
     signal: Vec<Complex64>,
+    /// A complex integer array: MATLAB reads the component class off
+    /// `MATLAB_class`, so this must arrive as `int16` and not as a double.
+    samples_i16: Vec<ComplexI16>,
 }
 
 fn write_complex(dir: &Path) {
@@ -315,6 +318,9 @@ fn write_complex(dir: &Path) {
             "assert(iscomplex(z), 'z is complex')",
             "assert(z == complex(1.0, -2.0), 'z value')",
             "assert(isequal(signal, [complex(1,0); complex(0,1); complex(-1,0); complex(0,-1)]), 'signal')",
+            "assert(isa(samples_i16, 'int16'), 'samples_i16 class')",
+            "assert(iscomplex(samples_i16), 'samples_i16 is complex')",
+            "assert(isequal(samples_i16, [complex(int16(-32768), int16(32767)); complex(int16(0), int16(-1)); complex(int16(1234), int16(-4321))]), 'samples_i16 values')",
             "disp('complex.mat OK')",
         ],
     );
@@ -325,6 +331,11 @@ fn write_complex(dir: &Path) {
             Complex64::new(0.0, 1.0),
             Complex64::new(-1.0, 0.0),
             Complex64::new(0.0, -1.0),
+        ],
+        samples_i16: vec![
+            ComplexI16::new(i16::MIN, i16::MAX),
+            ComplexI16::new(0, -1),
+            ComplexI16::new(1234, -4321),
         ],
     };
     mat::to_file(&v, dir.join("complex.mat")).unwrap();

--- a/src/mat/builder.rs
+++ b/src/mat/builder.rs
@@ -41,7 +41,7 @@ use crate::mat::options::{Compression, EmptyMarkerEncoding, InvalidNamePolicy, O
 use crate::mat::string_object;
 use crate::mat::userblock::{self, USERBLOCK_SIZE};
 use crate::mat::utf16;
-use crate::type_builders::{DatasetBuilder, GroupBuilder};
+use crate::type_builders::{ComplexComponent, DatasetBuilder, GroupBuilder};
 use crate::writer::FileBuilder;
 
 const REFS_GROUP: &str = "#refs#";
@@ -477,51 +477,29 @@ impl MatBuilder {
         Ok(self)
     }
 
-    /// Write a complex `f64` array.
+    /// Write a complex array of the given component type.
     ///
-    /// Empty inputs produce a zero-element compound dataset (no
-    /// `MATLAB_empty` marker): MATLAB reads this back as an empty complex
-    /// array of the right class. Non-empty inputs honor the configured
-    /// compression settings.
-    pub fn write_complex_f64(
+    /// The dataset is a `{real, imag}` compound of `T` and carries the
+    /// *component* class in `MATLAB_class` — `"int16"` for a complex `i16`
+    /// array — which is how MATLAB distinguishes `complex(int16(re),
+    /// int16(im))` from a complex `double`. No width is ever substituted for
+    /// another: the class the file reports is the one the caller asked for.
+    fn write_complex_of<T: ComplexComponent>(
         &mut self,
         name: &str,
+        class: MatClass,
         matlab_dims: &[usize],
-        data: &[(f64, f64)],
+        data: &[(T, T)],
     ) -> Result<&mut Self, MatError> {
         let mut storage_buf = [0u64; STORAGE_DIMS_BUF_LEN];
         let storage = storage_dims_u64_into(matlab_dims, &mut storage_buf);
         let compression = self.options.compression;
         let target = self.resolve_target(name)?;
         let ds = self.dataset_at_target(&target);
-        ds.with_complex64_data(data).with_shape(storage);
+        ds.with_complex_data(data).with_shape(storage);
         ds.set_attr(
             "MATLAB_class",
-            AttrValue::AsciiString(MatClass::Double.as_str().into()),
-        );
-        if !data.is_empty() {
-            apply_deflate(ds, compression);
-        }
-        Ok(self)
-    }
-
-    /// Write a complex `f32` array. See [`write_complex_f64`](Self::write_complex_f64) for empty-input
-    /// and compression semantics.
-    pub fn write_complex_f32(
-        &mut self,
-        name: &str,
-        matlab_dims: &[usize],
-        data: &[(f32, f32)],
-    ) -> Result<&mut Self, MatError> {
-        let mut storage_buf = [0u64; STORAGE_DIMS_BUF_LEN];
-        let storage = storage_dims_u64_into(matlab_dims, &mut storage_buf);
-        let compression = self.options.compression;
-        let target = self.resolve_target(name)?;
-        let ds = self.dataset_at_target(&target);
-        ds.with_complex32_data(data).with_shape(storage);
-        ds.set_attr(
-            "MATLAB_class",
-            AttrValue::AsciiString(MatClass::Single.as_str().into()),
+            AttrValue::AsciiString(class.as_str().into()),
         );
         if !data.is_empty() {
             apply_deflate(ds, compression);
@@ -1246,26 +1224,6 @@ impl<'a> StructWriter<'a> {
         Ok(self)
     }
     #[inline]
-    pub fn write_complex_f64(
-        &mut self,
-        name: &str,
-        dims: &[usize],
-        data: &[(f64, f64)],
-    ) -> Result<&mut Self, MatError> {
-        self.mb.write_complex_f64(name, dims, data)?;
-        Ok(self)
-    }
-    #[inline]
-    pub fn write_complex_f32(
-        &mut self,
-        name: &str,
-        dims: &[usize],
-        data: &[(f32, f32)],
-    ) -> Result<&mut Self, MatError> {
-        self.mb.write_complex_f32(name, dims, data)?;
-        Ok(self)
-    }
-    #[inline]
     pub fn write_string_object(
         &mut self,
         name: &str,
@@ -1497,26 +1455,6 @@ impl<'a> CellWriter<'a> {
         self.record(r);
         Ok(self)
     }
-    pub fn push_complex_f64(
-        &mut self,
-        dims: &[usize],
-        data: &[(f64, f64)],
-    ) -> Result<&mut Self, MatError> {
-        let r = self.arm();
-        self.mb.write_complex_f64(&r, dims, data)?;
-        self.record(r);
-        Ok(self)
-    }
-    pub fn push_complex_f32(
-        &mut self,
-        dims: &[usize],
-        data: &[(f32, f32)],
-    ) -> Result<&mut Self, MatError> {
-        let r = self.arm();
-        self.mb.write_complex_f32(&r, dims, data)?;
-        self.record(r);
-        Ok(self)
-    }
     pub fn push_string_object(
         &mut self,
         values: &[String],
@@ -1599,6 +1537,90 @@ impl<'a> CellWriter<'a> {
     pub fn matrix_dims(&self, extents: &[usize]) -> Vec<usize> {
         self.mb.matrix_dims(extents)
     }
+}
+
+/// The complex writers, one per component class, on all three write scopes.
+///
+/// Every one of them is [`MatBuilder::write_complex_of`] with the class filled
+/// in, so a new component width is a line in the invocation below rather than
+/// three hand-written methods that can drift apart.
+macro_rules! complex_writers {
+    ($($write:ident / $push:ident => $ty:ty, $class:ident, $matlab:literal),* $(,)?) => {
+        impl MatBuilder {
+            $(
+                #[doc = concat!(
+                    "Write a complex `", stringify!($ty), "` array (MATLAB class `",
+                    $matlab, "`)."
+                )]
+                ///
+                /// Empty inputs produce a zero-element compound dataset with no
+                /// `MATLAB_empty` marker, which MATLAB reads back as an empty
+                /// complex array of this class. Non-empty inputs honor the
+                /// configured compression settings.
+                pub fn $write(
+                    &mut self,
+                    name: &str,
+                    matlab_dims: &[usize],
+                    data: &[($ty, $ty)],
+                ) -> Result<&mut Self, MatError> {
+                    self.write_complex_of(name, MatClass::$class, matlab_dims, data)
+                }
+            )*
+        }
+
+        impl StructWriter<'_> {
+            $(
+                #[doc = concat!(
+                    "Write a complex `", stringify!($ty),
+                    "` array into the open struct. See [`MatBuilder::",
+                    stringify!($write), "`]."
+                )]
+                #[inline]
+                pub fn $write(
+                    &mut self,
+                    name: &str,
+                    dims: &[usize],
+                    data: &[($ty, $ty)],
+                ) -> Result<&mut Self, MatError> {
+                    self.mb.$write(name, dims, data)?;
+                    Ok(self)
+                }
+            )*
+        }
+
+        impl CellWriter<'_> {
+            $(
+                #[doc = concat!(
+                    "Push a complex `", stringify!($ty),
+                    "` array as the next cell element. See [`MatBuilder::",
+                    stringify!($write), "`]."
+                )]
+                pub fn $push(
+                    &mut self,
+                    dims: &[usize],
+                    data: &[($ty, $ty)],
+                ) -> Result<&mut Self, MatError> {
+                    let r = self.arm();
+                    self.mb.$write(&r, dims, data)?;
+                    self.record(r);
+                    Ok(self)
+                }
+            )*
+        }
+    };
+}
+
+complex_writers! {
+    write_complex_f64 / push_complex_f64 => f64, Double, "double",
+    write_complex_f32 / push_complex_f32 => f32, Single, "single",
+    write_complex_i64 / push_complex_i64 => i64, Int64, "int64",
+    write_complex_i32 / push_complex_i32 => i32, Int32, "int32",
+    write_complex_i16 / push_complex_i16 => i16, Int16, "int16",
+    write_complex_i8 / push_complex_i8 => i8, Int8, "int8",
+    write_complex_u64 / push_complex_u64 => u64, UInt64, "uint64",
+    write_complex_u32 / push_complex_u32 => u32, UInt32, "uint32",
+    write_complex_u16 / push_complex_u16 => u16, UInt16, "uint16",
+    write_complex_u8 / push_complex_u8 => u8, UInt8, "uint8",
 }
 
 #[cfg(test)]

--- a/src/mat/complex.rs
+++ b/src/mat/complex.rs
@@ -6,6 +6,14 @@
 //!
 //! For `Vec<Complex64>` the serializer produces a compound dataset of shape
 //! `[1, N]`; a bare `Complex64` becomes a compound scalar of shape `[1, 1]`.
+//!
+//! There is one type per component class, because the component class *is* the
+//! array's MATLAB class: a [`ComplexI16`] array reports `int16`, not some
+//! complex-specific class, and a capture that samples as pairs of 16-bit
+//! integers stores in half the space its `single` equivalent would take.
+//! Nothing is ever widened on the way in or out — a value written as
+//! [`ComplexI16`] reads back only as [`ComplexI16`], so the file always says
+//! what it holds.
 
 use core::fmt;
 
@@ -13,75 +21,116 @@ use serde::de::{self, MapAccess, Visitor};
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-pub(crate) const COMPLEX32_SENTINEL: &str = "__hdf5_pure_mat_Complex32__";
-pub(crate) const COMPLEX64_SENTINEL: &str = "__hdf5_pure_mat_Complex64__";
+use crate::mat::value::ComplexTag;
 
-macro_rules! complex_type {
-    ($name:ident, $scalar:ty, $sentinel:ident) => {
-        /// Complex number stored as a MATLAB-compatible compound dataset.
-        #[derive(Debug, Clone, Copy, PartialEq)]
-        pub struct $name {
-            /// Real part.
-            pub re: $scalar,
-            /// Imaginary part.
-            pub im: $scalar,
-        }
+macro_rules! complex_types {
+    ($($name:ident => $scalar:ty, $sentinel:ident, $tag:ident, $matlab:literal),* $(,)?) => {
+        $(
+            #[doc = concat!(
+                "Sentinel struct name for [`", stringify!($name), "`]."
+            )]
+            pub(crate) const $sentinel: &str =
+                concat!("__hdf5_pure_mat_", stringify!($name), "__");
 
-        impl $name {
-            /// Build a new complex value.
-            pub const fn new(re: $scalar, im: $scalar) -> Self {
-                Self { re, im }
+            #[doc = concat!(
+                "A complex number with `", stringify!($scalar),
+                "` components, stored as a MATLAB `", $matlab,
+                "` complex array."
+            )]
+            #[derive(Debug, Clone, Copy, PartialEq)]
+            pub struct $name {
+                /// Real part.
+                pub re: $scalar,
+                /// Imaginary part.
+                pub im: $scalar,
             }
-        }
 
-        impl Serialize for $name {
-            fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-                let mut s = serializer.serialize_struct($sentinel, 2)?;
-                s.serialize_field("real", &self.re)?;
-                s.serialize_field("imag", &self.im)?;
-                s.end()
+            impl $name {
+                /// Build a new complex value.
+                pub const fn new(re: $scalar, im: $scalar) -> Self {
+                    Self { re, im }
+                }
             }
-        }
 
-        impl<'de> Deserialize<'de> for $name {
-            fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-                struct ComplexVisitor;
+            impl Serialize for $name {
+                fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+                    let mut s = serializer.serialize_struct($sentinel, 2)?;
+                    s.serialize_field("real", &self.re)?;
+                    s.serialize_field("imag", &self.im)?;
+                    s.end()
+                }
+            }
 
-                impl<'de> Visitor<'de> for ComplexVisitor {
-                    type Value = $name;
-                    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                        f.write_str(concat!(
-                            stringify!($name),
-                            " struct with fields `real` and `imag`"
-                        ))
-                    }
-                    fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<$name, A::Error> {
-                        let mut re: Option<$scalar> = None;
-                        let mut im: Option<$scalar> = None;
-                        while let Some(key) = map.next_key::<String>()? {
-                            match key.as_str() {
-                                "real" => re = Some(map.next_value()?),
-                                "imag" => im = Some(map.next_value()?),
-                                _ => {
-                                    let _: serde::de::IgnoredAny = map.next_value()?;
+            impl<'de> Deserialize<'de> for $name {
+                fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+                    struct ComplexVisitor;
+
+                    impl<'de> Visitor<'de> for ComplexVisitor {
+                        type Value = $name;
+                        fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                            f.write_str(concat!(
+                                stringify!($name),
+                                " struct with fields `real` and `imag`"
+                            ))
+                        }
+                        fn visit_map<A: MapAccess<'de>>(
+                            self,
+                            mut map: A,
+                        ) -> Result<$name, A::Error> {
+                            let mut re: Option<$scalar> = None;
+                            let mut im: Option<$scalar> = None;
+                            while let Some(key) = map.next_key::<String>()? {
+                                match key.as_str() {
+                                    "real" => re = Some(map.next_value()?),
+                                    "imag" => im = Some(map.next_value()?),
+                                    _ => {
+                                        let _: serde::de::IgnoredAny = map.next_value()?;
+                                    }
                                 }
                             }
+                            Ok($name {
+                                re: re.ok_or_else(|| de::Error::missing_field("real"))?,
+                                im: im.ok_or_else(|| de::Error::missing_field("imag"))?,
+                            })
                         }
-                        Ok($name {
-                            re: re.ok_or_else(|| de::Error::missing_field("real"))?,
-                            im: im.ok_or_else(|| de::Error::missing_field("imag"))?,
-                        })
                     }
-                }
 
-                deserializer.deserialize_struct($sentinel, &["real", "imag"], ComplexVisitor)
+                    deserializer.deserialize_struct(
+                        $sentinel,
+                        &["real", "imag"],
+                        ComplexVisitor,
+                    )
+                }
+            }
+        )*
+
+        /// The component class a complex sentinel names, or `None` for any
+        /// other struct name.
+        ///
+        /// This is how the (de)serializer recognizes a complex value: the
+        /// sentinel carries the component class through serde, which has no
+        /// way to pass the concrete Rust type along with the struct.
+        pub(crate) fn complex_tag_for_sentinel(name: &str) -> Option<ComplexTag> {
+            match name {
+                $($sentinel => Some(ComplexTag::$tag),)*
+                _ => None,
             }
         }
     };
 }
 
-complex_type!(Complex32, f32, COMPLEX32_SENTINEL);
-complex_type!(Complex64, f64, COMPLEX64_SENTINEL);
+complex_types! {
+    Complex64 => f64, COMPLEX64_SENTINEL, F64, "double",
+    Complex32 => f32, COMPLEX32_SENTINEL, F32, "single",
+    ComplexI64 => i64, COMPLEX_I64_SENTINEL, I64, "int64",
+    ComplexI32 => i32, COMPLEX_I32_SENTINEL, I32, "int32",
+    ComplexI16 => i16, COMPLEX_I16_SENTINEL, I16, "int16",
+    ComplexI8 => i8, COMPLEX_I8_SENTINEL, I8, "int8",
+    ComplexU64 => u64, COMPLEX_U64_SENTINEL, U64, "uint64",
+    ComplexU32 => u32, COMPLEX_U32_SENTINEL, U32, "uint32",
+    ComplexU16 => u16, COMPLEX_U16_SENTINEL, U16, "uint16",
+    ComplexU8 => u8, COMPLEX_U8_SENTINEL, U8, "uint8",
+}
 
 #[cfg(test)]
 mod tests {
@@ -92,5 +141,39 @@ mod tests {
         let a = Complex64::new(1.0, -2.0);
         let b = Complex64 { re: 1.0, im: -2.0 };
         assert_eq!(a, b);
+    }
+
+    #[test]
+    fn each_sentinel_names_its_own_component_class() {
+        assert_eq!(
+            complex_tag_for_sentinel(COMPLEX_I16_SENTINEL),
+            Some(ComplexTag::I16)
+        );
+        assert_eq!(
+            complex_tag_for_sentinel(COMPLEX64_SENTINEL),
+            Some(ComplexTag::F64)
+        );
+        assert_eq!(complex_tag_for_sentinel("SomeUserStruct"), None);
+    }
+
+    /// The sentinel is the only thing distinguishing one complex type from
+    /// another once serde has erased the Rust type, so two sharing a name
+    /// would silently write each other's class.
+    #[test]
+    fn sentinels_are_distinct() {
+        let all = [
+            COMPLEX64_SENTINEL,
+            COMPLEX32_SENTINEL,
+            COMPLEX_I64_SENTINEL,
+            COMPLEX_I32_SENTINEL,
+            COMPLEX_I16_SENTINEL,
+            COMPLEX_I8_SENTINEL,
+            COMPLEX_U64_SENTINEL,
+            COMPLEX_U32_SENTINEL,
+            COMPLEX_U16_SENTINEL,
+            COMPLEX_U8_SENTINEL,
+        ];
+        let unique: std::collections::HashSet<&str> = all.iter().copied().collect();
+        assert_eq!(unique.len(), all.len());
     }
 }

--- a/src/mat/de/mcos_reader.rs
+++ b/src/mat/de/mcos_reader.rs
@@ -62,7 +62,7 @@ use crate::mat::string_object::{
     MATLAB_CLASS_STRING, MATLAB_OBJECT_DECODE_OPAQUE, MATLAB_STRING_SAVEOBJ_VERSION,
     MCOS_MAGIC_NUMBER,
 };
-use crate::mat::value::{MatValue, NumVec, ScalarNum};
+use crate::mat::value::{ComplexNum, ComplexVec, MatValue, NumVec, ScalarNum};
 use crate::reader::{Dataset, File, Object};
 use crate::types::DType;
 
@@ -1073,15 +1073,24 @@ fn numeric_f64_vec(value: MatValue, what: &str) -> Result<Vec<f64>, MatError> {
 /// Flatten a complex (or real) numeric property into `(re, im)` pairs.
 fn complex_pairs(value: MatValue, what: &str) -> Result<Vec<(f64, f64)>, MatError> {
     Ok(match value {
-        MatValue::ComplexScalar64 { re, im } => vec![(re, im)],
-        MatValue::ComplexScalar32 { re, im } => vec![(f64::from(re), f64::from(im))],
-        MatValue::ComplexVec64(pairs) => pairs,
-        MatValue::ComplexVec32(pairs) => pairs
-            .into_iter()
-            .map(|(r, i)| (f64::from(r), f64::from(i)))
-            .collect(),
-        MatValue::ComplexMatrix64 { pairs, .. } => pairs,
-        MatValue::ComplexMatrix32 { pairs, .. } => pairs
+        // Float components only: MATLAB stores these properties as `double`,
+        // and `single` widens to it losslessly. An integer-component complex
+        // property is not one of these classes and falls through to the error
+        // below rather than being converted into one.
+        MatValue::ComplexScalar(ComplexNum::F64(re, im)) => vec![(re, im)],
+        MatValue::ComplexScalar(ComplexNum::F32(re, im)) => {
+            vec![(f64::from(re), f64::from(im))]
+        }
+        MatValue::ComplexVec1D(ComplexVec::F64(pairs))
+        | MatValue::ComplexMatrix {
+            pairs: ComplexVec::F64(pairs),
+            ..
+        } => pairs,
+        MatValue::ComplexVec1D(ComplexVec::F32(pairs))
+        | MatValue::ComplexMatrix {
+            pairs: ComplexVec::F32(pairs),
+            ..
+        } => pairs
             .into_iter()
             .map(|(r, i)| (f64::from(r), f64::from(i)))
             .collect(),

--- a/src/mat/de/reader.rs
+++ b/src/mat/de/reader.rs
@@ -496,7 +496,7 @@ fn read_dataset(
         | MatClass::UInt32
         | MatClass::UInt64 => {
             if is_complex_dtype(&dtype) {
-                read_complex(ds, &shape, class)
+                read_complex(ds, &shape, class, &dtype)
             } else {
                 read_numeric(ds, &shape, class)
             }
@@ -723,6 +723,73 @@ fn is_complex_dtype(dtype: &DType) -> bool {
     }
 }
 
+/// The component tag a stored datatype decodes as, or `None` for anything that
+/// is not one of the ten numeric component classes.
+///
+/// Deliberately exhaustive with no fallback arm: [`class_from_dtype`] guesses
+/// `Double` for an unrecognized type, which is the right shape for naming a
+/// class but the wrong one for deciding how to slice raw bytes.
+fn complex_component_tag(dtype: &DType) -> Option<ComplexTag> {
+    Some(match dtype {
+        DType::F64 => ComplexTag::F64,
+        DType::F32 => ComplexTag::F32,
+        DType::I64 => ComplexTag::I64,
+        DType::I32 => ComplexTag::I32,
+        DType::I16 => ComplexTag::I16,
+        DType::I8 => ComplexTag::I8,
+        DType::U64 => ComplexTag::U64,
+        DType::U32 => ComplexTag::U32,
+        DType::U16 => ComplexTag::U16,
+        DType::U8 => ComplexTag::U8,
+        _ => return None,
+    })
+}
+
+/// Check that a complex compound is laid out the way `tag` says it is before
+/// any of its bytes are decoded.
+///
+/// The component width comes from the `MATLAB_class` attribute, but the bytes
+/// come from the compound, and nothing forces the two to agree: a file can
+/// claim `int16` over a pair of `f64` members, or carry no class attribute at
+/// all and fall back to `double` over a pair of `int64`s at the identical
+/// element size. Decoding either one succeeds and returns numbers that are
+/// entirely wrong, so the disagreement is refused here instead.
+fn validate_complex_dtype(dtype: &DType, tag: ComplexTag) -> Result<(), MatError> {
+    let DType::Compound(fields) = dtype else {
+        return Err(MatError::Custom(format!(
+            "complex {} dataset has a non-compound datatype {dtype}",
+            tag.class().as_str()
+        )));
+    };
+    // Real first, imaginary second: `parse_complex_pairs` reads the component
+    // at offset 0 as the real part, so the declared order is load-bearing and
+    // the reversed layout has to be refused rather than silently swapped.
+    let (Some((first, first_ty)), Some((second, second_ty))) = (fields.first(), fields.get(1))
+    else {
+        return Err(MatError::Custom(format!(
+            "complex {} compound has {} fields, expected 2",
+            tag.class().as_str(),
+            fields.len()
+        )));
+    };
+    if first != "real" || second != "imag" {
+        return Err(MatError::Custom(format!(
+            "complex {} compound is ordered {{{first}, {second}}}, expected {{real, imag}}",
+            tag.class().as_str()
+        )));
+    }
+    for (name, member) in [(first, first_ty), (second, second_ty)] {
+        if complex_component_tag(member) != Some(tag) {
+            return Err(MatError::Custom(format!(
+                "complex {} dataset stores its {name} component as {member}, \
+                 which is a different class than MATLAB_class claims",
+                tag.class().as_str()
+            )));
+        }
+    }
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Numeric reading
 // ---------------------------------------------------------------------------
@@ -883,7 +950,12 @@ fn transpose_col_major_to_row_major(
 // Complex reading
 // ---------------------------------------------------------------------------
 
-fn read_complex(ds: &Dataset, shape: &[u64], class: MatClass) -> Result<MatValue, MatError> {
+fn read_complex(
+    ds: &Dataset,
+    shape: &[u64],
+    class: MatClass,
+    dtype: &DType,
+) -> Result<MatValue, MatError> {
     let (rows, cols, total) = shape_decomposition(shape)?;
     let Some(tag) = ComplexTag::from_class(class) else {
         return Err(MatError::Custom(format!(
@@ -891,6 +963,7 @@ fn read_complex(ds: &Dataset, shape: &[u64], class: MatClass) -> Result<MatValue
             class.as_str()
         )));
     };
+    validate_complex_dtype(dtype, tag)?;
     let bytes = ds.read_u8().map_err(MatError::Hdf5)?;
     let pairs = parse_complex_vec(&bytes, total, tag)?;
 

--- a/src/mat/de/reader.rs
+++ b/src/mat/de/reader.rs
@@ -10,8 +10,9 @@ use crate::mat::de::mcos_reader::{self, Mcos, PropValue};
 use crate::mat::error::MatError;
 use crate::mat::string_object::MCOS_MAGIC_NUMBER;
 use crate::mat::utf16;
-use crate::mat::value::{MatValue, NumVec, ScalarNum};
+use crate::mat::value::{ComplexTag, ComplexVec, MatValue, NumVec, ScalarNum};
 use crate::reader::{Dataset, File, Group, Object};
+use crate::type_builders::ComplexComponent;
 use crate::types::DType;
 
 /// Maximum struct/cell nesting depth followed when reading. Real MATLAB data
@@ -450,8 +451,10 @@ fn read_dataset(
         // Complex compound types preserve their shape and class so a 0×0
         // `Matrix<Complex*>` round-trips back to a 0×0 complex matrix
         // rather than collapsing to a numeric empty vec.
-        if matches!(class, MatClass::Double | MatClass::Single) && is_complex_dtype(&dtype) {
-            return empty_complex_value(class, &shape);
+        if is_complex_dtype(&dtype)
+            && let Some(tag) = ComplexTag::from_class(class)
+        {
+            return empty_complex_value(tag, &shape);
         }
         // An empty struct-classed *dataset* (`MATLAB_empty=1`) is `struct([])`,
         // the marker the serializer writes for `Option::None` inside a
@@ -657,23 +660,15 @@ fn is_empty_attr(attrs: &HashMap<String, AttrValue>) -> bool {
     }
 }
 
-/// Build an empty `ComplexMatrix*` whose `(rows, cols)` matches the dataspace
+/// Build an empty `ComplexMatrix` whose `(rows, cols)` matches the dataspace
 /// shape, so deserializing into `Matrix<Complex*>` recovers the original
 /// shape (0×0, 0×N, N×0) instead of collapsing to 1×0.
-fn empty_complex_value(class: MatClass, shape: &[u64]) -> Result<MatValue, MatError> {
+fn empty_complex_value(tag: ComplexTag, shape: &[u64]) -> Result<MatValue, MatError> {
     let (rows, cols, _total) = shape_decomposition(shape)?;
-    Ok(match class {
-        MatClass::Double => MatValue::ComplexMatrix64 {
-            rows,
-            cols,
-            pairs: Vec::new(),
-        },
-        MatClass::Single => MatValue::ComplexMatrix32 {
-            rows,
-            cols,
-            pairs: Vec::new(),
-        },
-        _ => unreachable!("empty_complex_value called with non-float class"),
+    Ok(MatValue::ComplexMatrix {
+        rows,
+        cols,
+        pairs: ComplexVec::empty_with_tag(tag),
     })
 }
 
@@ -890,101 +885,85 @@ fn transpose_col_major_to_row_major(
 
 fn read_complex(ds: &Dataset, shape: &[u64], class: MatClass) -> Result<MatValue, MatError> {
     let (rows, cols, total) = shape_decomposition(shape)?;
+    let Some(tag) = ComplexTag::from_class(class) else {
+        return Err(MatError::Custom(format!(
+            "complex {{real, imag}} compound on class {}, which has no complex form",
+            class.as_str()
+        )));
+    };
     let bytes = ds.read_u8().map_err(MatError::Hdf5)?;
+    let pairs = parse_complex_vec(&bytes, total, tag)?;
 
-    match class {
-        MatClass::Double => {
-            let pairs = parse_complex64_pairs(&bytes, total)?;
-            if total == 1 {
-                let (re, im) = pairs[0];
-                return Ok(MatValue::ComplexScalar64 { re, im });
-            }
-            // Preserve the MATLAB [rows, cols] shape even when one dim is 1,
-            // so `Matrix<Complex64>` round-trips as a row vs column vector.
-            // The deserializer flattens to a plain sequence for
-            // `Vec<Complex64>` callers.
-            let row_major = if rows == 1 || cols == 1 {
-                pairs
-            } else {
-                transpose_pairs_col_to_row(pairs, rows, cols)
-            };
-            Ok(MatValue::ComplexMatrix64 {
-                rows,
-                cols,
-                pairs: row_major,
-            })
-        }
-        MatClass::Single => {
-            let pairs = parse_complex32_pairs(&bytes, total)?;
-            if total == 1 {
-                let (re, im) = pairs[0];
-                return Ok(MatValue::ComplexScalar32 { re, im });
-            }
-            let row_major = if rows == 1 || cols == 1 {
-                pairs
-            } else {
-                transpose_pairs_col_to_row(pairs, rows, cols)
-            };
-            Ok(MatValue::ComplexMatrix32 {
-                rows,
-                cols,
-                pairs: row_major,
-            })
-        }
-        _ => Err(MatError::Custom(
-            "complex compound on non-float class".into(),
-        )),
+    if total == 1 {
+        // `get` is in bounds: `parse_complex_vec` returned `total` pairs.
+        return Ok(MatValue::ComplexScalar(pairs.get(0).expect("one pair")));
     }
+    // Preserve the MATLAB [rows, cols] shape even when one dim is 1, so
+    // `Matrix<Complex*>` round-trips as a row vs column vector. The
+    // deserializer flattens to a plain sequence for `Vec<Complex*>` callers.
+    let row_major = if rows == 1 || cols == 1 {
+        pairs
+    } else {
+        // Stored column-major: transposing `[cols, rows]` yields row-major.
+        pairs.transposed(cols, rows)
+    };
+    Ok(MatValue::ComplexMatrix {
+        rows,
+        cols,
+        pairs: row_major,
+    })
 }
 
-fn parse_complex64_pairs(bytes: &[u8], count: usize) -> Result<Vec<(f64, f64)>, MatError> {
-    if bytes.len() < count * 16 {
+/// Decode `count` `{real, imag}` pairs of the component class `tag` from the
+/// dataset's raw element bytes.
+fn parse_complex_vec(bytes: &[u8], count: usize, tag: ComplexTag) -> Result<ComplexVec, MatError> {
+    macro_rules! arms {
+        ($($variant:ident => $ty:ty),* $(,)?) => {
+            match tag {
+                $(ComplexTag::$variant => {
+                    ComplexVec::$variant(parse_complex_pairs::<$ty>(bytes, count, tag)?)
+                })*
+            }
+        };
+    }
+    Ok(arms! {
+        F64 => f64,
+        F32 => f32,
+        I64 => i64,
+        I32 => i32,
+        I16 => i16,
+        I8 => i8,
+        U64 => u64,
+        U32 => u32,
+        U16 => u16,
+        U8 => u8,
+    })
+}
+
+fn parse_complex_pairs<T: ComplexComponent>(
+    bytes: &[u8],
+    count: usize,
+    tag: ComplexTag,
+) -> Result<Vec<(T, T)>, MatError> {
+    let component = size_of::<T>();
+    let element = component * 2;
+    if bytes.len() < count * element {
         return Err(MatError::Custom(format!(
-            "complex64 raw bytes too short: need {}, have {}",
-            count * 16,
+            "complex {} raw bytes too short: need {}, have {}",
+            tag.class().as_str(),
+            count * element,
             bytes.len()
         )));
     }
     let mut out = Vec::with_capacity(count);
     for i in 0..count {
-        let off = i * 16;
-        let re = f64::from_le_bytes(bytes[off..off + 8].try_into().unwrap());
-        let im = f64::from_le_bytes(bytes[off + 8..off + 16].try_into().unwrap());
-        out.push((re, im));
+        let off = i * element;
+        out.push((
+            T::decode_le(&bytes[off..off + component]),
+            T::decode_le(&bytes[off + component..off + element]),
+        ));
     }
     Ok(out)
-}
-
-fn parse_complex32_pairs(bytes: &[u8], count: usize) -> Result<Vec<(f32, f32)>, MatError> {
-    if bytes.len() < count * 8 {
-        return Err(MatError::Custom(format!(
-            "complex32 raw bytes too short: need {}, have {}",
-            count * 8,
-            bytes.len()
-        )));
-    }
-    let mut out = Vec::with_capacity(count);
-    for i in 0..count {
-        let off = i * 8;
-        let re = f32::from_le_bytes(bytes[off..off + 4].try_into().unwrap());
-        let im = f32::from_le_bytes(bytes[off + 4..off + 8].try_into().unwrap());
-        out.push((re, im));
-    }
-    Ok(out)
-}
-
-fn transpose_pairs_col_to_row<T: Copy>(
-    col_major: Vec<(T, T)>,
-    rows: usize,
-    cols: usize,
-) -> Vec<(T, T)> {
-    let mut out = Vec::with_capacity(rows * cols);
-    for r in 0..rows {
-        for c in 0..cols {
-            out.push(col_major[c * rows + r]);
-        }
-    }
-    out
 }
 
 #[cfg(test)]

--- a/src/mat/de/value_de.rs
+++ b/src/mat/de/value_de.rs
@@ -11,12 +11,12 @@ use serde::de::{
 };
 use serde::forward_to_deserialize_any;
 
-use crate::mat::complex::{COMPLEX32_SENTINEL, COMPLEX64_SENTINEL};
+use crate::mat::complex::complex_tag_for_sentinel;
 use crate::mat::de::mcos_reader::TABLE_META_KEY;
 use crate::mat::error::MatError;
-use crate::mat::matrix::{MATRIX_COMPLEX32_SENTINEL, MATRIX_COMPLEX64_SENTINEL, MATRIX_SENTINEL};
+use crate::mat::matrix::{MATRIX_SENTINEL, complex_tag_for_matrix_sentinel};
 use crate::mat::table::{MATCOLUMN_SENTINEL, MATTABLE_SENTINEL};
-use crate::mat::value::{MatValue, NumVec, ScalarNum};
+use crate::mat::value::{ComplexNum, ComplexVec, MatValue, NumVec, ScalarNum};
 
 // ---------------------------------------------------------------------------
 // Entry point
@@ -213,26 +213,15 @@ impl<'de> Deserializer<'de> for MatValueDeserializer {
             MatValue::Matrix { rows, cols, vec } => {
                 visitor.visit_seq(MatrixRowsSeq::new(rows, cols, vec))
             }
-            MatValue::ComplexVec64(pairs) => {
-                visitor.visit_seq(ComplexPairsSeq::Vec64(pairs.into_iter().collect()))
-            }
-            MatValue::ComplexVec32(pairs) => {
-                visitor.visit_seq(ComplexPairsSeq::Vec32(pairs.into_iter().collect()))
-            }
+            MatValue::ComplexVec1D(pairs) => visitor.visit_seq(ComplexPairsSeq::new(pairs)),
             // A degenerate 2-D complex matrix (1×N or N×1) flattens to a
             // sequence so `Vec<Complex*>` deserializes from either
             // orientation, matching the numeric `Matrix` flatten above.
-            MatValue::ComplexMatrix64 { rows, cols, pairs } if rows == 1 || cols == 1 => {
-                visitor.visit_seq(ComplexPairsSeq::Vec64(pairs.into_iter().collect()))
+            MatValue::ComplexMatrix { rows, cols, pairs } if rows == 1 || cols == 1 => {
+                visitor.visit_seq(ComplexPairsSeq::new(pairs))
             }
-            MatValue::ComplexMatrix32 { rows, cols, pairs } if rows == 1 || cols == 1 => {
-                visitor.visit_seq(ComplexPairsSeq::Vec32(pairs.into_iter().collect()))
-            }
-            MatValue::ComplexMatrix64 { rows, cols, pairs } => {
-                visitor.visit_seq(ComplexMatrixRowsSeq::new64(rows, cols, pairs))
-            }
-            MatValue::ComplexMatrix32 { rows, cols, pairs } => {
-                visitor.visit_seq(ComplexMatrixRowsSeq::new32(rows, cols, pairs))
+            MatValue::ComplexMatrix { rows, cols, pairs } => {
+                visitor.visit_seq(ComplexMatrixRowsSeq::new(rows, cols, pairs))
             }
             MatValue::Cell(elements) => visitor.visit_seq(CellSeq::new(elements)),
             // A struct array deserializes like `Matrix`: a `1×N`/`N×1` array
@@ -254,6 +243,11 @@ impl<'de> Deserializer<'de> for MatValueDeserializer {
             MatValue::Scalar(s) => {
                 let v = NumVec::from_single(s);
                 visitor.visit_seq(Vec1DSeq::new(v))
+            }
+            // …and so can a complex scalar, which is what a one-element
+            // complex array reads back as.
+            MatValue::ComplexScalar(n) => {
+                visitor.visit_seq(ComplexPairsSeq::new(ComplexVec::from_single(n)))
             }
             other => mismatch("sequence", other),
         }
@@ -297,12 +291,38 @@ impl<'de> Deserializer<'de> for MatValueDeserializer {
         fields: &'static [&'static str],
         visitor: V,
     ) -> Result<V::Value, MatError> {
+        // A complex sentinel names one component class, and only a value of
+        // that class satisfies it. Reading an `int16` complex dataset into a
+        // `Complex64` (or the reverse) is refused rather than converted: the
+        // component width is what the file says it holds, so silently changing
+        // it would make the Rust type a poor witness of the file.
+        if let Some(tag) = complex_tag_for_sentinel(name) {
+            let got = self.value.kind();
+            let wanted = || {
+                MatError::Custom(format!(
+                    "expected a complex {} value, got {got}",
+                    tag.class().as_str()
+                ))
+            };
+            return match self.value {
+                MatValue::ComplexScalar(n) if n.tag() == tag => {
+                    visitor.visit_map(ComplexStructMap::new(n))
+                }
+                // A real value of the same class reads as complex with a zero
+                // imaginary part.
+                MatValue::Scalar(s) => match ComplexNum::from_real(tag, s) {
+                    Some(n) => visitor.visit_map(ComplexStructMap::new(n)),
+                    None => Err(wanted()),
+                },
+                _ => Err(wanted()),
+            };
+        }
         match name {
-            // The three Matrix sentinels (numeric and the two complex
-            // variants) all consume the same set of `MatValue` shapes; the
-            // sentinel name only matters at serialize time, where it
-            // preserves the element class for an empty Vec.
-            MATRIX_SENTINEL | MATRIX_COMPLEX64_SENTINEL | MATRIX_COMPLEX32_SENTINEL => {
+            // Every Matrix sentinel (numeric and the per-class complex ones)
+            // consumes the same set of `MatValue` shapes; the sentinel name
+            // only matters at serialize time, where it preserves the element
+            // class for an empty Vec.
+            _ if name == MATRIX_SENTINEL || complex_tag_for_matrix_sentinel(name).is_some() => {
                 match self.value {
                     MatValue::Matrix { rows, cols, vec } => {
                         visitor.visit_map(MatrixStructMap::numeric(rows, cols, vec))
@@ -317,47 +337,21 @@ impl<'de> Deserializer<'de> for MatValueDeserializer {
                         let v = NumVec::from_single(s);
                         visitor.visit_map(MatrixStructMap::numeric(1, 1, v))
                     }
-                    MatValue::ComplexMatrix64 { rows, cols, pairs } => {
-                        visitor.visit_map(MatrixStructMap::complex64(rows, cols, pairs))
+                    MatValue::ComplexMatrix { rows, cols, pairs } => {
+                        visitor.visit_map(MatrixStructMap::complex(rows, cols, pairs))
                     }
-                    MatValue::ComplexMatrix32 { rows, cols, pairs } => {
-                        visitor.visit_map(MatrixStructMap::complex32(rows, cols, pairs))
-                    }
-                    MatValue::ComplexVec64(pairs) => {
+                    MatValue::ComplexVec1D(pairs) => {
                         let len = pairs.len();
-                        visitor.visit_map(MatrixStructMap::complex64(1, len, pairs))
+                        visitor.visit_map(MatrixStructMap::complex(1, len, pairs))
                     }
-                    MatValue::ComplexVec32(pairs) => {
-                        let len = pairs.len();
-                        visitor.visit_map(MatrixStructMap::complex32(1, len, pairs))
-                    }
-                    MatValue::ComplexScalar64 { re, im } => {
-                        visitor.visit_map(MatrixStructMap::complex64(1, 1, vec![(re, im)]))
-                    }
-                    MatValue::ComplexScalar32 { re, im } => {
-                        visitor.visit_map(MatrixStructMap::complex32(1, 1, vec![(re, im)]))
-                    }
+                    MatValue::ComplexScalar(n) => visitor.visit_map(MatrixStructMap::complex(
+                        1,
+                        1,
+                        ComplexVec::from_single(n),
+                    )),
                     other => mismatch("Matrix", other),
                 }
             }
-            COMPLEX64_SENTINEL => match self.value {
-                MatValue::ComplexScalar64 { re, im } => {
-                    visitor.visit_map(ComplexStructMap64::new(re, im))
-                }
-                MatValue::Scalar(ScalarNum::F64(re)) => {
-                    visitor.visit_map(ComplexStructMap64::new(re, 0.0))
-                }
-                other => mismatch("Complex64", other),
-            },
-            COMPLEX32_SENTINEL => match self.value {
-                MatValue::ComplexScalar32 { re, im } => {
-                    visitor.visit_map(ComplexStructMap32::new(re, im))
-                }
-                MatValue::Scalar(ScalarNum::F32(re)) => {
-                    visitor.visit_map(ComplexStructMap32::new(re, 0.0))
-                }
-                other => mismatch("Complex32", other),
-            },
             // A `MatColumn` asks for the underlying table-column value tagged by
             // kind, so the right variant can be built with full type fidelity.
             MATCOLUMN_SENTINEL => {
@@ -444,25 +438,13 @@ fn dispatch_any<'de, V: Visitor<'de>>(value: MatValue, visitor: V) -> Result<V::
         MatValue::Matrix { rows, cols, vec } => {
             visitor.visit_seq(MatrixRowsSeq::new(rows, cols, vec))
         }
-        MatValue::ComplexScalar64 { re, im } => visitor.visit_map(ComplexStructMap64::new(re, im)),
-        MatValue::ComplexScalar32 { re, im } => visitor.visit_map(ComplexStructMap32::new(re, im)),
-        MatValue::ComplexVec64(pairs) => {
-            visitor.visit_seq(ComplexPairsSeq::Vec64(pairs.into_iter().collect()))
+        MatValue::ComplexScalar(n) => visitor.visit_map(ComplexStructMap::new(n)),
+        MatValue::ComplexVec1D(pairs) => visitor.visit_seq(ComplexPairsSeq::new(pairs)),
+        MatValue::ComplexMatrix { rows, cols, pairs } if rows == 1 || cols == 1 => {
+            visitor.visit_seq(ComplexPairsSeq::new(pairs))
         }
-        MatValue::ComplexVec32(pairs) => {
-            visitor.visit_seq(ComplexPairsSeq::Vec32(pairs.into_iter().collect()))
-        }
-        MatValue::ComplexMatrix64 { rows, cols, pairs } if rows == 1 || cols == 1 => {
-            visitor.visit_seq(ComplexPairsSeq::Vec64(pairs.into_iter().collect()))
-        }
-        MatValue::ComplexMatrix32 { rows, cols, pairs } if rows == 1 || cols == 1 => {
-            visitor.visit_seq(ComplexPairsSeq::Vec32(pairs.into_iter().collect()))
-        }
-        MatValue::ComplexMatrix64 { rows, cols, pairs } => {
-            visitor.visit_seq(ComplexMatrixRowsSeq::new64(rows, cols, pairs))
-        }
-        MatValue::ComplexMatrix32 { rows, cols, pairs } => {
-            visitor.visit_seq(ComplexMatrixRowsSeq::new32(rows, cols, pairs))
+        MatValue::ComplexMatrix { rows, cols, pairs } => {
+            visitor.visit_seq(ComplexMatrixRowsSeq::new(rows, cols, pairs))
         }
         MatValue::Struct(fields) => visitor.visit_map(StructMap::new(fields)),
         MatValue::Cell(elements) => visitor.visit_seq(CellSeq::new(elements)),
@@ -791,9 +773,17 @@ impl NumVecIter {
 // ComplexPairs SeqAccess
 // ---------------------------------------------------------------------------
 
-enum ComplexPairsSeq {
-    Vec64(VecDeque<(f64, f64)>),
-    Vec32(VecDeque<(f32, f32)>),
+/// Yields each pair of a complex vector as a complex scalar, so `Vec<T>`
+/// deserializes element by element without materializing per-element values.
+struct ComplexPairsSeq {
+    pairs: ComplexVec,
+    next: usize,
+}
+
+impl ComplexPairsSeq {
+    fn new(pairs: ComplexVec) -> Self {
+        Self { pairs, next: 0 }
+    }
 }
 
 impl<'de> SeqAccess<'de> for ComplexPairsSeq {
@@ -802,62 +792,34 @@ impl<'de> SeqAccess<'de> for ComplexPairsSeq {
         &mut self,
         seed: T,
     ) -> Result<Option<T::Value>, MatError> {
-        match self {
-            ComplexPairsSeq::Vec64(q) => match q.pop_front() {
-                Some((re, im)) => seed
-                    .deserialize(MatValueDeserializer::new(MatValue::ComplexScalar64 {
-                        re,
-                        im,
-                    }))
-                    .map(Some),
-                None => Ok(None),
-            },
-            ComplexPairsSeq::Vec32(q) => match q.pop_front() {
-                Some((re, im)) => seed
-                    .deserialize(MatValueDeserializer::new(MatValue::ComplexScalar32 {
-                        re,
-                        im,
-                    }))
-                    .map(Some),
-                None => Ok(None),
-            },
+        match self.pairs.get(self.next) {
+            Some(n) => {
+                self.next += 1;
+                seed.deserialize(MatValueDeserializer::new(MatValue::ComplexScalar(n)))
+                    .map(Some)
+            }
+            None => Ok(None),
         }
     }
     fn size_hint(&self) -> Option<usize> {
-        Some(match self {
-            ComplexPairsSeq::Vec64(q) => q.len(),
-            ComplexPairsSeq::Vec32(q) => q.len(),
-        })
+        Some(self.pairs.len() - self.next)
     }
 }
 
 // ---------------------------------------------------------------------------
-// ComplexMatrixRows SeqAccess: yields each row as ComplexVec*
+// ComplexMatrixRows SeqAccess: yields each row as a complex vector
 // ---------------------------------------------------------------------------
 
-enum ComplexMatrixRowsSeq {
-    Mat64 {
-        rows_remaining: usize,
-        cols: usize,
-        row_major: Vec<(f64, f64)>, // consumed front-to-back
-    },
-    Mat32 {
-        rows_remaining: usize,
-        cols: usize,
-        row_major: Vec<(f32, f32)>,
-    },
+struct ComplexMatrixRowsSeq {
+    rows_remaining: usize,
+    cols: usize,
+    /// Row-major, consumed front-to-back one row per element.
+    row_major: ComplexVec,
 }
 
 impl ComplexMatrixRowsSeq {
-    fn new64(rows: usize, cols: usize, row_major: Vec<(f64, f64)>) -> Self {
-        ComplexMatrixRowsSeq::Mat64 {
-            rows_remaining: rows,
-            cols,
-            row_major,
-        }
-    }
-    fn new32(rows: usize, cols: usize, row_major: Vec<(f32, f32)>) -> Self {
-        ComplexMatrixRowsSeq::Mat32 {
+    fn new(rows: usize, cols: usize, row_major: ComplexVec) -> Self {
+        Self {
             rows_remaining: rows,
             cols,
             row_major,
@@ -871,36 +833,13 @@ impl<'de> SeqAccess<'de> for ComplexMatrixRowsSeq {
         &mut self,
         seed: T,
     ) -> Result<Option<T::Value>, MatError> {
-        match self {
-            ComplexMatrixRowsSeq::Mat64 {
-                rows_remaining,
-                cols,
-                row_major,
-            } => {
-                if *rows_remaining == 0 {
-                    return Ok(None);
-                }
-                *rows_remaining -= 1;
-                let tail = row_major.split_off(*cols);
-                let head = std::mem::replace(row_major, tail);
-                seed.deserialize(MatValueDeserializer::new(MatValue::ComplexVec64(head)))
-                    .map(Some)
-            }
-            ComplexMatrixRowsSeq::Mat32 {
-                rows_remaining,
-                cols,
-                row_major,
-            } => {
-                if *rows_remaining == 0 {
-                    return Ok(None);
-                }
-                *rows_remaining -= 1;
-                let tail = row_major.split_off(*cols);
-                let head = std::mem::replace(row_major, tail);
-                seed.deserialize(MatValueDeserializer::new(MatValue::ComplexVec32(head)))
-                    .map(Some)
-            }
+        if self.rows_remaining == 0 {
+            return Ok(None);
         }
+        self.rows_remaining -= 1;
+        let head = self.row_major.split_off_front(self.cols);
+        seed.deserialize(MatValueDeserializer::new(MatValue::ComplexVec1D(head)))
+            .map(Some)
     }
 }
 
@@ -976,8 +915,7 @@ struct MatrixStructMap {
 
 enum MatrixData {
     Numeric(NumVec),
-    Complex64(Vec<(f64, f64)>),
-    Complex32(Vec<(f32, f32)>),
+    Complex(ComplexVec),
 }
 
 enum MatrixState {
@@ -1000,21 +938,12 @@ impl MatrixStructMap {
         }
     }
 
-    fn complex64(rows: usize, cols: usize, pairs: Vec<(f64, f64)>) -> Self {
+    fn complex(rows: usize, cols: usize, pairs: ComplexVec) -> Self {
         Self {
             state: MatrixState::NeedRowsKey,
             rows,
             cols,
-            data: Some(MatrixData::Complex64(pairs)),
-        }
-    }
-
-    fn complex32(rows: usize, cols: usize, pairs: Vec<(f32, f32)>) -> Self {
-        Self {
-            state: MatrixState::NeedRowsKey,
-            rows,
-            cols,
-            data: Some(MatrixData::Complex32(pairs)),
+            data: Some(MatrixData::Complex(pairs)),
         }
     }
 }
@@ -1051,8 +980,7 @@ impl<'de> MapAccess<'de> for MatrixStructMap {
                 self.state = MatrixState::Done;
                 let value = match self.data.take().unwrap() {
                     MatrixData::Numeric(v) => MatValue::Vec1D(v),
-                    MatrixData::Complex64(pairs) => MatValue::ComplexVec64(pairs),
-                    MatrixData::Complex32(pairs) => MatValue::ComplexVec32(pairs),
+                    MatrixData::Complex(pairs) => MatValue::ComplexVec1D(pairs),
                 };
                 seed.deserialize(MatValueDeserializer::new(value))
             }
@@ -1074,16 +1002,14 @@ impl<'de> MapAccess<'de> for MatrixStructMap {
 // Complex sentinel MapAccess
 // ---------------------------------------------------------------------------
 
-struct ComplexStructMap64 {
+/// Presents a complex scalar as the `{real, imag}` map the `Complex*`
+/// newtypes deserialize from. One type for every component class: each
+/// component goes back through the value deserializer as a tagged scalar, so
+/// the newtype's own field type decides how it is read.
+struct ComplexStructMap {
     state: ComplexState,
-    re: f64,
-    im: f64,
-}
-
-struct ComplexStructMap32 {
-    state: ComplexState,
-    re: f32,
-    im: f32,
+    re: ScalarNum,
+    im: ScalarNum,
 }
 
 enum ComplexState {
@@ -1094,17 +1020,9 @@ enum ComplexState {
     Done,
 }
 
-impl ComplexStructMap64 {
-    fn new(re: f64, im: f64) -> Self {
-        Self {
-            state: ComplexState::NeedRealKey,
-            re,
-            im,
-        }
-    }
-}
-impl ComplexStructMap32 {
-    fn new(re: f32, im: f32) -> Self {
+impl ComplexStructMap {
+    fn new(n: ComplexNum) -> Self {
+        let (re, im) = n.components();
         Self {
             state: ComplexState::NeedRealKey,
             re,
@@ -1113,57 +1031,46 @@ impl ComplexStructMap32 {
     }
 }
 
-macro_rules! impl_complex_map {
-    ($map:ty, $re:ty, $de:expr) => {
-        impl<'de> MapAccess<'de> for $map {
-            type Error = MatError;
+impl<'de> MapAccess<'de> for ComplexStructMap {
+    type Error = MatError;
 
-            fn next_key_seed<K: DeserializeSeed<'de>>(
-                &mut self,
-                seed: K,
-            ) -> Result<Option<K::Value>, MatError> {
-                let (key, next) = match self.state {
-                    ComplexState::NeedRealKey => ("real", ComplexState::NeedRealValue),
-                    ComplexState::NeedImagKey => ("imag", ComplexState::NeedImagValue),
-                    ComplexState::Done => return Ok(None),
-                    _ => return Err(MatError::Custom("complex map state desync".into())),
-                };
-                self.state = next;
-                seed.deserialize(StringRefDe(key.to_string())).map(Some)
+    fn next_key_seed<K: DeserializeSeed<'de>>(
+        &mut self,
+        seed: K,
+    ) -> Result<Option<K::Value>, MatError> {
+        let (key, next) = match self.state {
+            ComplexState::NeedRealKey => ("real", ComplexState::NeedRealValue),
+            ComplexState::NeedImagKey => ("imag", ComplexState::NeedImagValue),
+            ComplexState::Done => return Ok(None),
+            _ => return Err(MatError::Custom("complex map state desync".into())),
+        };
+        self.state = next;
+        seed.deserialize(StringRefDe(key.to_string())).map(Some)
+    }
+
+    fn next_value_seed<V: DeserializeSeed<'de>>(&mut self, seed: V) -> Result<V::Value, MatError> {
+        let component = match self.state {
+            ComplexState::NeedRealValue => {
+                self.state = ComplexState::NeedImagKey;
+                self.re.clone()
             }
-            fn next_value_seed<V: DeserializeSeed<'de>>(
-                &mut self,
-                seed: V,
-            ) -> Result<V::Value, MatError> {
-                match self.state {
-                    ComplexState::NeedRealValue => {
-                        self.state = ComplexState::NeedImagKey;
-                        seed.deserialize($de(self.re))
-                    }
-                    ComplexState::NeedImagValue => {
-                        self.state = ComplexState::Done;
-                        seed.deserialize($de(self.im))
-                    }
-                    _ => Err(MatError::Custom("complex map value before key".into())),
-                }
+            ComplexState::NeedImagValue => {
+                self.state = ComplexState::Done;
+                self.im.clone()
             }
-            fn size_hint(&self) -> Option<usize> {
-                Some(match self.state {
-                    ComplexState::NeedRealKey | ComplexState::NeedRealValue => 2,
-                    ComplexState::NeedImagKey | ComplexState::NeedImagValue => 1,
-                    ComplexState::Done => 0,
-                })
-            }
-        }
-        // Touch $re so the pattern arg is reachable for documentation of the
-        // type being produced; this is a no-op at runtime.
-        #[allow(dead_code)]
-        const _: fn($re) = |_| {};
-    };
+            _ => return Err(MatError::Custom("complex map value before key".into())),
+        };
+        seed.deserialize(MatValueDeserializer::new(MatValue::Scalar(component)))
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        Some(match self.state {
+            ComplexState::NeedRealKey | ComplexState::NeedRealValue => 2,
+            ComplexState::NeedImagKey | ComplexState::NeedImagValue => 1,
+            ComplexState::Done => 0,
+        })
+    }
 }
-
-impl_complex_map!(ComplexStructMap64, f64, |x: f64| x.into_deserializer());
-impl_complex_map!(ComplexStructMap32, f32, |x: f32| x.into_deserializer());
 
 // ---------------------------------------------------------------------------
 // Enum unit variant

--- a/src/mat/matrix.rs
+++ b/src/mat/matrix.rs
@@ -12,26 +12,24 @@
 //! `Vec<Vec<T>>` is also recognized by the serializer as a 2-D matrix
 //! (checked for ragged rows). Use `Matrix` when you want an unambiguous API.
 //!
-//! # Why three sentinel constants
+//! # Why a sentinel per complex element class
 //!
-//! `MATRIX_SENTINEL`, `MATRIX_COMPLEX64_SENTINEL`, and
-//! `MATRIX_COMPLEX32_SENTINEL` are not redundant. The element class for a
-//! non-empty `Matrix<T>` can always be recovered from the serialized data
-//! (the inner `Vec<T>` carries enough type information through the seq
-//! unification path), so a single sentinel would suffice for the common
-//! case.
+//! `MATRIX_SENTINEL` and the per-class complex sentinels are not redundant.
+//! The element class for a non-empty `Matrix<T>` can always be recovered from
+//! the serialized data (the inner `Vec<T>` carries enough type information
+//! through the seq unification path), so a single sentinel would suffice for
+//! the common case.
 //!
 //! Empty matrices break that. A 0×0 / 0×N / N×0 `Matrix<Complex64>`
 //! produces a `Vec<Complex64>` of length zero; the seq unification observes
 //! no elements, defaults to an `f64`-empty `NumVec`, and the serializer
-//! would emit a numeric (non-complex) HDF5 dataset. The dedicated
-//! `Matrix<Complex64>` / `Matrix<Complex32>` sentinels carry the element
-//! class through the empty path so the on-disk dataset is the correct
-//! compound `{real, imag}` shape. The corresponding sealed
-//! [`MatElement`] trait makes the sentinel choice a compile-time property
-//! of `T`; missing dispatch surfaces as a compile error rather than a
-//! silent class loss. Do not collapse the three sentinels into one without
-//! re-solving the empty-shape problem.
+//! would emit a numeric (non-complex) HDF5 dataset. A dedicated sentinel per
+//! complex element type carries the class through the empty path so the
+//! on-disk dataset is the correct compound `{real, imag}` shape *of the right
+//! component width*. The corresponding sealed [`MatElement`] trait makes the
+//! sentinel choice a compile-time property of `T`; missing dispatch surfaces
+//! as a compile error rather than a silent class loss. Do not collapse the
+//! complex sentinels into one without re-solving the empty-shape problem.
 
 use core::fmt;
 
@@ -39,20 +37,54 @@ use serde::de::{self, MapAccess, Visitor};
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::mat::complex::{Complex32, Complex64};
+use crate::mat::complex::{
+    Complex32, Complex64, ComplexI8, ComplexI16, ComplexI32, ComplexI64, ComplexU8, ComplexU16,
+    ComplexU32, ComplexU64,
+};
+use crate::mat::value::ComplexTag;
 
 /// Sentinel struct name recognized by the MAT serializer/deserializer for a
 /// numeric `Matrix<T>` whose element class is carried by the serialized data.
 pub(crate) const MATRIX_SENTINEL: &str = "__hdf5_pure_mat_Matrix__";
 
-/// Sentinel for `Matrix<Complex64>`. Distinct from `MATRIX_SENTINEL` so an
-/// empty 0×0 / 0×N / N×0 matrix still writes as a complex (compound)
-/// dataset on disk: with no elements, the inner `Vec<Complex64>` would
-/// otherwise collapse to a default `f64`-empty NumVec and lose the class.
-pub(crate) const MATRIX_COMPLEX64_SENTINEL: &str = "__hdf5_pure_mat_MatrixComplex64__";
+/// The complex `Matrix<T>` sentinels and the element-class lookup that reads
+/// them back, from one list.
+macro_rules! matrix_complex_sentinels {
+    ($($konst:ident => $elem:ty, $tag:ident, $suffix:literal),* $(,)?) => {
+        $(
+            #[doc = concat!(
+                "Sentinel for `Matrix<", stringify!($elem),
+                ">`. Distinct from `MATRIX_SENTINEL` so an empty 0×0 / 0×N / \
+                 N×0 matrix still writes as a complex (compound) dataset of \
+                 this component class."
+            )]
+            pub(crate) const $konst: &str =
+                concat!("__hdf5_pure_mat_MatrixComplex", $suffix, "__");
+        )*
 
-/// Sentinel for `Matrix<Complex32>`. See [`MATRIX_COMPLEX64_SENTINEL`].
-pub(crate) const MATRIX_COMPLEX32_SENTINEL: &str = "__hdf5_pure_mat_MatrixComplex32__";
+        /// The complex element class a `Matrix<T>` sentinel names, or `None`
+        /// for the plain numeric sentinel and any other struct name.
+        pub(crate) fn complex_tag_for_matrix_sentinel(name: &str) -> Option<ComplexTag> {
+            match name {
+                $($konst => Some(ComplexTag::$tag),)*
+                _ => None,
+            }
+        }
+    };
+}
+
+matrix_complex_sentinels! {
+    MATRIX_COMPLEX64_SENTINEL => Complex64, F64, "64",
+    MATRIX_COMPLEX32_SENTINEL => Complex32, F32, "32",
+    MATRIX_COMPLEX_I64_SENTINEL => ComplexI64, I64, "I64",
+    MATRIX_COMPLEX_I32_SENTINEL => ComplexI32, I32, "I32",
+    MATRIX_COMPLEX_I16_SENTINEL => ComplexI16, I16, "I16",
+    MATRIX_COMPLEX_I8_SENTINEL => ComplexI8, I8, "I8",
+    MATRIX_COMPLEX_U64_SENTINEL => ComplexU64, U64, "U64",
+    MATRIX_COMPLEX_U32_SENTINEL => ComplexU32, U32, "U32",
+    MATRIX_COMPLEX_U16_SENTINEL => ComplexU16, U16, "U16",
+    MATRIX_COMPLEX_U8_SENTINEL => ComplexU8, U8, "U8",
+}
 
 mod sealed {
     pub trait Sealed {}
@@ -107,6 +139,14 @@ impl_mat_element! {
     bool => MATRIX_SENTINEL,
     Complex64 => MATRIX_COMPLEX64_SENTINEL,
     Complex32 => MATRIX_COMPLEX32_SENTINEL,
+    ComplexI64 => MATRIX_COMPLEX_I64_SENTINEL,
+    ComplexI32 => MATRIX_COMPLEX_I32_SENTINEL,
+    ComplexI16 => MATRIX_COMPLEX_I16_SENTINEL,
+    ComplexI8 => MATRIX_COMPLEX_I8_SENTINEL,
+    ComplexU64 => MATRIX_COMPLEX_U64_SENTINEL,
+    ComplexU32 => MATRIX_COMPLEX_U32_SENTINEL,
+    ComplexU16 => MATRIX_COMPLEX_U16_SENTINEL,
+    ComplexU8 => MATRIX_COMPLEX_U8_SENTINEL,
 }
 
 /// A dense 2-D matrix stored in row-major order (Rust convention).

--- a/src/mat/mod.rs
+++ b/src/mat/mod.rs
@@ -58,6 +58,8 @@ pub mod dims;
 pub mod identifier;
 pub mod options;
 pub mod string_object;
+#[cfg(feature = "serde")]
+pub(crate) mod transpose;
 
 // Complex/Matrix types and the serde-driven (de)serializer. Only meaningful
 // when serde is in scope.
@@ -88,7 +90,10 @@ pub use options::{
 };
 
 #[cfg(feature = "serde")]
-pub use complex::{Complex32, Complex64};
+pub use complex::{
+    Complex32, Complex64, ComplexI8, ComplexI16, ComplexI32, ComplexI64, ComplexU8, ComplexU16,
+    ComplexU32, ComplexU64,
+};
 #[cfg(feature = "serde")]
 pub use matrix::{MatElement, Matrix};
 #[cfg(feature = "serde")]

--- a/src/mat/ser/emit.rs
+++ b/src/mat/ser/emit.rs
@@ -12,9 +12,9 @@ use crate::type_builders::{
 };
 use crate::writer::FileBuilder;
 
-use crate::mat::value::{MatValue, NumVec, ScalarNum, ScalarTag};
+use crate::mat::value::{ComplexVec, MatValue, NumVec, ScalarNum, ScalarTag};
 
-use super::transpose::{transpose_pairs, transpose_scalars};
+use crate::mat::transpose::transpose_scalars;
 
 /// Hidden MATLAB conventional group that holds the targets of object
 /// references. Cell-array elements live here, addressed by absolute path.
@@ -177,40 +177,18 @@ fn apply_value_to_dataset(
             apply_char_string(ds, &s);
             Ok(())
         }
-        MatValue::ComplexScalar64 { re, im } => {
-            ds.with_complex64_data(&[(re, im)]).with_shape(&[1, 1]);
-            set_class(ds, MatClass::Double);
+        MatValue::ComplexScalar(n) => {
+            apply_complex(ds, ComplexVec::from_single(n), &[1, 1]);
             Ok(())
         }
-        MatValue::ComplexScalar32 { re, im } => {
-            ds.with_complex32_data(&[(re, im)]).with_shape(&[1, 1]);
-            set_class(ds, MatClass::Single);
-            Ok(())
-        }
-        MatValue::ComplexVec64(pairs) => {
+        MatValue::ComplexVec1D(pairs) => {
             let n = pairs.len() as u64;
-            ds.with_complex64_data(&pairs).with_shape(&[1, n]);
-            set_class(ds, MatClass::Double);
+            apply_complex(ds, pairs, &[1, n]);
             Ok(())
         }
-        MatValue::ComplexVec32(pairs) => {
-            let n = pairs.len() as u64;
-            ds.with_complex32_data(&pairs).with_shape(&[1, n]);
-            set_class(ds, MatClass::Single);
-            Ok(())
-        }
-        MatValue::ComplexMatrix64 { rows, cols, pairs } => {
-            let col_major = transpose_pairs(rows, cols, &pairs);
-            ds.with_complex64_data(&col_major)
-                .with_shape(&[cols as u64, rows as u64]);
-            set_class(ds, MatClass::Double);
-            Ok(())
-        }
-        MatValue::ComplexMatrix32 { rows, cols, pairs } => {
-            let col_major = transpose_pairs(rows, cols, &pairs);
-            ds.with_complex32_data(&col_major)
-                .with_shape(&[cols as u64, rows as u64]);
-            set_class(ds, MatClass::Single);
+        MatValue::ComplexMatrix { rows, cols, pairs } => {
+            let col_major = pairs.transposed(rows, cols);
+            apply_complex(ds, col_major, &[cols as u64, rows as u64]);
             Ok(())
         }
         MatValue::Cell(elements) => apply_cell(ds, elements, refs),
@@ -258,6 +236,27 @@ fn apply_empty_struct_array(ds: &mut DatasetBuilder) {
     ds.with_u64_data(&[]).with_shape(&[0u64, 0]);
     set_class(ds, MatClass::Struct);
     ds.set_attr("MATLAB_empty", AttrValue::U32(1));
+}
+
+/// Write `pairs` as a `{real, imag}` compound dataset of the given HDF5 shape,
+/// tagged with the component's MATLAB class.
+///
+/// The `match` is the one place the component width becomes a concrete Rust
+/// type; a class added to [`ComplexVec`] fails to compile here until it is
+/// listed, which is the point.
+fn apply_complex(ds: &mut DatasetBuilder, pairs: ComplexVec, shape: &[u64]) {
+    let class = pairs.tag().class();
+    macro_rules! arms {
+        ($($variant:ident),* $(,)?) => {
+            match pairs {
+                $(ComplexVec::$variant(v) => {
+                    ds.with_complex_data(&v).with_shape(shape);
+                })*
+            }
+        };
+    }
+    arms!(F64, F32, I64, I32, I16, I8, U64, U32, U16, U8);
+    set_class(ds, class);
 }
 
 fn apply_scalar(ds: &mut DatasetBuilder, n: ScalarNum) -> Result<(), MatError> {

--- a/src/mat/ser/emit_with_builder.rs
+++ b/src/mat/ser/emit_with_builder.rs
@@ -154,7 +154,8 @@ fn emit_cell_element(cw: &mut CellWriter, value: MatValue) -> Result<(), MatErro
             push_complex(cw, &[1, 1], ComplexVec::from_single(n))?;
         }
         MatValue::ComplexVec1D(pairs) => {
-            push_complex(cw, &[1, pairs.len()], pairs)?;
+            let dims = cw.vector_dims(pairs.len());
+            push_complex(cw, &dims, pairs)?;
         }
         MatValue::ComplexMatrix { rows, cols, pairs } => {
             let col_major = pairs.transposed(rows, cols);
@@ -315,7 +316,8 @@ fn emit_leaf_at_builder(mb: &mut MatBuilder, name: &str, value: MatValue) -> Res
             write_complex_at_builder(mb, name, &[1, 1], ComplexVec::from_single(n))
         }
         MatValue::ComplexVec1D(pairs) => {
-            write_complex_at_builder(mb, name, &[1, pairs.len()], pairs)
+            let dims = mb.vector_dims(pairs.len());
+            write_complex_at_builder(mb, name, &dims, pairs)
         }
         MatValue::ComplexMatrix { rows, cols, pairs } => {
             let col_major = pairs.transposed(rows, cols);
@@ -341,7 +343,8 @@ fn emit_leaf_at_struct(sw: &mut StructWriter, name: &str, value: MatValue) -> Re
             write_complex_at_struct(sw, name, &[1, 1], ComplexVec::from_single(n))
         }
         MatValue::ComplexVec1D(pairs) => {
-            write_complex_at_struct(sw, name, &[1, pairs.len()], pairs)
+            let dims = sw.vector_dims(pairs.len());
+            write_complex_at_struct(sw, name, &dims, pairs)
         }
         MatValue::ComplexMatrix { rows, cols, pairs } => {
             let col_major = pairs.transposed(rows, cols);

--- a/src/mat/ser/emit_with_builder.rs
+++ b/src/mat/ser/emit_with_builder.rs
@@ -8,9 +8,64 @@ use crate::mat::builder::{CellWriter, MatBuilder, StructWriter};
 use crate::mat::class::MatClass;
 use crate::mat::error::MatError;
 use crate::mat::options::{Options, StringClass};
-use crate::mat::value::{MatValue, NumVec, ScalarNum, ScalarTag};
+use crate::mat::value::{ComplexVec, MatValue, NumVec, ScalarNum, ScalarTag};
 
-use super::transpose::{transpose_pairs, transpose_scalars};
+use crate::mat::transpose::transpose_scalars;
+
+/// The complex dispatchers for the three write scopes, from one list.
+///
+/// Each expands to a `match` over every component class, which is where a
+/// class becomes a concrete Rust type; a class added to [`ComplexVec`] fails to
+/// compile here until it is listed, the same compile-time check `ser::emit`
+/// relies on.
+macro_rules! complex_dispatchers {
+    ($($variant:ident => $write:ident, $push:ident),* $(,)?) => {
+        fn write_complex_at_builder(
+            mb: &mut MatBuilder,
+            name: &str,
+            dims: &[usize],
+            pairs: ComplexVec,
+        ) -> Result<(), MatError> {
+            match pairs {
+                $(ComplexVec::$variant(v) => mb.$write(name, dims, &v).map(|_| ()),)*
+            }
+        }
+
+        fn write_complex_at_struct(
+            sw: &mut StructWriter,
+            name: &str,
+            dims: &[usize],
+            pairs: ComplexVec,
+        ) -> Result<(), MatError> {
+            match pairs {
+                $(ComplexVec::$variant(v) => sw.$write(name, dims, &v).map(|_| ()),)*
+            }
+        }
+
+        fn push_complex(
+            cw: &mut CellWriter,
+            dims: &[usize],
+            pairs: ComplexVec,
+        ) -> Result<(), MatError> {
+            match pairs {
+                $(ComplexVec::$variant(v) => cw.$push(dims, &v).map(|_| ()),)*
+            }
+        }
+    };
+}
+
+complex_dispatchers! {
+    F64 => write_complex_f64, push_complex_f64,
+    F32 => write_complex_f32, push_complex_f32,
+    I64 => write_complex_i64, push_complex_i64,
+    I32 => write_complex_i32, push_complex_i32,
+    I16 => write_complex_i16, push_complex_i16,
+    I8 => write_complex_i8, push_complex_i8,
+    U64 => write_complex_u64, push_complex_u64,
+    U32 => write_complex_u32, push_complex_u32,
+    U16 => write_complex_u16, push_complex_u16,
+    U8 => write_complex_u8, push_complex_u8,
+}
 
 /// Walk top-level fields and emit through a `MatBuilder`.
 pub(crate) fn emit_file_with_options(
@@ -95,25 +150,15 @@ fn emit_cell_element(cw: &mut CellWriter, value: MatValue) -> Result<(), MatErro
         MatValue::String(s) => {
             cw.push_char(&s)?;
         }
-        MatValue::ComplexScalar64 { re, im } => {
-            cw.push_complex_f64(&[1, 1], &[(re, im)])?;
+        MatValue::ComplexScalar(n) => {
+            push_complex(cw, &[1, 1], ComplexVec::from_single(n))?;
         }
-        MatValue::ComplexScalar32 { re, im } => {
-            cw.push_complex_f32(&[1, 1], &[(re, im)])?;
+        MatValue::ComplexVec1D(pairs) => {
+            push_complex(cw, &[1, pairs.len()], pairs)?;
         }
-        MatValue::ComplexVec64(pairs) => {
-            cw.push_complex_f64(&[1, pairs.len()], &pairs)?;
-        }
-        MatValue::ComplexVec32(pairs) => {
-            cw.push_complex_f32(&[1, pairs.len()], &pairs)?;
-        }
-        MatValue::ComplexMatrix64 { rows, cols, pairs } => {
-            let col_major = transpose_pairs(rows, cols, &pairs);
-            cw.push_complex_f64(&[rows, cols], &col_major)?;
-        }
-        MatValue::ComplexMatrix32 { rows, cols, pairs } => {
-            let col_major = transpose_pairs(rows, cols, &pairs);
-            cw.push_complex_f32(&[rows, cols], &col_major)?;
+        MatValue::ComplexMatrix { rows, cols, pairs } => {
+            let col_major = pairs.transposed(rows, cols);
+            push_complex(cw, &[rows, cols], col_major)?;
         }
         MatValue::EmptyStructArray => {
             cw.push_empty_struct_array()?;
@@ -266,27 +311,15 @@ fn emit_leaf_at_builder(mb: &mut MatBuilder, name: &str, value: MatValue) -> Res
         MatValue::Vec1D(v) => emit_vec_at_builder(mb, name, v),
         MatValue::Matrix { rows, cols, vec } => emit_matrix_at_builder(mb, name, rows, cols, vec),
         MatValue::String(s) => emit_string_at_builder(mb, name, &s),
-        MatValue::ComplexScalar64 { re, im } => {
-            mb.write_complex_f64(name, &[1, 1], &[(re, im)]).map(|_| ())
+        MatValue::ComplexScalar(n) => {
+            write_complex_at_builder(mb, name, &[1, 1], ComplexVec::from_single(n))
         }
-        MatValue::ComplexScalar32 { re, im } => {
-            mb.write_complex_f32(name, &[1, 1], &[(re, im)]).map(|_| ())
+        MatValue::ComplexVec1D(pairs) => {
+            write_complex_at_builder(mb, name, &[1, pairs.len()], pairs)
         }
-        MatValue::ComplexVec64(pairs) => mb
-            .write_complex_f64(name, &[1, pairs.len()], &pairs)
-            .map(|_| ()),
-        MatValue::ComplexVec32(pairs) => mb
-            .write_complex_f32(name, &[1, pairs.len()], &pairs)
-            .map(|_| ()),
-        MatValue::ComplexMatrix64 { rows, cols, pairs } => {
-            let col_major = transpose_pairs(rows, cols, &pairs);
-            mb.write_complex_f64(name, &[rows, cols], &col_major)
-                .map(|_| ())
-        }
-        MatValue::ComplexMatrix32 { rows, cols, pairs } => {
-            let col_major = transpose_pairs(rows, cols, &pairs);
-            mb.write_complex_f32(name, &[rows, cols], &col_major)
-                .map(|_| ())
+        MatValue::ComplexMatrix { rows, cols, pairs } => {
+            let col_major = pairs.transposed(rows, cols);
+            write_complex_at_builder(mb, name, &[rows, cols], col_major)
         }
         MatValue::EmptyStructArray => mb.write_empty_struct_array(name).map(|_| ()),
         MatValue::Opaque { .. } | MatValue::StructArray { .. } => {
@@ -304,27 +337,15 @@ fn emit_leaf_at_struct(sw: &mut StructWriter, name: &str, value: MatValue) -> Re
         MatValue::Vec1D(v) => emit_vec_at_struct(sw, name, v),
         MatValue::Matrix { rows, cols, vec } => emit_matrix_at_struct(sw, name, rows, cols, vec),
         MatValue::String(s) => emit_string_at_struct(sw, name, &s),
-        MatValue::ComplexScalar64 { re, im } => {
-            sw.write_complex_f64(name, &[1, 1], &[(re, im)]).map(|_| ())
+        MatValue::ComplexScalar(n) => {
+            write_complex_at_struct(sw, name, &[1, 1], ComplexVec::from_single(n))
         }
-        MatValue::ComplexScalar32 { re, im } => {
-            sw.write_complex_f32(name, &[1, 1], &[(re, im)]).map(|_| ())
+        MatValue::ComplexVec1D(pairs) => {
+            write_complex_at_struct(sw, name, &[1, pairs.len()], pairs)
         }
-        MatValue::ComplexVec64(pairs) => sw
-            .write_complex_f64(name, &[1, pairs.len()], &pairs)
-            .map(|_| ()),
-        MatValue::ComplexVec32(pairs) => sw
-            .write_complex_f32(name, &[1, pairs.len()], &pairs)
-            .map(|_| ()),
-        MatValue::ComplexMatrix64 { rows, cols, pairs } => {
-            let col_major = transpose_pairs(rows, cols, &pairs);
-            sw.write_complex_f64(name, &[rows, cols], &col_major)
-                .map(|_| ())
-        }
-        MatValue::ComplexMatrix32 { rows, cols, pairs } => {
-            let col_major = transpose_pairs(rows, cols, &pairs);
-            sw.write_complex_f32(name, &[rows, cols], &col_major)
-                .map(|_| ())
+        MatValue::ComplexMatrix { rows, cols, pairs } => {
+            let col_major = pairs.transposed(rows, cols);
+            write_complex_at_struct(sw, name, &[rows, cols], col_major)
         }
         MatValue::EmptyStructArray => sw.write_empty_struct_array(name).map(|_| ()),
         MatValue::Opaque { .. } | MatValue::StructArray { .. } => {

--- a/src/mat/ser/mod.rs
+++ b/src/mat/ser/mod.rs
@@ -3,7 +3,6 @@
 mod emit;
 mod emit_with_builder;
 mod root;
-mod transpose;
 mod value_ser;
 
 pub use root::{to_bytes, to_bytes_with_options};

--- a/src/mat/ser/value_ser.rs
+++ b/src/mat/ser/value_ser.rs
@@ -9,12 +9,14 @@ use serde::ser::{
     SerializeTupleStruct, Serializer,
 };
 
-use crate::mat::complex::{COMPLEX32_SENTINEL, COMPLEX64_SENTINEL};
+use crate::mat::complex::complex_tag_for_sentinel;
 use crate::mat::error::MatError;
-use crate::mat::matrix::{MATRIX_COMPLEX32_SENTINEL, MATRIX_COMPLEX64_SENTINEL, MATRIX_SENTINEL};
+use crate::mat::matrix::{MATRIX_SENTINEL, complex_tag_for_matrix_sentinel};
 use crate::mat::utf16;
 
-use crate::mat::value::{MatValue, NumVec, ScalarNum, ScalarTag};
+use crate::mat::value::{
+    ComplexNum, ComplexTag, ComplexVec, MatValue, NumVec, ScalarNum, ScalarTag,
+};
 
 // ---------------------------------------------------------------------------
 // Public entry: serialize a value into a MatValue
@@ -178,16 +180,17 @@ impl Serializer for ValueSerializer {
     }
 
     fn serialize_struct(self, name: &'static str, len: usize) -> Result<StructSer, MatError> {
+        if let Some(tag) = complex_tag_for_sentinel(name) {
+            return Ok(StructSer::Complex(tag, ComplexFields::default()));
+        }
+        if let Some(tag) = complex_tag_for_matrix_sentinel(name) {
+            return Ok(StructSer::Matrix(
+                MatrixFields::default(),
+                MatrixKind::Complex(tag),
+            ));
+        }
         Ok(match name {
             MATRIX_SENTINEL => StructSer::Matrix(MatrixFields::default(), MatrixKind::Numeric),
-            MATRIX_COMPLEX64_SENTINEL => {
-                StructSer::Matrix(MatrixFields::default(), MatrixKind::Complex64)
-            }
-            MATRIX_COMPLEX32_SENTINEL => {
-                StructSer::Matrix(MatrixFields::default(), MatrixKind::Complex32)
-            }
-            COMPLEX64_SENTINEL => StructSer::Complex64(ComplexFields::default()),
-            COMPLEX32_SENTINEL => StructSer::Complex32(ComplexFields::default()),
             // serde supplies the exact field count, so the field Vec can be
             // sized once instead of growing by reallocation.
             _ => StructSer::Plain(PlainStructFields::with_capacity(len)),
@@ -341,72 +344,40 @@ fn try_unify_homogeneous(elements: Vec<MatValue>) -> Result<MatValue, Vec<MatVal
         }
     }
 
-    // ----- all complex scalars of one width → ComplexVec (f64 case) -----
-    if elements
-        .iter()
-        .all(|e| matches!(e, MatValue::ComplexScalar64 { .. }))
-    {
-        let pairs: Vec<(f64, f64)> = elements
-            .into_iter()
-            .map(|e| match e {
-                MatValue::ComplexScalar64 { re, im } => (re, im),
-                _ => unreachable!(),
-            })
-            .collect();
-        return Ok(MatValue::ComplexVec64(pairs));
-    }
-    // ----- f32 complex-scalar variant of the above -----
-    if elements
-        .iter()
-        .all(|e| matches!(e, MatValue::ComplexScalar32 { .. }))
-    {
-        let pairs: Vec<(f32, f32)> = elements
-            .into_iter()
-            .map(|e| match e {
-                MatValue::ComplexScalar32 { re, im } => (re, im),
-                _ => unreachable!(),
-            })
-            .collect();
-        return Ok(MatValue::ComplexVec32(pairs));
-    }
-
-    // ----- all elements are ComplexVec of same length → ComplexMatrix -----
-    if let Some(MatValue::ComplexVec64(first)) = elements.first() {
-        let first_len = first.len();
+    // ----- all complex scalars of one class → ComplexVec1D -----
+    if let Some(MatValue::ComplexScalar(first)) = elements.first() {
+        let first_tag = first.tag();
         if elements
             .iter()
-            .all(|e| matches!(e, MatValue::ComplexVec64(v) if v.len() == first_len))
+            .all(|e| matches!(e, MatValue::ComplexScalar(n) if n.tag() == first_tag))
         {
-            let rows = elements.len();
-            let mut pairs: Vec<(f64, f64)> = Vec::with_capacity(rows * first_len);
+            let mut pairs = ComplexVec::with_capacity_for_tag(first_tag, elements.len());
             for e in elements {
-                let MatValue::ComplexVec64(v) = e else {
+                let MatValue::ComplexScalar(n) = e else {
                     unreachable!()
                 };
-                pairs.extend(v);
+                pairs.push(n).expect("tag check held");
             }
-            return Ok(MatValue::ComplexMatrix64 {
-                rows,
-                cols: first_len,
-                pairs,
-            });
+            return Ok(MatValue::ComplexVec1D(pairs));
         }
     }
-    if let Some(MatValue::ComplexVec32(first)) = elements.first() {
+
+    // ----- all elements are ComplexVec1D of one class & length → ComplexMatrix -----
+    if let Some(MatValue::ComplexVec1D(first)) = elements.first() {
+        let first_tag = first.tag();
         let first_len = first.len();
-        if elements
-            .iter()
-            .all(|e| matches!(e, MatValue::ComplexVec32(v) if v.len() == first_len))
-        {
+        if elements.iter().all(
+            |e| matches!(e, MatValue::ComplexVec1D(v) if v.tag() == first_tag && v.len() == first_len),
+        ) {
             let rows = elements.len();
-            let mut pairs: Vec<(f32, f32)> = Vec::with_capacity(rows * first_len);
+            let mut pairs = ComplexVec::with_capacity_for_tag(first_tag, rows * first_len);
             for e in elements {
-                let MatValue::ComplexVec32(v) = e else {
+                let MatValue::ComplexVec1D(v) = e else {
                     unreachable!()
                 };
-                pairs.extend(v);
+                pairs.extend(v).expect("tag check held");
             }
-            return Ok(MatValue::ComplexMatrix32 {
+            return Ok(MatValue::ComplexMatrix {
                 rows,
                 cols: first_len,
                 pairs,
@@ -477,20 +448,18 @@ impl SerializeMap for MapSer {
 
 pub(crate) enum StructSer {
     Matrix(MatrixFields, MatrixKind),
-    Complex64(ComplexFields<f64>),
-    Complex32(ComplexFields<f32>),
+    Complex(ComplexTag, ComplexFields),
     Plain(PlainStructFields),
 }
 
 /// Element class hint for a `Matrix<T>` sentinel. Carried through from the
-/// chosen sentinel name (see `matrix::matrix_sentinel_for`) so that empty
-/// matrices, where the inner `Vec<T>` cannot reveal `T`, still emit with the
-/// right MATLAB class.
+/// chosen sentinel name (see `matrix::MatElement`) so that empty matrices,
+/// where the inner `Vec<T>` cannot reveal `T`, still emit with the right
+/// MATLAB class.
 #[derive(Clone, Copy)]
 pub(crate) enum MatrixKind {
     Numeric,
-    Complex64,
-    Complex32,
+    Complex(ComplexTag),
 }
 
 #[derive(Default)]
@@ -500,10 +469,12 @@ pub(crate) struct MatrixFields {
     data: Option<MatValue>,
 }
 
+/// The two fields of a complex sentinel, held as tagged scalars: the component
+/// class comes from the sentinel, and `end` checks the fields against it.
 #[derive(Default)]
-pub(crate) struct ComplexFields<T> {
-    real: Option<T>,
-    imag: Option<T>,
+pub(crate) struct ComplexFields {
+    real: Option<ScalarNum>,
+    imag: Option<ScalarNum>,
 }
 
 #[derive(Default)]
@@ -548,21 +519,13 @@ impl SerializeStruct for StructSer {
                     )));
                 }
             },
-            StructSer::Complex64(fields) => match key {
-                "real" => fields.real = Some(expect_f64(value.serialize(ValueSerializer)?)?),
-                "imag" => fields.imag = Some(expect_f64(value.serialize(ValueSerializer)?)?),
+            StructSer::Complex(tag, fields) => match key {
+                "real" => fields.real = Some(expect_component(value.serialize(ValueSerializer)?)?),
+                "imag" => fields.imag = Some(expect_component(value.serialize(ValueSerializer)?)?),
                 other => {
                     return Err(MatError::Custom(format!(
-                        "unexpected field {other:?} on Complex64 sentinel"
-                    )));
-                }
-            },
-            StructSer::Complex32(fields) => match key {
-                "real" => fields.real = Some(expect_f32(value.serialize(ValueSerializer)?)?),
-                "imag" => fields.imag = Some(expect_f32(value.serialize(ValueSerializer)?)?),
-                other => {
-                    return Err(MatError::Custom(format!(
-                        "unexpected field {other:?} on Complex32 sentinel"
+                        "unexpected field {other:?} on the complex {} sentinel",
+                        tag.class().as_str()
                     )));
                 }
             },
@@ -578,22 +541,22 @@ impl SerializeStruct for StructSer {
         match self {
             StructSer::Plain(ps) => Ok(MatValue::Struct(ps.fields)),
             StructSer::Matrix(fields, kind) => matrix_from_fields(fields, kind),
-            StructSer::Complex64(fields) => Ok(MatValue::ComplexScalar64 {
-                re: fields
+            StructSer::Complex(tag, fields) => {
+                let re = fields
                     .real
-                    .ok_or_else(|| MatError::MissingField("real".into()))?,
-                im: fields
+                    .ok_or_else(|| MatError::MissingField("real".into()))?;
+                let im = fields
                     .imag
-                    .ok_or_else(|| MatError::MissingField("imag".into()))?,
-            }),
-            StructSer::Complex32(fields) => Ok(MatValue::ComplexScalar32 {
-                re: fields
-                    .real
-                    .ok_or_else(|| MatError::MissingField("real".into()))?,
-                im: fields
-                    .imag
-                    .ok_or_else(|| MatError::MissingField("imag".into()))?,
-            }),
+                    .ok_or_else(|| MatError::MissingField("imag".into()))?;
+                let n = ComplexNum::from_components(tag, re, im).ok_or_else(|| {
+                    MatError::Custom(format!(
+                        "complex {} fields must both be {}",
+                        tag.class().as_str(),
+                        tag.class().as_str()
+                    ))
+                })?;
+                Ok(MatValue::ComplexScalar(n))
+            }
         }
     }
 }
@@ -626,33 +589,21 @@ fn matrix_from_fields(fields: MatrixFields, kind: MatrixKind) -> Result<MatValue
             length_check(vec.len())?;
             Ok(MatValue::Matrix { rows, cols, vec })
         }
-        // Matrix<Complex64>: ComplexVec64 in the data slot, OR an empty
-        // Vec1D (the f64-default that an empty `Vec<Complex64>` collapses
-        // to in the seq path: with no elements observed, the seq
-        // unification can't recover T). The dedicated sentinel here lets
-        // us recover the class.
-        (MatrixKind::Complex64, MatValue::ComplexVec64(pairs)) => {
+        // Matrix<Complex*>: a ComplexVec1D of the sentinel's class in the data
+        // slot, OR an empty Vec1D (the f64-default that an empty
+        // `Vec<Complex*>` collapses to in the seq path: with no elements
+        // observed, the seq unification can't recover T). The dedicated
+        // sentinel here lets us recover the class.
+        (MatrixKind::Complex(tag), MatValue::ComplexVec1D(pairs)) if pairs.tag() == tag => {
             length_check(pairs.len())?;
-            Ok(MatValue::ComplexMatrix64 { rows, cols, pairs })
+            Ok(MatValue::ComplexMatrix { rows, cols, pairs })
         }
-        (MatrixKind::Complex64, MatValue::Vec1D(vec)) if vec.is_empty() => {
+        (MatrixKind::Complex(tag), MatValue::Vec1D(vec)) if vec.is_empty() => {
             length_check(0)?;
-            Ok(MatValue::ComplexMatrix64 {
+            Ok(MatValue::ComplexMatrix {
                 rows,
                 cols,
-                pairs: Vec::new(),
-            })
-        }
-        (MatrixKind::Complex32, MatValue::ComplexVec32(pairs)) => {
-            length_check(pairs.len())?;
-            Ok(MatValue::ComplexMatrix32 { rows, cols, pairs })
-        }
-        (MatrixKind::Complex32, MatValue::Vec1D(vec)) if vec.is_empty() => {
-            length_check(0)?;
-            Ok(MatValue::ComplexMatrix32 {
-                rows,
-                cols,
-                pairs: Vec::new(),
+                pairs: ComplexVec::empty_with_tag(tag),
             })
         }
         (_, other) => Err(MatError::Custom(format!(
@@ -685,27 +636,13 @@ fn expect_usize(v: MatValue, field: &str) -> Result<usize, MatError> {
     }
 }
 
-fn expect_f64(v: MatValue) -> Result<f64, MatError> {
+/// A complex sentinel's `real`/`imag` field, kept at the width it was
+/// serialized at. `end` checks it against the sentinel's class.
+fn expect_component(v: MatValue) -> Result<ScalarNum, MatError> {
     match v {
-        MatValue::Scalar(ScalarNum::F64(x)) => Ok(x),
-        MatValue::Scalar(ScalarNum::F32(x)) => Ok(x as f64),
+        MatValue::Scalar(s) => Ok(s),
         other => Err(MatError::Custom(format!(
-            "Complex field must be f64, got {}",
-            other.kind()
-        ))),
-    }
-}
-
-fn expect_f32(v: MatValue) -> Result<f32, MatError> {
-    match v {
-        MatValue::Scalar(ScalarNum::F32(x)) => Ok(x),
-        #[expect(
-            clippy::cast_possible_truncation,
-            reason = "coercing a user-supplied F64 complex field to the requested f32; lossy float narrowing is the intended conversion"
-        )]
-        MatValue::Scalar(ScalarNum::F64(x)) => Ok(x as f32),
-        other => Err(MatError::Custom(format!(
-            "Complex field must be f32, got {}",
+            "a complex field must be a numeric scalar, got {}",
             other.kind()
         ))),
     }

--- a/src/mat/transpose.rs
+++ b/src/mat/transpose.rs
@@ -1,10 +1,10 @@
 //! Row-major to column-major transpose shared by both write paths.
 //!
 //! MATLAB stores 2-D arrays column-major; the serializer holds them row-major.
-//! Both the default (`emit`) and options (`emit_with_builder`) write paths need
-//! the same transpose, so it lives here once. The implementation is cache-tiled
-//! (32x32 blocks) to keep both the strided source reads and the destination
-//! writes cache-resident on large matrices.
+//! Both write paths (`ser::emit` and `ser::emit_with_builder`) and the complex
+//! value model need the same transpose, so it lives here once. The
+//! implementation is cache-tiled (32x32 blocks) to keep both the strided source
+//! reads and the destination writes cache-resident on large matrices.
 
 /// Transpose a row-major matrix of shape `[rows, cols]` into column-major.
 ///
@@ -46,13 +46,13 @@ fn transpose_2d<T: Copy>(rows: usize, cols: usize, row_major: &[T]) -> Vec<T> {
 
 /// Transpose a row-major matrix of scalars into column-major order.
 #[inline]
-pub(super) fn transpose_scalars<T: Copy>(rows: usize, cols: usize, row_major: &[T]) -> Vec<T> {
+pub(crate) fn transpose_scalars<T: Copy>(rows: usize, cols: usize, row_major: &[T]) -> Vec<T> {
     transpose_2d(rows, cols, row_major)
 }
 
 /// Transpose a row-major matrix of `(re, im)` pairs into column-major order.
 #[inline]
-pub(super) fn transpose_pairs<T: Copy>(
+pub(crate) fn transpose_pairs<T: Copy>(
     rows: usize,
     cols: usize,
     row_major: &[(T, T)],

--- a/src/mat/value.rs
+++ b/src/mat/value.rs
@@ -1,7 +1,9 @@
 //! Intermediate value tree built by the serializer, later emitted to an
 //! HDF5 file with MATLAB conventions.
 
+use crate::mat::class::MatClass;
 use crate::mat::error::MatError;
+use crate::mat::transpose::transpose_pairs;
 
 /// A scalar numeric value tagged by its Rust type.
 #[derive(Debug, Clone, PartialEq)]
@@ -198,6 +200,198 @@ impl NumVec {
     }
 }
 
+/// The complex counterparts of [`ScalarNum`] / [`NumVec`], generated from one
+/// list so a component width is added in a single place.
+///
+/// MATLAB stores a complex array as a `{real, imag}` compound whose
+/// `MATLAB_class` names the *component* class, so the set of component classes
+/// is the numeric classes: every one that [`NumVec`] carries except `logical`,
+/// which has no complex form. Keeping the component class in a tag rather than
+/// in the variant name is what lets an empty complex array still know what it
+/// is — the pairs are gone, the tag is not.
+macro_rules! complex_kinds {
+    ($($variant:ident => $ty:ty, $class:ident),* $(,)?) => {
+        /// The component class of a complex value.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        pub(crate) enum ComplexTag {
+            $($variant,)*
+        }
+
+        impl ComplexTag {
+            /// The MATLAB class a complex array of this component reports in
+            /// its `MATLAB_class` attribute.
+            pub(crate) fn class(self) -> MatClass {
+                match self {
+                    $(ComplexTag::$variant => MatClass::$class,)*
+                }
+            }
+
+            /// The component tag for `class`, or `None` for a class that has no
+            /// complex form (`char`, `logical`, `struct`, `cell`).
+            pub(crate) fn from_class(class: MatClass) -> Option<Self> {
+                match class {
+                    $(MatClass::$class => Some(ComplexTag::$variant),)*
+                    _ => None,
+                }
+            }
+        }
+
+        /// A complex scalar tagged by its component class.
+        #[derive(Debug, Clone, Copy, PartialEq)]
+        pub(crate) enum ComplexNum {
+            $($variant($ty, $ty),)*
+        }
+
+        impl ComplexNum {
+            pub(crate) fn tag(&self) -> ComplexTag {
+                match self {
+                    $(ComplexNum::$variant(..) => ComplexTag::$variant,)*
+                }
+            }
+
+            /// The real and imaginary parts as tagged scalars, so a caller can
+            /// hand each to serde without naming the component type.
+            pub(crate) fn components(self) -> (ScalarNum, ScalarNum) {
+                match self {
+                    $(ComplexNum::$variant(re, im) => {
+                        (ScalarNum::$variant(re), ScalarNum::$variant(im))
+                    })*
+                }
+            }
+
+            /// Rebuild a complex value from its two components, requiring both
+            /// to carry `tag`'s class.
+            ///
+            /// Returns `None` on any mismatch rather than converting: a
+            /// component is stored at the width the caller asked for, so a
+            /// coercion here would be a silent change of what the file says it
+            /// holds.
+            pub(crate) fn from_components(
+                tag: ComplexTag,
+                re: ScalarNum,
+                im: ScalarNum,
+            ) -> Option<Self> {
+                match (tag, re, im) {
+                    $((ComplexTag::$variant, ScalarNum::$variant(re), ScalarNum::$variant(im)) => {
+                        Some(ComplexNum::$variant(re, im))
+                    })*
+                    _ => None,
+                }
+            }
+
+            /// Promote a real scalar to a complex value with a zero imaginary
+            /// part, when the scalar's class is `tag`'s. `None` for a class
+            /// mismatch, and for `logical`, which has no complex form.
+            pub(crate) fn from_real(tag: ComplexTag, re: ScalarNum) -> Option<Self> {
+                match (tag, re) {
+                    $((ComplexTag::$variant, ScalarNum::$variant(re)) => {
+                        Some(ComplexNum::$variant(re, <$ty>::default()))
+                    })*
+                    _ => None,
+                }
+            }
+        }
+
+        /// A typed 1-D array of complex pairs, laid out `[(re, im), ...]`.
+        #[derive(Debug, Clone, PartialEq)]
+        pub(crate) enum ComplexVec {
+            $($variant(Vec<($ty, $ty)>),)*
+        }
+
+        impl ComplexVec {
+            pub(crate) fn len(&self) -> usize {
+                match self {
+                    $(ComplexVec::$variant(v) => v.len(),)*
+                }
+            }
+
+            pub(crate) fn tag(&self) -> ComplexTag {
+                match self {
+                    $(ComplexVec::$variant(_) => ComplexTag::$variant,)*
+                }
+            }
+
+            pub(crate) fn empty_with_tag(tag: ComplexTag) -> Self {
+                match tag {
+                    $(ComplexTag::$variant => ComplexVec::$variant(Vec::new()),)*
+                }
+            }
+
+            pub(crate) fn with_capacity_for_tag(tag: ComplexTag, cap: usize) -> Self {
+                match tag {
+                    $(ComplexTag::$variant => ComplexVec::$variant(Vec::with_capacity(cap)),)*
+                }
+            }
+
+            pub(crate) fn from_single(n: ComplexNum) -> Self {
+                match n {
+                    $(ComplexNum::$variant(re, im) => ComplexVec::$variant(vec![(re, im)]),)*
+                }
+            }
+
+            /// The pair at `index`, or `None` if out of bounds.
+            pub(crate) fn get(&self, index: usize) -> Option<ComplexNum> {
+                match self {
+                    $(ComplexVec::$variant(v) => {
+                        v.get(index).map(|&(re, im)| ComplexNum::$variant(re, im))
+                    })*
+                }
+            }
+
+            /// Push a pair, requiring a matching tag.
+            pub(crate) fn push(&mut self, n: ComplexNum) -> Result<(), MatError> {
+                match (self, n) {
+                    $((ComplexVec::$variant(v), ComplexNum::$variant(re, im)) => v.push((re, im)),)*
+                    _ => return Err(MatError::MixedSequenceElementTypes),
+                }
+                Ok(())
+            }
+
+            /// Append another vec of the same tag.
+            pub(crate) fn extend(&mut self, other: ComplexVec) -> Result<(), MatError> {
+                match (self, other) {
+                    $((ComplexVec::$variant(a), ComplexVec::$variant(b)) => a.extend(b),)*
+                    _ => return Err(MatError::MixedSequenceElementTypes),
+                }
+                Ok(())
+            }
+
+            /// Split the first `n` pairs off the front, leaving the rest.
+            pub(crate) fn split_off_front(&mut self, n: usize) -> ComplexVec {
+                match self {
+                    $(ComplexVec::$variant(v) => {
+                        let tail = v.split_off(n);
+                        ComplexVec::$variant(core::mem::replace(v, tail))
+                    })*
+                }
+            }
+
+            /// Reinterpret `rows × cols` row-major pairs as column-major, the
+            /// order MATLAB stores a matrix in.
+            pub(crate) fn transposed(self, rows: usize, cols: usize) -> Self {
+                match self {
+                    $(ComplexVec::$variant(v) => {
+                        ComplexVec::$variant(transpose_pairs(rows, cols, &v))
+                    })*
+                }
+            }
+        }
+    };
+}
+
+complex_kinds! {
+    F64 => f64, Double,
+    F32 => f32, Single,
+    I64 => i64, Int64,
+    I32 => i32, Int32,
+    I16 => i16, Int16,
+    I8 => i8, Int8,
+    U64 => u64, UInt64,
+    U32 => u32, UInt32,
+    U16 => u16, UInt16,
+    U8 => u8, UInt8,
+}
+
 /// Intermediate tree node produced by the value serializer.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum MatValue {
@@ -216,25 +410,16 @@ pub(crate) enum MatValue {
     },
     /// UTF-16 `char` string → stored as `uint16 [1, N]`.
     String(String),
-    /// Complex scalar (`double` class).
-    ComplexScalar64 { re: f64, im: f64 },
-    /// Complex scalar (`single` class).
-    ComplexScalar32 { re: f32, im: f32 },
-    /// Complex 1-D array (`double`). Pairs laid out `[(re, im), ...]`.
-    ComplexVec64(Vec<(f64, f64)>),
-    /// Complex 1-D array (`single`).
-    ComplexVec32(Vec<(f32, f32)>),
-    /// Complex 2-D matrix (`double`), row-major pairs.
-    ComplexMatrix64 {
+    /// Complex scalar → stored as a `[1, 1]` `{real, imag}` compound.
+    ComplexScalar(ComplexNum),
+    /// Complex 1-D array → stored as `[1, N]`.
+    ComplexVec1D(ComplexVec),
+    /// Complex 2-D matrix in row-major order → stored column-major with shape
+    /// `[cols, rows]`, mirroring [`MatValue::Matrix`].
+    ComplexMatrix {
         rows: usize,
         cols: usize,
-        pairs: Vec<(f64, f64)>,
-    },
-    /// Complex 2-D matrix (`single`).
-    ComplexMatrix32 {
-        rows: usize,
-        cols: usize,
-        pairs: Vec<(f32, f32)>,
+        pairs: ComplexVec,
     },
     /// Ordered, named fields. Serialized as a MATLAB struct group.
     Struct(Vec<(String, MatValue)>),
@@ -305,9 +490,9 @@ impl MatValue {
             MatValue::Vec1D(_) => "1-D vector",
             MatValue::Matrix { .. } => "2-D matrix",
             MatValue::String(_) => "string",
-            MatValue::ComplexScalar64 { .. } | MatValue::ComplexScalar32 { .. } => "complex scalar",
-            MatValue::ComplexVec64(_) | MatValue::ComplexVec32(_) => "complex vector",
-            MatValue::ComplexMatrix64 { .. } | MatValue::ComplexMatrix32 { .. } => "complex matrix",
+            MatValue::ComplexScalar(_) => "complex scalar",
+            MatValue::ComplexVec1D(_) => "complex vector",
+            MatValue::ComplexMatrix { .. } => "complex matrix",
             MatValue::Struct(_) => "struct",
             MatValue::Cell(_) => "cell array",
             MatValue::EmptyStructArray => "empty struct array",

--- a/src/type_builders.rs
+++ b/src/type_builders.rs
@@ -266,6 +266,10 @@ pub(crate) trait ComplexComponent: complex_component::Sealed + Copy {
     /// Decode one component from exactly `size_of::<Self>()` little-endian
     /// bytes. Callers slice the element out of the raw buffer first, so a
     /// wrong length is a bug here rather than bad input.
+    ///
+    /// Gated to match its only caller: the MAT reader is `serde`-only, while
+    /// the writer half of this trait compiles unconditionally.
+    #[cfg(feature = "serde")]
     fn decode_le(bytes: &[u8]) -> Self;
 }
 
@@ -280,6 +284,7 @@ macro_rules! impl_complex_component {
                 fn encode_le(self, out: &mut Vec<u8>) {
                     out.extend_from_slice(&self.to_le_bytes());
                 }
+                #[cfg(feature = "serde")]
                 fn decode_le(bytes: &[u8]) -> Self {
                     Self::from_le_bytes(
                         bytes

--- a/src/type_builders.rs
+++ b/src/type_builders.rs
@@ -241,6 +241,70 @@ impl Default for CompoundTypeBuilder {
     }
 }
 
+mod complex_component {
+    pub trait Sealed {}
+}
+
+/// A scalar type that can be the component of a complex `{real, imag}` dataset.
+///
+/// A complex array is a two-field compound of one numeric class, so the only
+/// things the layout depends on are the component's datatype and its
+/// little-endian encoding — which is exactly what this trait supplies, and why
+/// [`DatasetBuilder::with_complex_data`] needs nothing per width beyond a new
+/// impl here.
+///
+/// Sealed: the impls below cover every class the crate can store, and a
+/// component type outside that set could only produce a malformed file.
+pub(crate) trait ComplexComponent: complex_component::Sealed + Copy {
+    /// The datatype of one component, identical to what the type's
+    /// `with_*_data` writer emits for a real dataset of the same class.
+    fn datatype() -> Datatype;
+
+    /// Append `self` to `out` in little-endian byte order.
+    fn encode_le(self, out: &mut Vec<u8>);
+
+    /// Decode one component from exactly `size_of::<Self>()` little-endian
+    /// bytes. Callers slice the element out of the raw buffer first, so a
+    /// wrong length is a bug here rather than bad input.
+    fn decode_le(bytes: &[u8]) -> Self;
+}
+
+macro_rules! impl_complex_component {
+    ($($ty:ty => $make:ident),* $(,)?) => {
+        $(
+            impl complex_component::Sealed for $ty {}
+            impl ComplexComponent for $ty {
+                fn datatype() -> Datatype {
+                    $make()
+                }
+                fn encode_le(self, out: &mut Vec<u8>) {
+                    out.extend_from_slice(&self.to_le_bytes());
+                }
+                fn decode_le(bytes: &[u8]) -> Self {
+                    Self::from_le_bytes(
+                        bytes
+                            .try_into()
+                            .expect("caller slices exactly one component"),
+                    )
+                }
+            }
+        )*
+    };
+}
+
+impl_complex_component! {
+    f64 => make_f64_type,
+    f32 => make_f32_type,
+    i64 => make_i64_type,
+    i32 => make_i32_type,
+    i16 => make_i16_type,
+    i8 => make_i8_type,
+    u64 => make_u64_type,
+    u32 => make_u32_type,
+    u16 => make_u16_type,
+    u8 => make_u8_type,
+}
+
 /// Builder for an HDF5 compound datatype with explicit field offsets and size.
 ///
 /// This is the pure-Rust equivalent of creating an `H5T_COMPOUND` type and
@@ -1379,28 +1443,27 @@ impl DatasetBuilder {
 
     /// Write a complex32 (f32 real/imag pair) dataset.
     pub fn with_complex32_data(&mut self, data: &[(f32, f32)]) -> &mut Self {
-        let ct = CompoundTypeBuilder::new()
-            .f32_field("real")
-            .f32_field("imag")
-            .build();
-        let mut raw = Vec::with_capacity(data.len() * 8);
-        for &(r, i) in data {
-            raw.extend_from_slice(&r.to_le_bytes());
-            raw.extend_from_slice(&i.to_le_bytes());
-        }
-        self.with_compound_data(ct, raw, data.len() as u64)
+        self.with_complex_data(data)
     }
 
     /// Write a complex64 (f64 real/imag pair) dataset.
     pub fn with_complex64_data(&mut self, data: &[(f64, f64)]) -> &mut Self {
+        self.with_complex_data(data)
+    }
+
+    /// Write a complex dataset of any component width: a two-field `{real,
+    /// imag}` compound with `real` at offset 0 and `imag` at
+    /// `size_of::<T>()`, which is the layout MATLAB v7.3 uses for a complex
+    /// array of the component's class.
+    pub(crate) fn with_complex_data<T: ComplexComponent>(&mut self, data: &[(T, T)]) -> &mut Self {
         let ct = CompoundTypeBuilder::new()
-            .f64_field("real")
-            .f64_field("imag")
+            .field("real", T::datatype())
+            .field("imag", T::datatype())
             .build();
-        let mut raw = Vec::with_capacity(data.len() * 16);
-        for &(r, i) in data {
-            raw.extend_from_slice(&r.to_le_bytes());
-            raw.extend_from_slice(&i.to_le_bytes());
+        let mut raw = Vec::with_capacity(data.len() * 2 * size_of::<T>());
+        for &(re, im) in data {
+            re.encode_le(&mut raw);
+            im.encode_le(&mut raw);
         }
         self.with_compound_data(ct, raw, data.len() as u64)
     }

--- a/tests/complex_integer.rs
+++ b/tests/complex_integer.rs
@@ -10,7 +10,7 @@
 //! the file self-describing, and the shapes and edge values the float complex
 //! path already handles.
 
-use hdf5_pure::mat::options::Compression;
+use hdf5_pure::mat::options::{Compression, OneDimensionalMode};
 use hdf5_pure::mat::{
     self, Complex32, Complex64, ComplexI8, ComplexI16, ComplexI32, ComplexI64, ComplexU8,
     ComplexU16, ComplexU32, ComplexU64, Matrix, Options,
@@ -407,6 +407,49 @@ fn compression_round_trips_and_leaves_the_empty_array_alone() {
     );
     let back: Both = mat::from_bytes(&deflated).unwrap();
     assert_eq!(back, v);
+}
+
+/// A complex vector is a vector, so it takes the configured orientation like
+/// every other one. It used to be written as a MATLAB row regardless, which
+/// made it the only kind of 1-D array whose shape contradicted both the option
+/// and the default write path.
+#[test]
+fn a_complex_vector_takes_the_configured_orientation_like_a_real_one() {
+    #[derive(Serialize)]
+    struct Both {
+        reals: Vec<i16>,
+        cplx: Vec<ComplexI16>,
+    }
+
+    let v = Both {
+        reals: vec![1, 2, 3],
+        cplx: vec![
+            ComplexI16::new(1, -1),
+            ComplexI16::new(2, -2),
+            ComplexI16::new(3, -3),
+        ],
+    };
+    let shapes = |opts: &Options| {
+        let file = File::from_bytes(mat::to_bytes_with_options(&v, opts).unwrap()).unwrap();
+        (
+            file.dataset("reals").unwrap().shape().unwrap(),
+            file.dataset("cplx").unwrap().shape().unwrap(),
+        )
+    };
+
+    let (reals, cplx) = shapes(&Options::default());
+    assert_eq!(reals, cplx, "column-vector default");
+
+    let mut row = Options::default();
+    row.one_dimensional_mode = OneDimensionalMode::RowVector;
+    let (reals_row, cplx_row) = shapes(&row);
+    assert_eq!(reals_row, cplx_row, "row-vector mode");
+    assert_ne!(reals, reals_row, "the option has to move the shape at all");
+
+    // And the default options path agrees with `to_bytes`, which has no
+    // options to consult.
+    let plain = File::from_bytes(mat::to_bytes(&v).unwrap()).unwrap();
+    assert_eq!(plain.dataset("cplx").unwrap().shape().unwrap(), cplx);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/complex_integer.rs
+++ b/tests/complex_integer.rs
@@ -1,0 +1,459 @@
+#![cfg(feature = "serde")]
+//! Complex arrays with integer components.
+//!
+//! Hardware that samples in the complex plane — ADCs, digitizer front ends —
+//! produces pairs of signed 16-bit integers, and widening them to `single` on
+//! the way into a `.mat` file doubles the payload while adding nothing: the
+//! mantissa bits are zero by construction. These tests pin the layout that
+//! avoids that (a `{real, imag}` compound of the component class, with
+//! `MATLAB_class` naming the component), the exact-width guarantee that makes
+//! the file self-describing, and the shapes and edge values the float complex
+//! path already handles.
+
+use hdf5_pure::mat::options::Compression;
+use hdf5_pure::mat::{
+    self, Complex32, Complex64, ComplexI8, ComplexI16, ComplexI32, ComplexI64, ComplexU8,
+    ComplexU16, ComplexU32, ComplexU64, Matrix, Options,
+};
+use hdf5_pure::{AttrValue, Datatype, DatatypeByteOrder, File};
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// Shapes
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct Shapes {
+    scalar: ComplexI16,
+    row: Vec<ComplexI16>,
+    column: Matrix<ComplexI16>,
+    matrix: Matrix<ComplexI16>,
+    empty: Matrix<ComplexI16>,
+}
+
+fn shapes() -> Shapes {
+    Shapes {
+        scalar: ComplexI16::new(7, -9),
+        row: vec![
+            ComplexI16::new(1, 2),
+            ComplexI16::new(3, 4),
+            ComplexI16::new(5, 6),
+        ],
+        column: Matrix::from_row_major(
+            3,
+            1,
+            vec![
+                ComplexI16::new(10, -10),
+                ComplexI16::new(20, -20),
+                ComplexI16::new(30, -30),
+            ],
+        ),
+        matrix: Matrix::from_row_major(
+            2,
+            3,
+            vec![
+                ComplexI16::new(1, -1),
+                ComplexI16::new(2, -2),
+                ComplexI16::new(3, -3),
+                ComplexI16::new(4, -4),
+                ComplexI16::new(5, -5),
+                ComplexI16::new(6, -6),
+            ],
+        ),
+        empty: Matrix::from_row_major(0, 0, Vec::new()),
+    }
+}
+
+#[test]
+fn every_shape_round_trips() {
+    let v = shapes();
+    let bytes = mat::to_bytes(&v).unwrap();
+    let back: Shapes = mat::from_bytes(&bytes).unwrap();
+    assert_eq!(back, v);
+}
+
+/// A 1×N and an N×1 array of the same values are different MATLAB arrays, and
+/// the shape has to survive the column-major storage round trip in both
+/// orientations.
+#[test]
+fn row_and_column_orientation_survive() {
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    struct Oriented {
+        row: Matrix<ComplexI16>,
+        column: Matrix<ComplexI16>,
+    }
+
+    let pairs = || {
+        vec![
+            ComplexI16::new(10, -10),
+            ComplexI16::new(20, -20),
+            ComplexI16::new(30, -30),
+        ]
+    };
+    let v = Oriented {
+        row: Matrix::from_row_major(1, 3, pairs()),
+        column: Matrix::from_row_major(3, 1, pairs()),
+    };
+
+    let back: Oriented = mat::from_bytes(&mat::to_bytes(&v).unwrap()).unwrap();
+    assert_eq!((back.row.rows(), back.row.cols()), (1, 3));
+    assert_eq!((back.column.rows(), back.column.cols()), (3, 1));
+    assert_eq!(back, v);
+}
+
+/// A one-element complex array reads back as a complex *scalar*, which still
+/// has to satisfy a `Vec` target — the same allowance the real numeric path
+/// makes for a one-element numeric array.
+#[test]
+fn a_one_element_array_still_deserializes_as_a_vec() {
+    let one = Capture {
+        samples: vec![ComplexI16::new(5, -5)],
+    };
+    let back: Capture = mat::from_bytes(&mat::to_bytes(&one).unwrap()).unwrap();
+    assert_eq!(back, one);
+}
+
+/// An empty complex array carries no pairs, so only the class attribute and
+/// the compound datatype can say what it was — which is exactly what a reader
+/// needs to hand it back as an empty `int16` complex array rather than an
+/// untyped empty.
+#[test]
+fn an_empty_array_keeps_its_component_class() {
+    let v = shapes();
+    let bytes = mat::to_bytes(&v).unwrap();
+    let file = File::from_bytes(bytes).unwrap();
+    let ds = file.dataset("empty").unwrap();
+
+    assert_eq!(
+        ds.attrs().unwrap().get("MATLAB_class"),
+        Some(&AttrValue::String("int16".into()))
+    );
+    assert_compound_of(&ds.datatype().unwrap(), 2, true);
+    assert!(ds.read_u8().unwrap().is_empty());
+    // No `MATLAB_empty` marker: a zero-element compound is already an empty
+    // complex array to MATLAB, and the marker would make it an empty double.
+    assert!(!ds.attrs().unwrap().contains_key("MATLAB_empty"));
+}
+
+// ---------------------------------------------------------------------------
+// Layout
+// ---------------------------------------------------------------------------
+
+/// Assert a `{real, imag}` compound whose components are `size` bytes wide,
+/// `real` at offset 0 and `imag` at `size`.
+fn assert_compound_of(dt: &Datatype, size: u32, signed: bool) {
+    let Datatype::Compound {
+        size: total,
+        members,
+    } = dt
+    else {
+        panic!("expected a compound datatype, got {dt:?}");
+    };
+    assert_eq!(*total, size * 2, "compound is two components wide");
+    assert_eq!(members.len(), 2);
+    assert_eq!(members[0].name, "real");
+    assert_eq!(members[0].byte_offset, 0);
+    assert_eq!(members[1].name, "imag");
+    assert_eq!(members[1].byte_offset, u64::from(size));
+    for m in members {
+        match &m.datatype {
+            Datatype::FixedPoint {
+                size: component,
+                byte_order,
+                signed: is_signed,
+                bit_offset,
+                bit_precision,
+            } => {
+                assert_eq!(*component, size);
+                assert_eq!(*byte_order, DatatypeByteOrder::LittleEndian);
+                assert_eq!(*is_signed, signed);
+                assert_eq!(*bit_offset, 0);
+                assert_eq!(u32::from(*bit_precision), size * 8);
+            }
+            other => panic!("expected a fixed-point component, got {other:?}"),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct Capture {
+    samples: Vec<ComplexI16>,
+}
+
+/// The datatype is what MATLAB reads the class off, so asserting the round
+/// trip alone would accept a file this crate is happy with and MATLAB refuses.
+#[test]
+fn the_datatype_is_a_four_byte_int16_compound() {
+    let c = Capture {
+        samples: vec![ComplexI16::new(1, -1), ComplexI16::new(2, -2)],
+    };
+    let bytes = mat::to_bytes(&c).unwrap();
+    let file = File::from_bytes(bytes).unwrap();
+    let ds = file.dataset("samples").unwrap();
+
+    assert_compound_of(&ds.datatype().unwrap(), 2, true);
+    assert_eq!(
+        ds.attrs().unwrap().get("MATLAB_class"),
+        Some(&AttrValue::String("int16".into()))
+    );
+}
+
+/// Halving the payload is the entire point of the feature, so it is pinned by
+/// a test rather than assumed from the datatype.
+#[test]
+fn the_payload_is_four_bytes_per_element_half_of_the_single_equivalent() {
+    #[derive(Serialize)]
+    struct AsSingle {
+        samples: Vec<Complex32>,
+    }
+
+    let n = 64;
+    let ints = Capture {
+        samples: (0..n)
+            .map(|i| ComplexI16::new(i as i16, -(i as i16)))
+            .collect(),
+    };
+    let floats = AsSingle {
+        samples: (0..n)
+            .map(|i| Complex32::new(i as f32, -(i as f32)))
+            .collect(),
+    };
+
+    let int_payload = payload_len(mat::to_bytes(&ints).unwrap(), "samples");
+    let float_payload = payload_len(mat::to_bytes(&floats).unwrap(), "samples");
+
+    assert_eq!(int_payload, 4 * n as usize);
+    assert_eq!(float_payload, 8 * n as usize);
+}
+
+fn payload_len(bytes: Vec<u8>, name: &str) -> usize {
+    File::from_bytes(bytes)
+        .unwrap()
+        .dataset(name)
+        .unwrap()
+        .read_u8()
+        .unwrap()
+        .len()
+}
+
+// ---------------------------------------------------------------------------
+// Values
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct Edges {
+    i8s: Vec<ComplexI8>,
+    i16s: Vec<ComplexI16>,
+    i32s: Vec<ComplexI32>,
+    i64s: Vec<ComplexI64>,
+    u8s: Vec<ComplexU8>,
+    u16s: Vec<ComplexU16>,
+    u32s: Vec<ComplexU32>,
+    u64s: Vec<ComplexU64>,
+}
+
+/// Every width's extremes, including the minima that a naive negation or a
+/// signed/unsigned mix-up would mangle.
+#[test]
+fn extreme_component_values_survive() {
+    let v = Edges {
+        i8s: vec![
+            ComplexI8::new(i8::MIN, i8::MAX),
+            ComplexI8::new(0, -1),
+            ComplexI8::new(-1, 0),
+        ],
+        i16s: vec![
+            ComplexI16::new(i16::MIN, i16::MAX),
+            ComplexI16::new(0, 0),
+            ComplexI16::new(-1, 1),
+            ComplexI16::new(i16::MAX, i16::MIN),
+        ],
+        i32s: vec![ComplexI32::new(i32::MIN, i32::MAX)],
+        i64s: vec![ComplexI64::new(i64::MIN, i64::MAX)],
+        u8s: vec![ComplexU8::new(0, u8::MAX)],
+        u16s: vec![ComplexU16::new(u16::MAX, 0)],
+        u32s: vec![ComplexU32::new(u32::MAX, 1)],
+        u64s: vec![ComplexU64::new(u64::MAX, 0)],
+    };
+    let bytes = mat::to_bytes(&v).unwrap();
+    let back: Edges = mat::from_bytes(&bytes).unwrap();
+    assert_eq!(back, v);
+}
+
+/// Each width reports its own MATLAB class and its own component width; a
+/// shared code path that got the class from the wrong place would still round
+/// trip through this crate and still be wrong in MATLAB.
+#[test]
+fn each_width_reports_its_own_class_and_size() {
+    let v = Edges {
+        i8s: vec![ComplexI8::new(1, 2)],
+        i16s: vec![ComplexI16::new(1, 2)],
+        i32s: vec![ComplexI32::new(1, 2)],
+        i64s: vec![ComplexI64::new(1, 2)],
+        u8s: vec![ComplexU8::new(1, 2)],
+        u16s: vec![ComplexU16::new(1, 2)],
+        u32s: vec![ComplexU32::new(1, 2)],
+        u64s: vec![ComplexU64::new(1, 2)],
+    };
+    let file = File::from_bytes(mat::to_bytes(&v).unwrap()).unwrap();
+
+    for (name, class, size, signed) in [
+        ("i8s", "int8", 1u32, true),
+        ("i16s", "int16", 2, true),
+        ("i32s", "int32", 4, true),
+        ("i64s", "int64", 8, true),
+        ("u8s", "uint8", 1, false),
+        ("u16s", "uint16", 2, false),
+        ("u32s", "uint32", 4, false),
+        ("u64s", "uint64", 8, false),
+    ] {
+        let ds = file.dataset(name).unwrap();
+        assert_eq!(
+            ds.attrs().unwrap().get("MATLAB_class"),
+            Some(&AttrValue::String(class.into())),
+            "class of {name}"
+        );
+        assert_compound_of(&ds.datatype().unwrap(), size, signed);
+        assert_eq!(
+            ds.read_u8().unwrap().len(),
+            2 * size as usize,
+            "payload of {name}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// No silent width changes, in either direction
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct AsI16 {
+    samples: Vec<ComplexI16>,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct AsF64 {
+    samples: Vec<Complex64>,
+}
+
+/// Reading an `int16` capture as a float complex would be lossless and is
+/// still refused: the component width is part of what the file says it holds,
+/// so a Rust type that quietly disagrees with it is a worse witness than an
+/// error.
+#[test]
+fn an_integer_capture_does_not_deserialize_as_float_complex() {
+    let bytes = mat::to_bytes(&AsI16 {
+        samples: vec![ComplexI16::new(3, -4)],
+    })
+    .unwrap();
+    let err = mat::from_bytes::<AsF64>(&bytes).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("complex double"),
+        "error should name the class it wanted: {msg}"
+    );
+}
+
+/// The lossy direction is refused for the same reason, and would truncate.
+#[test]
+fn a_float_capture_does_not_deserialize_as_integer_complex() {
+    let bytes = mat::to_bytes(&AsF64 {
+        samples: vec![Complex64::new(3.5, -4.5)],
+    })
+    .unwrap();
+    let err = mat::from_bytes::<AsI16>(&bytes).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("complex int16"),
+        "error should name the class it wanted: {msg}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Compression
+// ---------------------------------------------------------------------------
+
+/// The deflate path is shape-sensitive, and an empty array must stay
+/// unfiltered (a filtered zero-element dataset is what MATLAB chokes on).
+#[test]
+fn compression_round_trips_and_leaves_the_empty_array_alone() {
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    struct Both {
+        samples: Vec<ComplexI16>,
+        empty: Matrix<ComplexI16>,
+    }
+
+    let v = Both {
+        // Highly compressible: a repeating ramp.
+        samples: (0..4096)
+            .map(|i| ComplexI16::new((i % 8) as i16, -((i % 8) as i16)))
+            .collect(),
+        empty: Matrix::from_row_major(0, 0, Vec::new()),
+    };
+
+    let plain = mat::to_bytes_with_options(&v, &Options::default()).unwrap();
+    let mut opts = Options::default();
+    opts.compression = Compression::Deflate {
+        level: 6,
+        shuffle: false,
+    };
+    let deflated = mat::to_bytes_with_options(&v, &opts).unwrap();
+
+    assert!(
+        deflated.len() < plain.len(),
+        "deflate should shrink a repeating ramp: {} vs {}",
+        deflated.len(),
+        plain.len()
+    );
+    let back: Both = mat::from_bytes(&deflated).unwrap();
+    assert_eq!(back, v);
+}
+
+// ---------------------------------------------------------------------------
+// The mid-level builder
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_builder_writes_complex_integers_in_every_scope() {
+    use hdf5_pure::mat::MatBuilder;
+
+    let mut mb = MatBuilder::new(Options::default());
+    mb.write_complex_i16("top", &[1, 2], &[(1, -1), (2, -2)])
+        .unwrap();
+    mb.struct_("nested", |sw| {
+        sw.write_complex_i32("field", &[1, 1], &[(7, -7)])?;
+        Ok(())
+    })
+    .unwrap();
+    mb.cell("cell", &[1, 1], |cw| {
+        cw.push_complex_u8(&[1, 2], &[(1, 2), (3, 4)])?;
+        Ok(())
+    })
+    .unwrap();
+    let bytes = mb.finish().unwrap();
+
+    let file = File::from_bytes(bytes).unwrap();
+    assert_compound_of(&file.dataset("top").unwrap().datatype().unwrap(), 2, true);
+    assert_compound_of(
+        &file.dataset("nested/field").unwrap().datatype().unwrap(),
+        4,
+        true,
+    );
+    assert_eq!(
+        file.dataset("nested/field")
+            .unwrap()
+            .attrs()
+            .unwrap()
+            .get("MATLAB_class"),
+        Some(&AttrValue::String("int32".into()))
+    );
+    // The cell element lives under `#refs#`; the first (and only) one here.
+    let refs = file.group("#refs#").unwrap();
+    let name = refs.datasets().unwrap().into_iter().next().unwrap();
+    let ds = refs.dataset(&name).unwrap();
+    assert_compound_of(&ds.datatype().unwrap(), 1, false);
+    assert_eq!(
+        ds.attrs().unwrap().get("MATLAB_class"),
+        Some(&AttrValue::String("uint8".into()))
+    );
+}

--- a/tests/complex_integer.rs
+++ b/tests/complex_integer.rs
@@ -15,7 +15,9 @@ use hdf5_pure::mat::{
     self, Complex32, Complex64, ComplexI8, ComplexI16, ComplexI32, ComplexI64, ComplexU8,
     ComplexU16, ComplexU32, ComplexU64, Matrix, Options,
 };
-use hdf5_pure::{AttrValue, Datatype, DatatypeByteOrder, File};
+use hdf5_pure::{
+    AttrValue, CompoundTypeBuilder, Datatype, DatatypeByteOrder, File, FileBuilder, make_i64_type,
+};
 use serde::{Deserialize, Serialize};
 
 // ---------------------------------------------------------------------------
@@ -130,8 +132,13 @@ fn an_empty_array_keeps_its_component_class() {
     );
     assert_compound_of(&ds.datatype().unwrap(), 2, true);
     assert!(ds.read_u8().unwrap().is_empty());
-    // No `MATLAB_empty` marker: a zero-element compound is already an empty
-    // complex array to MATLAB, and the marker would make it an empty double.
+    // A zero-element compound of the component class is what this writer emits
+    // for an empty complex array, and it round-trips. It is *not* what MATLAB
+    // itself emits: `Mat_VarWriteEmpty` writes the dims as data under
+    // `MATLAB_empty=1`, keeping the plain class name, and libmatio reads that
+    // form back as complex `int16` too. Pinning the shape we write here so the
+    // divergence is visible rather than assumed — see the empty-array note in
+    // `docs/interop/matlab.md`.
     assert!(!ds.attrs().unwrap().contains_key("MATLAB_empty"));
 }
 
@@ -366,6 +373,73 @@ fn a_float_capture_does_not_deserialize_as_integer_complex() {
     assert!(
         msg.contains("complex int16"),
         "error should name the class it wanted: {msg}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// A file that disagrees with itself
+// ---------------------------------------------------------------------------
+
+/// Assemble a complex `double` array carrying a `MATLAB_class` attribute that
+/// names some other class, the way a malformed or third-party writer can.
+fn complex_f64_labelled(class: Option<&str>) -> Vec<u8> {
+    let mut fb = FileBuilder::new();
+    {
+        let d = fb.create_dataset("samples");
+        d.with_complex64_data(&[(1.0, -1.0), (2.0, -2.0), (3.0, -3.0)])
+            .with_shape(&[1, 3]);
+        if let Some(class) = class {
+            d.set_attr("MATLAB_class", AttrValue::AsciiString(class.to_owned()));
+        }
+    }
+    fb.finish().unwrap()
+}
+
+/// The component width is read from `MATLAB_class` while the bytes come from
+/// the compound, and nothing in the format forces the two to agree. A narrower
+/// claim over wider members passes every length check and decodes to the low
+/// halves of the real components, so it has to be refused on the datatype.
+#[test]
+fn a_class_attribute_that_contradicts_the_compound_is_refused() {
+    let bytes = complex_f64_labelled(Some("int16"));
+    let err = mat::from_bytes::<AsI16>(&bytes).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("int16") && msg.contains("f64"),
+        "error should name both the claimed class and the stored one: {msg}"
+    );
+}
+
+/// The same disagreement reached without a malicious attribute at all: with no
+/// `MATLAB_class`, the class is guessed from the datatype, and the guess for a
+/// compound is `double`. A complex `int64` array has the identical 16-byte
+/// element size, so the length check cannot tell the two apart.
+#[test]
+fn an_unlabelled_complex_integer_array_is_not_decoded_as_double() {
+    let ct = CompoundTypeBuilder::new()
+        .field("real", make_i64_type())
+        .field("imag", make_i64_type())
+        .build();
+    let mut raw = Vec::new();
+    for (re, im) in [(1i64, -1i64), (2, -2)] {
+        raw.extend_from_slice(&re.to_le_bytes());
+        raw.extend_from_slice(&im.to_le_bytes());
+    }
+
+    let mut fb = FileBuilder::new();
+    {
+        let d = fb.create_dataset("samples");
+        d.with_compound_data(ct, raw, 2).with_shape(&[1, 2]);
+    }
+    let bytes = fb.finish().unwrap();
+
+    // The bytes are i64 pairs; the absent attribute makes the reader guess
+    // `double`, which is the same element size and would decode as garbage.
+    let err = mat::from_bytes::<AsF64>(&bytes).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("double") && msg.contains("i64"),
+        "error should name the guessed class and the stored one: {msg}"
     );
 }
 

--- a/tests/complex_integer.rs
+++ b/tests/complex_integer.rs
@@ -574,3 +574,164 @@ fn the_builder_writes_complex_integers_in_every_scope() {
         Some(&AttrValue::String("uint8".into()))
     );
 }
+
+// ---------------------------------------------------------------------------
+// Every arm shape, every integer class
+// ---------------------------------------------------------------------------
+
+/// A complex value reaches the writer through one of five distinct arms —
+/// scalar, 1-D vector, 2-D matrix, a matrix built from equal-length rows, and a
+/// cell element — and each one is a separate dispatch site. The per-class risk
+/// is small because the dispatch is macro-generated from one list, but the
+/// per-*arm* risk is not, so every arm is exercised for every integer class
+/// rather than for `int16` alone. The float classes take the same arms and are
+/// covered by the pre-existing `Complex64`/`Complex32` round trips.
+macro_rules! arm_shapes_for {
+    ($($name:ident: $ty:ident, $class:literal, $size:literal, $signed:literal;)*) => {
+        $(
+            #[test]
+            fn $name() {
+                #[derive(Serialize, Deserialize, Debug, PartialEq)]
+                struct Arms {
+                    scalar: $ty,
+                    vector: Vec<$ty>,
+                    matrix: Matrix<$ty>,
+                    rows: Vec<Vec<$ty>>,
+                    cells: Vec<Matrix<$ty>>,
+                    empty: Matrix<$ty>,
+                }
+
+                // Small non-negative values, so one table serves the signed and
+                // unsigned classes alike; ranges are pinned separately by
+                // `extreme_component_values_survive`.
+                let e = |re: i64, im: i64| $ty::new(re as _, im as _);
+                let v = Arms {
+                    scalar: e(7, 9),
+                    vector: vec![e(1, 2), e(3, 4), e(5, 6)],
+                    matrix: Matrix::from_row_major(
+                        2,
+                        3,
+                        vec![e(1, 1), e(2, 2), e(3, 3), e(4, 4), e(5, 5), e(6, 6)],
+                    ),
+                    rows: vec![vec![e(1, 2), e(3, 4)], vec![e(5, 6), e(7, 8)]],
+                    cells: vec![
+                        Matrix::from_row_major(2, 2, vec![e(1, 1), e(2, 2), e(3, 3), e(4, 4)]),
+                        Matrix::from_row_major(1, 2, vec![e(5, 5), e(6, 6)]),
+                    ],
+                    empty: Matrix::from_row_major(0, 0, Vec::new()),
+                };
+
+                // `to_bytes` and `to_bytes_with_options` are two separate emit
+                // paths with their own copy of every arm — the orientation
+                // defect this PR fixes lived in one and not the other — so
+                // each arm is exercised through both.
+                let written = [
+                    ("to_bytes", mat::to_bytes(&v).unwrap()),
+                    (
+                        "to_bytes_with_options",
+                        mat::to_bytes_with_options(&v, &Options::default()).unwrap(),
+                    ),
+                ];
+
+                for (path, bytes) in written {
+                    let back: Arms = mat::from_bytes(&bytes).unwrap();
+                    assert_eq!(back, v, "{path}");
+
+                    // The round trip alone would accept a compound this crate
+                    // is happy with and MATLAB refuses, so pin the stored
+                    // layout of every arm that writes one directly.
+                    let file = File::from_bytes(bytes).unwrap();
+                    for name in ["scalar", "vector", "matrix", "rows", "empty"] {
+                        let ds = file.dataset(name).unwrap();
+                        assert_compound_of(&ds.datatype().unwrap(), $size, $signed);
+                        assert_eq!(
+                            ds.attrs().unwrap().get("MATLAB_class"),
+                            Some(&AttrValue::String($class.into())),
+                            "{path}: {name} should carry the component class"
+                        );
+                    }
+
+                    // The cell's elements live under `#refs#`, and each is a
+                    // complex matrix — the one arm `push_complex` reaches that
+                    // no other field here exercises.
+                    let refs = file.group("#refs#").unwrap();
+                    let names = refs.datasets().unwrap();
+                    assert_eq!(names.len(), 2, "{path}: one dataset per cell element");
+                    for name in names {
+                        let ds = refs.dataset(&name).unwrap();
+                        assert_compound_of(&ds.datatype().unwrap(), $size, $signed);
+                        assert_eq!(
+                            ds.attrs().unwrap().get("MATLAB_class"),
+                            Some(&AttrValue::String($class.into())),
+                            "{path}: cell element"
+                        );
+                    }
+                }
+            }
+        )*
+    };
+}
+
+arm_shapes_for! {
+    every_arm_shape_survives_for_int8: ComplexI8, "int8", 1, true;
+    every_arm_shape_survives_for_int16: ComplexI16, "int16", 2, true;
+    every_arm_shape_survives_for_int32: ComplexI32, "int32", 4, true;
+    every_arm_shape_survives_for_int64: ComplexI64, "int64", 8, true;
+    every_arm_shape_survives_for_uint8: ComplexU8, "uint8", 1, false;
+    every_arm_shape_survives_for_uint16: ComplexU16, "uint16", 2, false;
+    every_arm_shape_survives_for_uint32: ComplexU32, "uint32", 4, false;
+    every_arm_shape_survives_for_uint64: ComplexU64, "uint64", 8, false;
+}
+
+// ---------------------------------------------------------------------------
+// Promoting a real value to complex
+// ---------------------------------------------------------------------------
+
+/// A real array of the component class reads as complex with a zero imaginary
+/// part — a file written by something that dropped an all-real capture's
+/// `imag` field still loads into a complex target. This generalized from the
+/// two float classes to all ten, so it is checked at a class that did not
+/// exist on the old path.
+#[test]
+fn a_real_scalar_of_the_same_class_reads_as_complex_with_zero_imag() {
+    #[derive(Serialize)]
+    struct Real {
+        a: i16,
+        b: u64,
+    }
+    #[derive(Deserialize, Debug, PartialEq)]
+    struct Cplx {
+        a: ComplexI16,
+        b: ComplexU64,
+    }
+
+    let bytes = mat::to_bytes(&Real { a: -42, b: 42 }).unwrap();
+    let back: Cplx = mat::from_bytes(&bytes).unwrap();
+    assert_eq!(back.a, ComplexI16::new(-42, 0));
+    assert_eq!(back.b, ComplexU64::new(42, 0));
+}
+
+/// The promotion is class-exact like every other complex read: a real `double`
+/// does not become a complex `int16` just because the imaginary part it is
+/// missing would have been zero.
+#[test]
+fn a_real_scalar_of_another_class_is_not_promoted() {
+    #[derive(Serialize)]
+    struct Real {
+        x: f64,
+    }
+    #[derive(Deserialize, Debug)]
+    struct Cplx {
+        // Never read: the point is that deserializing into it fails.
+        #[allow(dead_code)]
+        x: ComplexI16,
+    }
+
+    let bytes = mat::to_bytes(&Real { x: 42.0 }).unwrap();
+    let err = mat::from_bytes::<Cplx>(&bytes).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("complex int16"),
+        "error should name the class it wanted: {msg}"
+    );
+}

--- a/tests/serde_crosscheck.rs
+++ b/tests/serde_crosscheck.rs
@@ -7,7 +7,7 @@
 //! files we produce are valid HDF5 and follow MATLAB conventions that other
 //! tools (scipy, MATLAB itself) should also accept.
 
-use hdf5_pure::mat::{self, Complex64, Matrix};
+use hdf5_pure::mat::{self, Complex64, ComplexI16, Matrix};
 use serde::{Deserialize, Serialize};
 use tempfile::tempdir;
 
@@ -167,6 +167,56 @@ fn c_library_reads_complex_as_compound() {
         .read_scalar::<hdf5::types::FixedAscii<32>>()
         .unwrap();
     assert_eq!(cls.as_str(), "double");
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct Capture {
+    samples: Vec<ComplexI16>,
+}
+
+/// The C library resolves the compound and its component class independently
+/// of anything this crate believes, so it is the check that the `int16`
+/// complex layout is the one MATLAB will see: two 2-byte signed members at
+/// offsets 0 and 2, and four bytes per sample rather than eight.
+#[test]
+fn c_library_reads_complex_int16_as_a_four_byte_compound() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("capture.mat");
+
+    let c = Capture {
+        samples: vec![
+            ComplexI16::new(i16::MIN, i16::MAX),
+            ComplexI16::new(0, -1),
+            ComplexI16::new(1234, -4321),
+        ],
+    };
+    mat::to_file(&c, &path).unwrap();
+
+    let file = hdf5::File::open(&path).unwrap();
+    let ds = file.dataset("samples").unwrap();
+    assert_eq!(ds.shape(), vec![1, 3]);
+
+    #[repr(C)]
+    #[derive(hdf5::H5Type, Clone, Copy, Debug)]
+    struct Pair {
+        real: i16,
+        imag: i16,
+    }
+    assert_eq!(ds.dtype().unwrap().size(), 4);
+    assert_eq!(ds.storage_size(), 4 * 3);
+
+    let pairs: Vec<Pair> = ds.read_raw().unwrap();
+    assert_eq!(pairs.len(), 3);
+    assert_eq!((pairs[0].real, pairs[0].imag), (i16::MIN, i16::MAX));
+    assert_eq!((pairs[1].real, pairs[1].imag), (0, -1));
+    assert_eq!((pairs[2].real, pairs[2].imag), (1234, -4321));
+
+    // The class names the component, not anything complex-specific.
+    let class_attr = ds.attr("MATLAB_class").unwrap();
+    let cls = class_attr
+        .read_scalar::<hdf5::types::FixedAscii<32>>()
+        .unwrap();
+    assert_eq!(cls.as_str(), "int16");
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]

--- a/tests/serde_matio_crosscheck.rs
+++ b/tests/serde_matio_crosscheck.rs
@@ -46,6 +46,15 @@ mod ffi {
         pub internal: *mut c_void,
     }
 
+    /// A complex variable's data pointer: matio splits the real and imaginary
+    /// planes into two arrays, unlike the interleaved `{real, imag}` compound
+    /// the file stores.
+    #[repr(C)]
+    pub struct mat_complex_split_t {
+        pub Re: *mut c_void,
+        pub Im: *mut c_void,
+    }
+
     // File versions
     pub const MAT_FT_MAT73: c_uint = 0x0200;
 
@@ -80,6 +89,10 @@ mod ffi {
     pub const MAT_T_UINT64: c_int = 13;
 
     pub const MAT_COMPRESSION_NONE: c_int = 0;
+
+    /// `Mat_VarCreate` option flag marking the data as complex; the `data`
+    /// pointer is then a `mat_complex_split_t` rather than a flat array.
+    pub const MAT_F_COMPLEX: c_int = 0x0800;
 
     unsafe extern "C" {
         pub unsafe fn Mat_CreateVer(
@@ -242,6 +255,48 @@ impl MatVar {
             col_major,
         )
     }
+    /// Build a complex variable of `class_type` from split real/imaginary
+    /// planes, the form matio takes complex data in. `dims` are MATLAB dims.
+    fn create_complex<T: Copy>(
+        name: &str,
+        class_type: i32,
+        data_type: i32,
+        dims: &[usize],
+        re: &[T],
+        im: &[T],
+    ) -> Self {
+        assert_eq!(re.len(), im.len());
+        let c = CString::new(name).unwrap();
+        let split = ffi::mat_complex_split_t {
+            Re: re.as_ptr() as *mut c_void,
+            Im: im.as_ptr() as *mut c_void,
+        };
+        let ptr = unsafe {
+            ffi::Mat_VarCreate(
+                c.as_ptr(),
+                class_type,
+                data_type,
+                dims.len() as i32,
+                dims.as_ptr(),
+                std::ptr::from_ref(&split) as *const c_void,
+                ffi::MAT_F_COMPLEX,
+            )
+        };
+        assert!(!ptr.is_null(), "Mat_VarCreate({name}) failed");
+        Self { ptr, owned: true }
+    }
+
+    pub fn complex_i16_row_vec(name: &str, re: &[i16], im: &[i16]) -> Self {
+        Self::create_complex(
+            name,
+            ffi::MAT_C_INT16,
+            ffi::MAT_T_INT16,
+            &[1, re.len()],
+            re,
+            im,
+        )
+    }
+
     pub fn i32_scalar(name: &str, v: i32) -> Self {
         Self::create_numeric(name, ffi::MAT_C_INT32, ffi::MAT_T_INT32, &[1, 1], &[v])
     }
@@ -285,6 +340,17 @@ impl MatVar {
         let n = self.nelements();
         let p = unsafe { (*self.ptr).data } as *const T;
         unsafe { std::slice::from_raw_parts(p, n) }.to_vec()
+    }
+
+    /// Read a complex variable's split real and imaginary planes. `T` must
+    /// match the on-disk component class.
+    pub fn complex_data_as<T: Copy>(&self) -> (Vec<T>, Vec<T>) {
+        assert!(self.is_complex(), "variable is not complex");
+        let n = self.nelements();
+        let split = unsafe { &*((*self.ptr).data as *const ffi::mat_complex_split_t) };
+        let re = unsafe { std::slice::from_raw_parts(split.Re as *const T, n) }.to_vec();
+        let im = unsafe { std::slice::from_raw_parts(split.Im as *const T, n) }.to_vec();
+        (re, im)
     }
 
     pub fn scalar_f64(&self) -> f64 {
@@ -366,7 +432,7 @@ impl Drop for MatVar {
 // Tests
 // =======================================================================
 
-use hdf5_pure::mat::{self, Matrix};
+use hdf5_pure::mat::{self, ComplexI16, Matrix};
 use serde::{Deserialize, Serialize};
 use std::sync::{Mutex, MutexGuard};
 use tempfile::tempdir;
@@ -695,4 +761,124 @@ fn hdf5_pure_reads_row_vector_matrix_from_matio() {
     assert_eq!(parsed.m.rows(), 1);
     assert_eq!(parsed.m.cols(), 4);
     assert_eq!(parsed.m.data(), &[10.0, 20.0, 30.0, 40.0]);
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct Capture {
+    samples: Vec<ComplexI16>,
+}
+
+/// matio reports the complex flag and the element class as two independent
+/// facts, so this is the check that both agree: a complex `int16` array, not
+/// a complex double and not a two-field struct.
+#[test]
+fn matio_reads_complex_int16_from_hdf5_pure() {
+    let _g = matio_lock();
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("capture.mat");
+
+    mat::to_file(
+        &Capture {
+            samples: vec![
+                ComplexI16::new(i16::MIN, i16::MAX),
+                ComplexI16::new(0, -1),
+                ComplexI16::new(1234, -4321),
+            ],
+        },
+        &path,
+    )
+    .unwrap();
+
+    let f = MatFile::open(&path);
+    let v = f.read("samples").unwrap();
+    assert!(v.is_complex(), "matio should see a complex array");
+    assert_eq!(v.class_type(), ffi::MAT_C_INT16);
+    assert_eq!(v.nelements(), 3);
+
+    let (re, im) = v.complex_data_as::<i16>();
+    assert_eq!(re, vec![i16::MIN, 0, 1234]);
+    assert_eq!(im, vec![i16::MAX, -1, -4321]);
+}
+
+/// The other direction, and the one that settles what the layout should be:
+/// `libmatio` — the reference C implementation of the MAT format — writes the
+/// complex `int16` array, and this crate reads it. Nothing about the encoding
+/// is this crate's choice here.
+#[test]
+fn hdf5_pure_reads_complex_int16_written_by_matio() {
+    let _g = matio_lock();
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("matio_capture.mat");
+    {
+        let f = MatFile::create_v73(&path);
+        f.write(MatVar::complex_i16_row_vec(
+            "samples",
+            &[i16::MIN, 0, 1234],
+            &[i16::MAX, -1, -4321],
+        ));
+    }
+
+    // The datatype matio produced is the one this crate writes: a 4-byte
+    // compound, `real` at 0 and `imag` at 2, both 2-byte signed integers.
+    let file = hdf5_pure::File::open(&path).unwrap();
+    let ds = file.dataset("samples").unwrap();
+    match ds.datatype().unwrap() {
+        hdf5_pure::Datatype::Compound { size, members } => {
+            assert_eq!(size, 4);
+            assert_eq!(members[0].name, "real");
+            assert_eq!(members[0].byte_offset, 0);
+            assert_eq!(members[1].name, "imag");
+            assert_eq!(members[1].byte_offset, 2);
+            for m in &members {
+                match m.datatype {
+                    hdf5_pure::Datatype::FixedPoint { size, signed, .. } => {
+                        assert_eq!(size, 2);
+                        assert!(signed);
+                    }
+                    ref other => panic!("expected a fixed-point component, got {other:?}"),
+                }
+            }
+        }
+        other => panic!("expected a compound datatype, got {other:?}"),
+    }
+
+    // And so are the attribute conventions: the class names the component,
+    // and no `MATLAB_int_decode` accompanies a numeric class (matio writes
+    // that one only for `logical` and `char`).
+    let attrs = ds.attrs().unwrap();
+    assert_eq!(
+        attrs.get("MATLAB_class"),
+        Some(&hdf5_pure::AttrValue::String("int16".into()))
+    );
+    assert!(!attrs.contains_key("MATLAB_int_decode"));
+
+    let parsed: Capture = mat::from_file(&path).unwrap();
+    assert_eq!(
+        parsed,
+        Capture {
+            samples: vec![
+                ComplexI16::new(i16::MIN, i16::MAX),
+                ComplexI16::new(0, -1),
+                ComplexI16::new(1234, -4321),
+            ]
+        }
+    );
+
+    // Same MATLAB dims through this crate's builder: the stored shape and the
+    // payload bytes come out identical to matio's, interleaved `(re, im)`
+    // little-endian pairs.
+    let ours = dir.path().join("ours_capture.mat");
+    let mut mb = hdf5_pure::mat::MatBuilder::new(hdf5_pure::mat::Options::default());
+    mb.write_complex_i16(
+        "samples",
+        &[1, 3],
+        &[(i16::MIN, i16::MAX), (0, -1), (1234, -4321)],
+    )
+    .unwrap();
+    std::fs::write(&ours, mb.finish().unwrap()).unwrap();
+
+    let our_ds = hdf5_pure::File::open(&ours).unwrap();
+    let our_ds = our_ds.dataset("samples").unwrap();
+    assert_eq!(our_ds.shape().unwrap(), ds.shape().unwrap());
+    assert_eq!(our_ds.read_u8().unwrap(), ds.read_u8().unwrap());
 }


### PR DESCRIPTION
Capture hardware samples the complex plane as pairs of signed 16-bit integers — the native output width of most ADC and digitizer front ends. This crate could only store those as complex `single`, so every sample became an f32 holding an exactly representable small integer: the file doubled and the extra bytes were zero mantissa by construction. The read path refused the alternative outright, with `complex compound on non-float class`.

The complex surface now covers every numeric component class.

## What's new

- **`mat::ComplexI8`/`I16`/`I32`/`I64` and the `ComplexU*` counterparts** join `Complex64`/`Complex32`: serde newtypes, valid `Matrix<T>` elements, each with its own sentinel so an empty `Matrix<ComplexI16>` still knows its class.
- **`MatBuilder::write_complex_i16`** and its nine siblings, mirrored on `StructWriter` and as `CellWriter::push_complex_*`.
- A complex `int16` array is a 4-byte `{real, imag}` compound with `MATLAB_class = "int16"` — four bytes per sample instead of eight, and the file still says what it holds. Shape handling, the row/column distinction, empty-array semantics, and deflate carry over from the float path unchanged.

Additive only. The manifest stays at 0.27.0, already declared for the breaking #198 work this cycle.

## No silent widening, in either direction

An `int16` dataset deserializes into `ComplexI16` and nothing else. Reading it as `Complex64` would be lossless and is still refused: the component width is part of what the file says it holds, and a Rust type that quietly disagrees is a worse witness than an error. The truncating direction is refused for the same reason. No narrowing helper ships with this — a caller holding float data it knows to be exact integers is the one that can judge whether narrowing is meaningful.

The same rule is now enforced against the file itself, which is the part this PR originally got wrong (see below): `MATLAB_class` names the component width, the compound carries the bytes, and a file where the two disagree is refused rather than decoded.

## Parameterized, not enumerated

`ComplexTag`/`ComplexNum`/`ComplexVec` mirror the `ScalarTag`/`ScalarNum`/`NumVec` the real numeric path already uses, and the six width-specific `MatValue` variants collapse into `ComplexScalar`/`ComplexVec1D`/`ComplexMatrix`. Ten classes across seven dispatch sites would otherwise be seventy arms kept in step by hand; each site is now one macro over one list, and every list is a non-exhaustive match that fails to compile until a new class is added to it. Keeping the class in a tag rather than in the variant name is also what lets an empty complex array still know what it is — the pairs are gone, the tag is not.

`MatValue` and the tag types are `pub(crate)` and unexported, so the variant collapse is not a public break; the existing `with_complex32_data`/`with_complex64_data` and `write_complex_f64`/`f32` keep their signatures.

`ser::transpose` moves up to `mat::transpose`, since the value model needs it too.

## A regression this PR introduced, found in review and fixed

The refactor deleted the `_ => Err("complex compound on non-float class")` arm and put nothing in its place. That arm had covered all eight integer classes, so for one commit a file claiming `int16` over a pair of `f64` members stopped erroring and started decoding the low halves of the real components into samples:

```
main:          Err("complex compound on non-float class")
2bd3ae3:       Ok([ComplexI16 { re: 0, im: 0 }, ComplexI16 { re: 0, im: 16368 }])
aba51c2:       Err(... stores its real component as f64, which is a different class than MATLAB_class claims)
```

`read_complex` took the component width from the class attribute and never looked at the datatype the caller already held; `parse_complex_pairs` only rejects a payload *shorter* than the class implies, so every narrower-claim-over-wider-members combination passed silently. The disagreement is reachable without a malformed attribute at all: `class_from_dtype` guesses `Double` for a compound, so a complex `int64` array carrying no `MATLAB_class` has the identical 16-byte element size and cannot be told apart by length.

`validate_complex_dtype` now checks the compound against the resolved class before any byte is decoded, through a mapping that is exhaustive with no fallback arm — the `_ => Double` guess is right for naming a class and wrong for slicing raw bytes. It also pins the field order: `is_complex_dtype` accepts `real` and `imag` either way round while the parser reads offset 0 as real unconditionally, so a `{imag, real}` compound used to read back swapped.

## Pre-existing defects fixed

All in the **float** path, all predating this work:

- A one-element complex array reads back as a complex *scalar*, which did not satisfy a `Vec<Complex64>` target — even though the numeric path has made exactly that allowance for a one-element numeric array since it was written.
- The empty-complex read gate was `Double | Single`, so an empty integer complex array came back as an untyped empty vector rather than an empty complex array of its class.
- A 1-D complex array written through `to_bytes_with_options` was **always a MATLAB row vector**: the complex call sites passed a literal `[1, N]` where the numeric ones ask `vector_dims` for the configured `OneDimensionalMode`. A `Vec<Complex64>` came out a row while the `Vec<f64>` beside it came out a column, the option moved one and not the other, and neither matched the column the default `to_bytes` path gives both. Measured before fixing, for a 3-element field pair: `to_bytes` gave reals `[1, 3]` / complex `[1, 3]`; `to_bytes_with_options` at the same orientation gave reals `[1, 3]` / complex `[3, 1]`. **This changes on-disk output for existing `Complex64`/`Complex32` users of the options path** — their complex vectors become columns, agreeing with every other vector in the file. It is listed under `Changed` in the changelog, not only `Fixed`.

## What MATLAB expects, settled rather than asserted

matio's `mat73.c` builds the complex type as a compound of `2 * H5Tget_size(base)` with `real` at 0 and `imag` at the component width, using the class's own type; writes the plain class name to `MATLAB_class`; and emits `MATLAB_int_decode` only for `logical` and `char`, never for a numeric class. All three have tests behind them now:

- **libmatio reads ours** — `is_complex` set, class `int16`, values element for element.
- **We read libmatio's** — its datatype is the same 4-byte compound, its class attribute is `int16`, and it carries no `MATLAB_int_decode`.
- **The bytes match** — the same values through both writers give identical stored shape and identical payload bytes.

`hdf5-metno` covers the compound layout independently. `matlab_fixtures` gains an `int16` complex variable with `isa` / `iscomplex` / `isequal` assertions so a MATLAB or Octave session confirms the last mile; CI still skips `matio-crosscheck` by design.

One consumer-side caveat, now documented: MATLAB stores and loads complex integers but refuses *arithmetic* on them (`Complex integer arithmetic is not supported`) until the caller casts. That costs nothing for a capture format stored compactly and widened at the point of use, but it would surprise someone expecting to do math in place.

## Tests

30 new tests (25 in `tests/complex_integer.rs`, 3 across the two C crosschecks, 2 unit), each checked by breaking the code under it. The one worth naming: **swapping the `real` and `imag` members of the compound is invisible to every round-trip test in the suite** — this crate's reader takes the raw bytes and never consults member names or offsets. Only the layout assertions and the two C crosschecks catch it, which is exactly the defect that reads back fine here and is refused by MATLAB.

The full `--features serde` suite is green against the final tree, alongside `fmt --check` and `clippy --all-targets -D warnings`. The `--all-features` run (95 binaries, 1630 tests) was green as of the feature commit; CI covers it, along with `--no-default-features` and the rustdoc gate, for the fixes on top.

## Coverage gaps review found, since closed

Two places where the generalization from two component classes to ten outran its tests:

- **`ComplexNum::from_real`** — a real array of the component class reading back as complex with a zero imaginary part — was reached by no committed test. Breaking it to return `None` unconditionally left 697 tests green across the library, the round trips, the builder, the cell arrays and the options path. Now covered at two classes, plus the refusal that keeps the promotion class-exact.
- **End-to-end arm coverage stopped at `int16`.** A complex value reaches the writer through five distinct arms — scalar, 1-D vector, 2-D matrix, a matrix built from equal-length rows, and a cell element. `arm_shapes_for!` now runs all five for all eight integer classes and pins each one's stored compound and class attribute.

Writing the second found a third gap it had to close first: `to_bytes` and `to_bytes_with_options` are separate emit paths with their own copy of every arm, which is exactly why the orientation defect could live in one and not the other. A version of the test using only `to_bytes` did not notice the cell-element matrix transpose being deleted. Each arm now runs through both paths, and nothing in the pre-existing suite catches that mutation either way.

## Known divergence

- **Empty complex arrays do not follow `EmptyMarkerEncoding`.** They are written as a zero-element compound that keeps its component class and round-trips here; MATLAB's `Mat_VarWriteEmpty` instead stores the dims as data under `MATLAB_empty = 1` with the plain class name, and libmatio reads both. The option moves real arrays and not complex ones. Documented in `docs/interop/matlab.md` rather than changed, since it alters written output; pre-existing for `Complex64`/`Complex32`.
- The C crosschecks cover `int16` of the ten classes. All ten were run through libmatio by hand during review with the correct class, complex flag, and component size; extending the committed crosscheck to the other nine is a loop over a table.

## Note

There is no issue for this request, so the changelog entries carry no `([#NN](url))` link, against the usual convention. Happy to file one and add the reference.
