### PR TITLE
Store chunks back to back rather than padded to the host's cache line (#227)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,16 +303,27 @@ jobs:
           key: miri
       - name: Miri test (mat::transpose unsafe)
         # `--no-default-features --features std,serde` keeps the interpreted
-        # build minimal: `serde` is what gates the `mat` module, and the
-        # transpose tests are pure in-memory, so there is no need to compile the
-        # `deflate` (flate2/miniz_oxide) or `checksum` code that Miri never
-        # executes. Smaller, more deterministic surface.
+        # build minimal: `std` gates the `mat` module and `serde` gates
+        # `transpose` within it, and the transpose tests are pure in-memory, so
+        # there is no need to compile the `deflate` (flate2/miniz_oxide) or
+        # `checksum` code that Miri never executes.
         #
-        # A filter that matches nothing makes libtest exit 0, which is how this
-        # job came to guard a module holding no unsafe at all. Fail loudly on an
-        # empty run so a rename cannot quietly hollow the gate out again.
+        # Two ways this gate can go hollow, both of which have to fail loudly:
+        #
+        #   1. The filter stops matching. libtest exits 0 when a filter selects
+        #      nothing, so a rename would leave the job green having interpreted
+        #      nothing at all.
+        #   2. The unsafe leaves the module while the tests stay. This is what
+        #      actually happened before: #113 deleted the unsafe from
+        #      `chunk_cache`, the job kept running that module's 11 safe tests,
+        #      and it stayed green and vacuous for many releases. A count check
+        #      alone would not have caught it.
         run: |
           set -o pipefail
+          if ! grep -q 'unsafe' src/mat/transpose.rs; then
+            echo "::error::src/mat/transpose.rs holds no unsafe; point this job at the code that does."
+            exit 1
+          fi
           cargo miri test --locked --no-default-features --features std,serde \
             --lib mat::transpose 2>&1 | tee miri.log
           if grep -q "running 0 tests" miri.log; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,11 +281,16 @@ jobs:
   # Undefined-behavior sanitizing with Miri (issue #26).
   #
   # The library is almost entirely safe Rust. The one piece of non-trivial
-  # unsafe reachable from a `std` build is `mat::transpose`, which writes a
-  # tiled transpose through a raw pointer into uninitialized `Vec` capacity and
-  # then calls `set_len`. Miri interprets those writes under Stacked Borrows +
-  # strict provenance, catching the out-of-bounds or partially-initialized cases
-  # a normal test run cannot observe.
+  # unsafe reachable from a `std + serde` build is `mat::transpose`, which
+  # writes a tiled transpose through a raw pointer into uninitialized `Vec`
+  # capacity and then calls `set_len`. Miri interprets those writes under
+  # Stacked Borrows + strict provenance, catching the out-of-bounds or
+  # partially-initialized cases a normal test run cannot observe.
+  #
+  # `serde` is not a default feature, so the default feature set compiles no
+  # non-trivial unsafe at all; `no_std` swaps this module out for `nosync`
+  # rather than adding to it. Both are why this job names its features
+  # explicitly instead of relying on the defaults.
   #
   # Scoped to that module's unit tests on purpose: most other tests touch the
   # filesystem and the crosscheck tests call into the libhdf5 C library, neither
@@ -302,32 +307,41 @@ jobs:
         with:
           key: miri
       - name: Miri test (mat::transpose unsafe)
-        # `--no-default-features --features std,serde` keeps the interpreted
-        # build minimal: `std` gates the `mat` module and `serde` gates
-        # `transpose` within it, and the transpose tests are pure in-memory, so
-        # there is no need to compile the `deflate` (flate2/miniz_oxide) or
-        # `checksum` code that Miri never executes.
+        # `--no-default-features --features std,serde` selects the smallest set
+        # that compiles the code under test: `std` gates the `mat` module and
+        # `serde` gates `transpose` within it. Dropping `deflate` also drops
+        # compiling flate2/miniz_oxide, which Miri would never execute.
         #
-        # Two ways this gate can go hollow, both of which have to fail loudly:
+        # Three ways this gate can go hollow, each of which has to fail loudly.
+        # None is hypothetical: mode 2 is what actually happened here.
         #
         #   1. The filter stops matching. libtest exits 0 when a filter selects
         #      nothing, so a rename would leave the job green having interpreted
         #      nothing at all.
-        #   2. The unsafe leaves the module while the tests stay. This is what
-        #      actually happened before: #113 deleted the unsafe from
-        #      `chunk_cache`, the job kept running that module's 11 safe tests,
-        #      and it stayed green and vacuous for many releases. A count check
-        #      alone would not have caught it.
+        #   2. The unsafe leaves the module while the tests stay. #113 deleted
+        #      the unsafe from `chunk_cache`, the job kept running that module's
+        #      11 safe tests, and it stayed green and vacuous for many releases.
+        #      A count check alone would not have caught it, which is why the
+        #      guard below greps for unsafe in *code* position -- a bare word
+        #      match would also be satisfied by a leftover SAFETY comment.
+        #   3. The tests are selected but never run (`#[ignore]`, or a refactor
+        #      that stops them calling the transpose). "running 7 tests ...
+        #      7 ignored" passes both of the checks above, so the pass count
+        #      itself has to be asserted nonzero.
         run: |
           set -o pipefail
-          if ! grep -q 'unsafe' src/mat/transpose.rs; then
-            echo "::error::src/mat/transpose.rs holds no unsafe; point this job at the code that does."
+          if ! grep -qE '^[^/]*\bunsafe[[:space:]]*(\{|fn |impl )' src/mat/transpose.rs; then
+            echo "::error::src/mat/transpose.rs holds no unsafe code; point this job at the code that does."
             exit 1
           fi
           cargo miri test --locked --no-default-features --features std,serde \
             --lib mat::transpose 2>&1 | tee miri.log
           if grep -q "running 0 tests" miri.log; then
             echo "::error::Miri ran no tests: the --lib filter matched nothing."
+            exit 1
+          fi
+          if ! grep -qE '[1-9][0-9]* passed' miri.log; then
+            echo "::error::Miri passed no tests: they were selected but ignored or skipped."
             exit 1
           fi
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,19 +280,18 @@ jobs:
   # ===========================================================================
   # Undefined-behavior sanitizing with Miri (issue #26).
   #
-  # The library is almost entirely safe Rust; the unsafe that exists is the
-  # cache-line-aligned chunk buffer in `chunk_cache` (manual global-allocator
-  # `alloc_zeroed`/`dealloc`, `slice::from_raw_parts[_mut]`, and `unsafe impl
-  # Send`/`Sync` for `CacheAlignedBuffer`). Miri interprets that allocation and
-  # the surrounding pointer arithmetic under Stacked Borrows + strict provenance,
-  # catching aliasing / out-of-bounds / leak UB that the normal test run cannot
-  # observe.
+  # The library is almost entirely safe Rust. The one piece of non-trivial
+  # unsafe reachable from a `std` build is `mat::transpose`, which writes a
+  # tiled transpose through a raw pointer into uninitialized `Vec` capacity and
+  # then calls `set_len`. Miri interprets those writes under Stacked Borrows +
+  # strict provenance, catching the out-of-bounds or partially-initialized cases
+  # a normal test run cannot observe.
   #
-  # Scoped to the `chunk_cache` unit tests on purpose: most other tests touch the
+  # Scoped to that module's unit tests on purpose: most other tests touch the
   # filesystem and the crosscheck tests call into the libhdf5 C library, neither
-  # of which Miri can execute. Widen the `--lib` test filter as more
-  # pure-in-memory unsafe lands (the single-threaded `nosync::Mutex` is the next
-  # candidate, once the crate's no_std unit-test harness compiles).
+  # of which Miri can execute. Widen the `--lib` filter as more pure-in-memory
+  # unsafe lands (the single-threaded `nosync::Mutex` is the next candidate,
+  # once the crate's no_std unit-test harness compiles).
   miri:
     name: Miri (undefined behavior)
     runs-on: ubuntu-latest
@@ -302,11 +301,23 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: miri
-      - name: Miri test (chunk_cache unsafe)
-        # `--no-default-features --features std` keeps the interpreted build
-        # minimal: the `chunk_cache` tests are pure in-memory, so there is no
-        # need to compile the `deflate` (flate2/miniz_oxide) or `checksum` code
-        # that Miri never executes. Smaller, more deterministic surface.
-        run: cargo miri test --locked --no-default-features --features std --lib chunk_cache
+      - name: Miri test (mat::transpose unsafe)
+        # `--no-default-features --features std,serde` keeps the interpreted
+        # build minimal: `serde` is what gates the `mat` module, and the
+        # transpose tests are pure in-memory, so there is no need to compile the
+        # `deflate` (flate2/miniz_oxide) or `checksum` code that Miri never
+        # executes. Smaller, more deterministic surface.
+        #
+        # A filter that matches nothing makes libtest exit 0, which is how this
+        # job came to guard a module holding no unsafe at all. Fail loudly on an
+        # empty run so a rename cannot quietly hollow the gate out again.
+        run: |
+          set -o pipefail
+          cargo miri test --locked --no-default-features --features std,serde \
+            --lib mat::transpose 2>&1 | tee miri.log
+          if grep -q "running 0 tests" miri.log; then
+            echo "::error::Miri ran no tests: the --lib filter matched nothing."
+            exit 1
+          fi
         env:
           MIRIFLAGS: -Zmiri-strict-provenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - **Breaking:** `FormatError::DenseAttributeHeapTooLarge` now carries only `limit`, and bounds the heap's 40-bit address space rather than a single 2 GiB direct block ([#195](https://github.com/stephenberry/hdf5-pure/issues/195)).
 - Every dense attribute set has different bytes: its name index is a tree of 512-byte nodes, and its attributes sit in a doubling table whose blocks start at 1 KiB and grow by adding blocks rather than by rounding one up to a power of two. Files written by earlier versions still read ([#195](https://github.com/stephenberry/hdf5-pure/issues/195)).
 - `mat::to_file` and `mat::to_file_with_options` stream to disk rather than building the whole file in memory first. Same bytes ([#226](https://github.com/stephenberry/hdf5-pure/pull/226)).
+- Chunks are written back to back instead of padded to the host's cache line, so a chunked dataset no longer occupies more space on `aarch64` than on `x86_64` and a given input produces the same bytes on every target. Files written by earlier versions still read ([#227](https://github.com/stephenberry/hdf5-pure/issues/227)).
 
 ## [0.28.0] - 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - **Breaking:** `FormatError::DenseAttributeHeapTooLarge` now carries only `limit`, and bounds the heap's 40-bit address space rather than a single 2 GiB direct block ([#195](https://github.com/stephenberry/hdf5-pure/issues/195)).
 - Every dense attribute set has different bytes: its name index is a tree of 512-byte nodes, and its attributes sit in a doubling table whose blocks start at 1 KiB and grow by adding blocks rather than by rounding one up to a power of two. Files written by earlier versions still read ([#195](https://github.com/stephenberry/hdf5-pure/issues/195)).
 - `mat::to_file` and `mat::to_file_with_options` stream to disk rather than building the whole file in memory first. Same bytes ([#226](https://github.com/stephenberry/hdf5-pure/pull/226)).
-- Chunks are written back to back instead of padded to the host's cache line, so a chunked dataset no longer occupies more space on `aarch64` than on `x86_64` and a given input produces the same bytes on every target. Files written by earlier versions still read ([#227](https://github.com/stephenberry/hdf5-pure/issues/227)).
+- Chunks are written back to back instead of padded to the host's cache line, so a chunked dataset no longer occupies more space on `aarch64` than on `x86_64`, and chunk placement no longer varies by target. Files written by earlier versions still read ([#227](https://github.com/stephenberry/hdf5-pure/issues/227)).
 
 ### Fixed
 
-- `Matrix::from_row_major` now panics when `rows * cols` overflows `usize` instead of accepting a shape whose wrapped product matched a short data vector, which let the MATLAB writer's transpose write past its allocation. The serde path refuses the same shape with an error ([#227](https://github.com/stephenberry/hdf5-pure/issues/227)).
+- A MATLAB matrix shape whose `rows * cols` wraps `usize` is refused everywhere it can enter: `Matrix::from_row_major` and `Matrix::zeros` panic, while the serde and file-reading paths return an error. Previously the wrapped product could match a short data vector, and the writer's transpose then wrote past its allocation ([#230](https://github.com/stephenberry/hdf5-pure/pull/230)).
 
 ## [0.28.0] - 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `mat::to_file` and `mat::to_file_with_options` stream to disk rather than building the whole file in memory first. Same bytes ([#226](https://github.com/stephenberry/hdf5-pure/pull/226)).
 - Chunks are written back to back instead of padded to the host's cache line, so a chunked dataset no longer occupies more space on `aarch64` than on `x86_64` and a given input produces the same bytes on every target. Files written by earlier versions still read ([#227](https://github.com/stephenberry/hdf5-pure/issues/227)).
 
+### Fixed
+
+- `Matrix::from_row_major` now panics when `rows * cols` overflows `usize` instead of accepting a shape whose wrapped product matched a short data vector, which let the MATLAB writer's transpose write past its allocation. The serde path refuses the same shape with an error ([#227](https://github.com/stephenberry/hdf5-pure/issues/227)).
+
 ## [0.28.0] - 2026-07-28
 
 `File::open_rw` picks its own backing. A latest-format file with no userblock is edited in bounded memory rather than through a whole-file mirror, and the mirror is now the fallback for the files the bounded engine cannot edit rather than the default for everything. Nothing about a file's space strategy decides which open a caller reaches for any more, so `File::open_rw_bounded` is deprecated: it survives only as the strict default, now expressible as `MemoryStrategy::Bounded` on `FileAccessProperties`, and `File::edit_backing` reports which backend an open actually resolved to. Two guarantees that used to be silently ignored are refused before any work happens: the SWMR writer will not accept a `Bounded` it cannot honor, and `File::create_with_options` checks a creation/access pair up front rather than leaving a file on disk and returning the reopen's error.

--- a/docs/about/architecture.md
+++ b/docs/about/architecture.md
@@ -93,9 +93,9 @@ that is correct down to the bytes, or it produces no file and tells you why.
 
 ## Safety and robustness
 
-- **Almost entirely safe Rust.** The only non-trivial `unsafe` is the
-  cache-line-aligned chunk buffer in the chunk cache, which is exercised under
-  [Miri](https://github.com/rust-lang/miri) with strict provenance in CI.
+- **Almost entirely safe Rust.** The only non-trivial `unsafe` is the tiled
+  row-major/column-major transpose used by the MATLAB writer, which is exercised
+  under [Miri](https://github.com/rust-lang/miri) with strict provenance in CI.
 - **32-bit safe.** Every file-derived offset and length is narrowed through
   checked conversions, so a 64-bit value that does not fit a 32-bit `usize`
   errors instead of truncating. CI runs the suite on `i686` under QEMU and

--- a/docs/about/architecture.md
+++ b/docs/about/architecture.md
@@ -93,9 +93,11 @@ that is correct down to the bytes, or it produces no file and tells you why.
 
 ## Safety and robustness
 
-- **Almost entirely safe Rust.** The only non-trivial `unsafe` is the tiled
-  row-major/column-major transpose used by the MATLAB writer, which is exercised
-  under [Miri](https://github.com/rust-lang/miri) with strict provenance in CI.
+- **Almost entirely safe Rust.** In a `std` build the only non-trivial `unsafe`
+  is the tiled row-major/column-major transpose used by the MATLAB writer, which
+  is exercised under [Miri](https://github.com/rust-lang/miri) with strict
+  provenance in CI. A `no_std` build adds the single-threaded `Mutex`
+  replacement, whose `Send`/`Sync` rest on the target being single-threaded.
 - **32-bit safe.** Every file-derived offset and length is narrowed through
   checked conversions, so a 64-bit value that does not fit a 32-bit `usize`
   errors instead of truncating. CI runs the suite on `i686` under QEMU and

--- a/docs/about/architecture.md
+++ b/docs/about/architecture.md
@@ -93,11 +93,13 @@ that is correct down to the bytes, or it produces no file and tells you why.
 
 ## Safety and robustness
 
-- **Almost entirely safe Rust.** In a `std` build the only non-trivial `unsafe`
-  is the tiled row-major/column-major transpose used by the MATLAB writer, which
-  is exercised under [Miri](https://github.com/rust-lang/miri) with strict
-  provenance in CI. A `no_std` build adds the single-threaded `Mutex`
-  replacement, whose `Send`/`Sync` rest on the target being single-threaded.
+- **Almost entirely safe Rust.** The default feature set contains no non-trivial
+  `unsafe`. Adding `serde` compiles the tiled row-major/column-major transpose
+  used by the MATLAB writer, which is exercised under
+  [Miri](https://github.com/rust-lang/miri) with strict provenance in CI.
+  A `no_std` build has neither, and compiles a single-threaded `Mutex`
+  replacement instead, whose `Send`/`Sync` rest on the target being
+  single-threaded.
 - **32-bit safe.** Every file-derived offset and length is narrowed through
   checked conversions, so a 64-bit value that does not fit a 32-bit `usize`
   errors instead of truncating. CI runs the suite on `i686` under QEMU and

--- a/docs/interop/portability.md
+++ b/docs/interop/portability.md
@@ -116,6 +116,16 @@ discipline backs the optional [ZFP filter](../guide/compression.md)
 `.mat` path. For the cross-tool story in depth, see the
 [MATLAB interop page](matlab.md).
 
+### Host-independent output
+
+The bytes a write produces are a function of the data and the options alone.
+Nothing about the machine doing the writing — its architecture, pointer width,
+or cache-line size — reaches the file, so the same input yields the same file on
+every target, and a file does not grow when written on one platform rather than
+another. Chunks in particular are stored back to back; if your workload wants
+cache-line-aligned buffers, align the destination memory you read into rather
+than looking for it in the file.
+
 ### 32-bit safety
 
 The same crosscheck discipline extends to 32-bit hosts. Every offset and length
@@ -128,6 +138,7 @@ with `File::open_streaming` (see [streaming](../guide/streaming.md)) instead of
 ### Memory safety
 
 The crate is almost entirely safe Rust. The only non-trivial `unsafe` is the
-cache-line-aligned chunk buffer in the chunk cache, and it is exercised under
-Miri with strict provenance in CI. The [architecture page](../about/architecture.md)
-covers the safety and robustness guarantees in more detail.
+tiled row-major/column-major transpose used by the MATLAB writer, and it is
+exercised under Miri with strict provenance in CI. The
+[architecture page](../about/architecture.md) covers the safety and robustness
+guarantees in more detail.

--- a/docs/interop/portability.md
+++ b/docs/interop/portability.md
@@ -125,12 +125,18 @@ platform that wrote it. Chunks in particular are stored back to back, with no
 alignment padding; a workload that needs cache-line-aligned data should align
 its own buffers, since the file carries no padding to inherit.
 
-This is a claim about the *host*, not a general determinism guarantee. Output
-still depends on the order the data is handed over: serializing a `.mat` from a
-`HashMap` writes its fields in that map's iteration order, which the standard
-library randomizes per map, so two equal `HashMap`s can produce different files
-on one machine in one run. Use a `BTreeMap`, or a struct, when the field order
-has to be stable.
+This is a claim about the *host*, and it holds at a fixed feature set. Two
+things sit outside it:
+
+- Output depends on the order the data is handed over. Serializing a `.mat`
+  from a `HashMap` writes its fields in that map's iteration order, which the
+  standard library randomizes per map, so two equal `HashMap`s can produce
+  different files on one machine in one run. Use a `BTreeMap`, or a struct,
+  when the field order has to be stable.
+- The `fast-deflate` feature swaps the Rust deflate backend for zlib-ng, which
+  dispatches on runtime CPU features. Compressed bytes are then a property of
+  the machine after all. The default `deflate` backend is pure Rust and does
+  not have this behavior.
 
 ### 32-bit safety
 
@@ -143,10 +149,17 @@ with `File::open_streaming` (see [streaming](../guide/streaming.md)) instead of
 
 ### Memory safety
 
-The crate is almost entirely safe Rust. In a `std` build the only non-trivial
-`unsafe` is the tiled row-major/column-major transpose used by the MATLAB
-writer, and it is exercised under Miri with strict provenance in CI. A
-`no_std` build adds one more: the single-threaded `Mutex` above, whose
-`Send`/`Sync` rest on the target being single-threaded rather than on a lock.
+The crate is almost entirely safe Rust, and the default feature set contains no
+non-trivial `unsafe` at all. Two features introduce some, and they are mutually
+exclusive rather than cumulative:
+
+- `std` + `serde` compiles the tiled row-major/column-major transpose used by
+  the MATLAB writer, which writes through a raw pointer into uninitialized
+  `Vec` capacity. It is exercised under Miri with strict provenance in CI.
+- A `no_std` build instead compiles a single-threaded `Mutex` replacement whose
+  `Send`/`Sync` rest on the target being single-threaded rather than on a lock.
+  Because `no_std` excludes the `mat` module entirely, this replaces the
+  transpose rather than adding to it.
+
 The [architecture page](../about/architecture.md) covers the safety and
 robustness guarantees in more detail.

--- a/docs/interop/portability.md
+++ b/docs/interop/portability.md
@@ -118,13 +118,19 @@ discipline backs the optional [ZFP filter](../guide/compression.md)
 
 ### Host-independent output
 
-The bytes a write produces are a function of the data and the options alone.
-Nothing about the machine doing the writing — its architecture, pointer width,
-or cache-line size — reaches the file, so the same input yields the same file on
-every target, and a file does not grow when written on one platform rather than
-another. Chunks in particular are stored back to back; if your workload wants
-cache-line-aligned buffers, align the destination memory you read into rather
-than looking for it in the file.
+No property of the machine doing the writing — its architecture, pointer width,
+or cache-line size — reaches the file. The same input written on `aarch64` and
+on `x86_64` produces the same bytes, and a file does not grow because of the
+platform that wrote it. Chunks in particular are stored back to back, with no
+alignment padding; a workload that needs cache-line-aligned data should align
+its own buffers, since the file carries no padding to inherit.
+
+This is a claim about the *host*, not a general determinism guarantee. Output
+still depends on the order the data is handed over: serializing a `.mat` from a
+`HashMap` writes its fields in that map's iteration order, which the standard
+library randomizes per map, so two equal `HashMap`s can produce different files
+on one machine in one run. Use a `BTreeMap`, or a struct, when the field order
+has to be stable.
 
 ### 32-bit safety
 
@@ -137,8 +143,10 @@ with `File::open_streaming` (see [streaming](../guide/streaming.md)) instead of
 
 ### Memory safety
 
-The crate is almost entirely safe Rust. The only non-trivial `unsafe` is the
-tiled row-major/column-major transpose used by the MATLAB writer, and it is
-exercised under Miri with strict provenance in CI. The
-[architecture page](../about/architecture.md) covers the safety and robustness
-guarantees in more detail.
+The crate is almost entirely safe Rust. In a `std` build the only non-trivial
+`unsafe` is the tiled row-major/column-major transpose used by the MATLAB
+writer, and it is exercised under Miri with strict provenance in CI. A
+`no_std` build adds one more: the single-threaded `Mutex` above, whose
+`Send`/`Sync` rest on the target being single-threaded rather than on a lock.
+The [architecture page](../about/architecture.md) covers the safety and
+robustness guarantees in more detail.

--- a/src/chunk_cache.rs
+++ b/src/chunk_cache.rs
@@ -23,30 +23,6 @@ use std::collections::HashMap;
 
 use crate::chunked_read::ChunkInfo;
 
-// ---------------------------------------------------------------------------
-// Cache-line alignment
-// ---------------------------------------------------------------------------
-
-/// Cache line size in bytes for the target architecture.
-///
-/// ARM64 uses 128-byte cache lines; x86_64 uses 64-byte. The writer aligns
-/// chunk data blocks to this boundary on disk so a chunk read lands on a
-/// cache-line-aligned file offset.
-#[cfg(target_arch = "aarch64")]
-pub const CACHE_LINE_SIZE: usize = 128;
-
-#[cfg(target_arch = "x86_64")]
-pub const CACHE_LINE_SIZE: usize = 64;
-
-#[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
-pub const CACHE_LINE_SIZE: usize = 64;
-
-/// Round `size` up to the next multiple of [`CACHE_LINE_SIZE`].
-#[inline]
-pub fn align_to_cache_line(size: usize) -> usize {
-    (size + CACHE_LINE_SIZE - 1) & !(CACHE_LINE_SIZE - 1)
-}
-
 /// Coordinate key for a chunk — the N-dimensional offset vector.
 pub type ChunkCoord = Vec<u64>;
 
@@ -571,16 +547,5 @@ mod tests {
         cache.put_decompressed(vec![0], vec![1, 2, 3]); // duplicate
         assert_eq!(cache.stats().cached_chunks(), 1);
         assert_eq!(cache.stats().cached_bytes(), 3);
-    }
-
-    #[test]
-    fn align_to_cache_line_values() {
-        assert_eq!(align_to_cache_line(0), 0);
-        assert_eq!(align_to_cache_line(1), CACHE_LINE_SIZE);
-        assert_eq!(align_to_cache_line(CACHE_LINE_SIZE), CACHE_LINE_SIZE);
-        assert_eq!(
-            align_to_cache_line(CACHE_LINE_SIZE + 1),
-            CACHE_LINE_SIZE * 2
-        );
     }
 }

--- a/src/chunked_write.rs
+++ b/src/chunked_write.rs
@@ -1555,6 +1555,9 @@ pub(crate) fn assemble_chunked_at(
             has_filters,
             ea_address,
         )?;
+        // The chunk loop filled `data_buf` to exactly its reserved capacity, so
+        // extending would otherwise double the whole buffer and copy it.
+        data_buf.reserve_exact(ea_bytes.len());
         data_buf.extend_from_slice(&ea_bytes);
 
         serialize_v4_extensible_array(chunk_dims_u32, ea_address, offset_size, element_size as u32)
@@ -1584,6 +1587,8 @@ pub(crate) fn assemble_chunked_at(
             has_filters,
             fa_address,
         );
+        // As above: reserve the index exactly rather than let the buffer double.
+        data_buf.reserve_exact(fa_bytes.len());
         data_buf.extend_from_slice(&fa_bytes);
 
         serialize_v4_fixed_array(
@@ -2071,10 +2076,10 @@ mod tests {
         assert_eq!(result, values);
     }
 
-    /// Chunks are stored back to back, with no padding between them. The chunk
-    /// size here (7 f64 = 56 bytes) is deliberately not a multiple of any cache
-    /// line, so any alignment padding would push the second and third chunks off
-    /// the concatenation this asserts.
+    /// Chunks are stored back to back, and the index begins where the last
+    /// chunk ends. The chunk size here (7 f64 = 56 bytes) is deliberately not a
+    /// multiple of any cache line, so padding at *either* site — between chunks
+    /// or before the index — would move bytes this pins.
     #[test]
     fn chunks_are_stored_back_to_back() {
         let values: Vec<f64> = (0..21).map(|i| i as f64).collect();
@@ -2088,11 +2093,19 @@ mod tests {
         let result = build_chunked_data_at_ext(&raw, &[21], ctx, &options, 0x1000, None).unwrap();
 
         // Unfiltered chunks are stored verbatim, so the data region opens with
-        // the raw bytes in order and the index follows immediately after.
+        // the raw bytes in order.
         assert_eq!(
             &result.data_bytes[..raw.len()],
             &raw[..],
             "the three chunks must concatenate with nothing between them"
+        );
+        // And the Fixed Array header starts in the very next byte. Asserting the
+        // signature's position, rather than only the chunk prefix, is what keeps
+        // padding from creeping back in ahead of the index.
+        assert_eq!(
+            &result.data_bytes[raw.len()..raw.len() + 4],
+            b"FAHD",
+            "the chunk index must begin where the last chunk ends"
         );
     }
 
@@ -2123,6 +2136,17 @@ mod tests {
             .map(|s| s.compressed_size)
             .collect();
         assert_eq!(planned, vec![37, 111, 5]);
+    }
+
+    /// A chunk-less plan has no first chunk to anchor the index against, so it
+    /// is refused rather than planned as an empty region.
+    #[test]
+    fn a_verbatim_plan_with_no_chunks_is_refused() {
+        let result = plan_chunked_data_verbatim(&[], &[7], 8, 56, None, 0x1000, None);
+        assert!(
+            matches!(result, Err(FormatError::ChunkedReadError(_))),
+            "a chunk-less plan must be refused"
+        );
     }
 
     #[test]

--- a/src/chunked_write.rs
+++ b/src/chunked_write.rs
@@ -7,7 +7,6 @@ extern crate alloc;
 use alloc::{vec, vec::Vec};
 
 use crate::checksum::jenkins_lookup3;
-use crate::chunk_cache::{CACHE_LINE_SIZE, align_to_cache_line};
 use crate::convert::TryToUsize;
 use crate::error::FormatError;
 use crate::extensible_array::{EaGeometry, ExtensibleArrayHeader};
@@ -1500,10 +1499,10 @@ pub(crate) fn compress_chunks(
 }
 
 /// Lay an already-[`compress`ed](compress_chunks) chunk set out at `base_address`,
-/// producing the on-disk data region (chunk bytes + cache-line padding + chunk
-/// index) and the v4 data-layout message. Cheap: this only concatenates and
-/// builds the index, so it can be run more than once (different addresses)
-/// without repeating the dataset's compression.
+/// producing the on-disk data region (chunk bytes followed by the chunk index)
+/// and the v4 data-layout message. Cheap: this only concatenates and builds the
+/// index, so it can be run more than once (different addresses) without
+/// repeating the dataset's compression.
 pub(crate) fn assemble_chunked_at(
     set: &CompressedChunkSet,
     base_address: u64,
@@ -1521,18 +1520,13 @@ pub(crate) fn assemble_chunked_at(
     let has_filters = *has_filters;
     let num_chunks = compressed.len();
 
-    // Pre-size the data buffer: chunk bytes plus a cache-line slack per chunk.
+    // Pre-size the data buffer to hold every chunk; the index structure appended
+    // afterwards grows it the rest of the way.
     let chunk_bytes_total: usize = compressed.iter().map(Vec::len).sum();
-    let mut data_buf = Vec::with_capacity(chunk_bytes_total + (num_chunks + 1) * CACHE_LINE_SIZE);
+    let mut data_buf = Vec::with_capacity(chunk_bytes_total);
     let mut written_chunks = Vec::with_capacity(num_chunks);
 
     for (chunk, &raw_size) in compressed.iter().zip(raw_sizes.iter()) {
-        // Pad current position to cache-line boundary.
-        let aligned_offset = align_to_cache_line(data_buf.len());
-        if aligned_offset > data_buf.len() {
-            data_buf.resize(aligned_offset, 0u8);
-        }
-
         let address = base_address + data_buf.len() as u64;
         data_buf.extend_from_slice(chunk);
 
@@ -1546,12 +1540,6 @@ pub(crate) fn assemble_chunked_at(
 
     let offset_size: u8 = 8;
     let length_size: u8 = 8;
-
-    // Pad before index structures so they are also cache-line aligned.
-    let aligned_idx = align_to_cache_line(data_buf.len());
-    if aligned_idx > data_buf.len() {
-        data_buf.resize(aligned_idx, 0u8);
-    }
 
     #[expect(
         clippy::cast_possible_truncation,
@@ -1638,8 +1626,8 @@ pub fn build_chunked_data_at_ext(
 }
 
 /// Per-chunk metadata in dense row-major grid order — enough to compute the
-/// destination layout (chunk addresses, index structures, cache-line padding)
-/// *without* the chunk bytes. `compressed_size` is the exact byte count the
+/// destination layout (chunk addresses and index structures) *without* the
+/// chunk bytes. `compressed_size` is the exact byte count the
 /// matching [`ChunkProvider::chunk_bytes`] call must return.
 #[derive(Debug, Clone)]
 pub(crate) struct ChunkMeta {
@@ -1672,7 +1660,7 @@ pub(crate) trait ChunkProvider: Send + Sync {
 pub(crate) trait ByteSink {
     /// Append `bytes` to the output.
     fn put(&mut self, bytes: &[u8]) -> Result<(), FormatError>;
-    /// Append `n` zero bytes (cache-line padding).
+    /// Append `n` zero bytes.
     fn put_zeros(&mut self, n: usize) -> Result<(), FormatError>;
     /// Total bytes written so far (used to assert layout addresses on a
     /// non-seekable sink).
@@ -1701,10 +1689,10 @@ impl ByteSink for Vec<u8> {
     }
 }
 
-/// One grid slot's placement in the data region: the zero padding before it and
-/// the chunk's compressed byte count.
+/// One grid slot's placement in the data region. Slots are stored back to back,
+/// so a slot's own compressed byte count is its whole placement: the next slot
+/// begins where this one ends.
 pub(crate) struct ChunkSlotPlan {
-    pub(crate) pad_before: u64,
     pub(crate) compressed_size: u64,
 }
 
@@ -1715,13 +1703,11 @@ pub(crate) struct ChunkSlotPlan {
 pub(crate) struct VerbatimPlan {
     /// One entry per grid slot, in ascending address order.
     pub(crate) slots: Vec<ChunkSlotPlan>,
-    /// Zero padding before the index structure (cache-line alignment).
-    pub(crate) index_pad: u64,
     /// The serialized chunk-index structure (Fixed Array / Extensible Array),
     /// emitted after the chunk bytes. Empty for the single-chunk layout (whose
     /// address is embedded in the layout message instead).
     pub(crate) index_tail: Vec<u8>,
-    /// Total byte length of the data region (chunks + padding + index tail).
+    /// Total byte length of the data region (chunks + index tail).
     pub(crate) total_len: u64,
 }
 
@@ -1755,28 +1741,23 @@ pub(crate) fn plan_chunked_data_verbatim(
     let num_chunks = meta.len();
     let has_filters = pipeline_message.is_some();
 
-    // Walk a running cursor instead of pushing bytes; padding and addresses are a
-    // pure function of preceding chunk sizes, mirroring the buffered builder.
+    // Walk a running cursor instead of pushing bytes; each address is a pure
+    // function of the preceding chunk sizes, mirroring the buffered builder.
     let mut cursor: u64 = 0;
     let mut slots = Vec::with_capacity(num_chunks);
     let mut written_chunks = Vec::with_capacity(num_chunks);
 
     for m in meta {
-        let aligned_offset = align_to_cache_line(cursor.to_usize()?) as u64;
-        let pad_before = aligned_offset - cursor;
-        let address = base_address + aligned_offset;
+        let address = base_address + cursor;
         let compressed_size = m.compressed_size;
-        slots.push(ChunkSlotPlan {
-            pad_before,
-            compressed_size,
-        });
+        slots.push(ChunkSlotPlan { compressed_size });
         written_chunks.push(WrittenChunk {
             address,
             compressed_size,
             raw_size,
             filter_mask: m.filter_mask,
         });
-        cursor = aligned_offset + compressed_size;
+        cursor += compressed_size;
     }
 
     #[expect(
@@ -1788,11 +1769,6 @@ pub(crate) fn plan_chunked_data_verbatim(
     let length_size: u8 = 8;
 
     let use_extensible = maxshape.is_some_and(|ms| ms.contains(&u64::MAX));
-
-    // Pad before the index structure so it is also cache-line aligned.
-    let aligned_idx = align_to_cache_line(cursor.to_usize()?) as u64;
-    let index_pad = aligned_idx - cursor;
-    cursor = aligned_idx;
 
     let mut index_tail = Vec::new();
     #[expect(
@@ -1859,7 +1835,6 @@ pub(crate) fn plan_chunked_data_verbatim(
     Ok(VerbatimLayout {
         plan: VerbatimPlan {
             slots,
-            index_pad,
             index_tail,
             total_len: cursor,
         },
@@ -1882,7 +1857,6 @@ pub(crate) fn emit_chunked_data_verbatim<S: ByteSink>(
     // chunk count.
     let mut chunk = Vec::new();
     for (i, slot) in plan.slots.iter().enumerate() {
-        sink.put_zeros(slot.pad_before.to_usize()?)?;
         chunk.clear();
         provider.chunk_bytes(i, &mut chunk)?;
         if chunk.len() as u64 != slot.compressed_size {
@@ -1894,7 +1868,6 @@ pub(crate) fn emit_chunked_data_verbatim<S: ByteSink>(
         }
         sink.put(&chunk)?;
     }
-    sink.put_zeros(plan.index_pad.to_usize()?)?;
     sink.put(&plan.index_tail)?;
     Ok(())
 }
@@ -2098,41 +2071,58 @@ mod tests {
         assert_eq!(result, values);
     }
 
+    /// Chunks are stored back to back, with no padding between them. The chunk
+    /// size here (7 f64 = 56 bytes) is deliberately not a multiple of any cache
+    /// line, so any alignment padding would push the second and third chunks off
+    /// the concatenation this asserts.
     #[test]
-    fn chunk_addresses_are_cache_aligned() {
-        use super::align_to_cache_line;
-        let values: Vec<f64> = (0..100).map(|i| i as f64).collect();
+    fn chunks_are_stored_back_to_back() {
+        let values: Vec<f64> = (0..21).map(|i| i as f64).collect();
         let raw = f64_to_bytes(&values);
-        let base_address = 0x1000u64;
-        // Ensure base is aligned for this test
-        let base_address = align_to_cache_line(base_address as usize) as u64;
         let options = ChunkOptions {
-            chunk_dims: Some(vec![20]),
+            chunk_dims: Some(vec![7]),
             ..Default::default()
         };
-        let dims = [20u64];
+        let dims = [7u64];
         let ctx = ChunkContext::basic(&dims, 8);
-        let result =
-            build_chunked_data_at_ext(&raw, &[100], ctx, &options, base_address, None).unwrap();
+        let result = build_chunked_data_at_ext(&raw, &[21], ctx, &options, 0x1000, None).unwrap();
 
-        // Parse layout to get chunk addresses (via roundtrip read)
-        let file_size = base_address as usize + result.data_bytes.len();
-        let mut file_data = vec![0u8; file_size];
-        file_data[base_address as usize..].copy_from_slice(&result.data_bytes);
+        // Unfiltered chunks are stored verbatim, so the data region opens with
+        // the raw bytes in order and the index follows immediately after.
+        assert_eq!(
+            &result.data_bytes[..raw.len()],
+            &raw[..],
+            "the three chunks must concatenate with nothing between them"
+        );
+    }
 
-        let layout = DataLayout::parse(&result.layout_message, 8, 8).unwrap();
-        let dataspace = Dataspace {
-            space_type: DataspaceType::Simple,
-            rank: 1,
-            dimensions: vec![100],
-            max_dimensions: None,
-        };
-        let datatype = make_f64_type();
+    /// The same rule for the streaming path, stated where it is computed: the
+    /// data region is exactly the chunks plus the index, so a plan that inserted
+    /// padding would make `total_len` exceed the sum.
+    #[test]
+    fn a_verbatim_plan_reserves_only_the_chunks_and_the_index() {
+        let meta: Vec<ChunkMeta> = [37u64, 111, 5]
+            .into_iter()
+            .map(|compressed_size| ChunkMeta {
+                compressed_size,
+                filter_mask: 0,
+            })
+            .collect();
+        let layout =
+            plan_chunked_data_verbatim(&meta, &[7], 8, 56, Some(&[]), 0x1000, None).unwrap();
 
-        // Verify data roundtrips correctly
-        let output =
-            read_chunked_data(&file_data, &layout, &dataspace, &datatype, None, 8, 8).unwrap();
-        assert_eq!(bytes_to_f64(&output), values);
+        let chunk_bytes: u64 = meta.iter().map(|m| m.compressed_size).sum();
+        assert_eq!(
+            layout.plan.total_len,
+            chunk_bytes + layout.plan.index_tail.len() as u64
+        );
+        let planned: Vec<u64> = layout
+            .plan
+            .slots
+            .iter()
+            .map(|s| s.compressed_size)
+            .collect();
+        assert_eq!(planned, vec![37, 111, 5]);
     }
 
     #[test]

--- a/src/mat/de/reader.rs
+++ b/src/mat/de/reader.rs
@@ -853,7 +853,10 @@ fn shape_decomposition(shape: &[u64]) -> Result<(usize, usize, usize), MatError>
     // [rows, cols] matrix). For a 1-D variant like [1, N] or [N, 1], treat as
     // a vector of length N. The dimensions come from the file, so each is
     // narrowed to `usize` through the checked conversion that errors (rather
-    // than truncating) if a dimension exceeds the platform's pointer width.
+    // than truncating) if a dimension exceeds the platform's pointer width,
+    // and the product is taken with `checked_mul` for the same reason: a
+    // declared shape whose product wraps would otherwise yield an element
+    // count far below the largest index the transpose derives from `rows`.
     Ok(match shape.len() {
         0 => (1, 1, 1),
         1 => {
@@ -864,16 +867,25 @@ fn shape_decomposition(shape: &[u64]) -> Result<(usize, usize, usize), MatError>
             let cols_hdf5 = shape[0].to_usize()?;
             let rows_hdf5 = shape[1].to_usize()?;
             // MATLAB matrix has rows = rows_hdf5, cols = cols_hdf5.
-            let total = cols_hdf5 * rows_hdf5;
+            let total = checked_element_count(cols_hdf5, rows_hdf5, shape)?;
             (rows_hdf5, cols_hdf5, total)
         }
         _ => {
             let mut total: usize = 1;
             for &d in shape {
-                total *= d.to_usize()?;
+                total = checked_element_count(total, d.to_usize()?, shape)?;
             }
             (1, total, total)
         }
+    })
+}
+
+/// Multiply two file-derived extents, refusing a product that would wrap.
+fn checked_element_count(a: usize, b: usize, shape: &[u64]) -> Result<usize, MatError> {
+    a.checked_mul(b).ok_or_else(|| {
+        MatError::Custom(format!(
+            "shape {shape:?} declares more elements than the address space holds"
+        ))
     })
 }
 
@@ -1042,6 +1054,42 @@ fn parse_complex_pairs<T: ComplexComponent>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A declared 2-D shape whose product wraps to a plausible element count.
+    /// The dimensions come from the file, so this is reachable from
+    /// `mat::from_bytes` on a malformed input, not just from a Rust call site.
+    #[test]
+    fn shape_decomposition_refuses_a_wrapping_two_dimensional_shape() {
+        // Derived from `usize::MAX` rather than written out: each dimension has
+        // to fit in a `usize` (or the narrowing errors first, for a different
+        // reason) while the product wraps. A literal tuned to 64-bit would
+        // narrow-error on the 32-bit job and pass for the wrong reason.
+        let wraps_to_four = (usize::MAX / 4 + 2) as u64;
+        let err = shape_decomposition(&[wraps_to_four, 4]).unwrap_err();
+        assert!(
+            matches!(&err, MatError::Custom(m) if m.contains("address space")),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    /// The same rule for rank >= 3, where the product accumulates across a loop.
+    #[test]
+    fn shape_decomposition_refuses_a_wrapping_high_rank_shape() {
+        let err = shape_decomposition(&[1 << 31, 1 << 31, 1 << 31, 4]).unwrap_err();
+        assert!(
+            matches!(&err, MatError::Custom(m) if m.contains("address space")),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    /// The guard must not reject shapes that genuinely fit.
+    #[test]
+    fn shape_decomposition_accepts_ordinary_shapes() {
+        assert_eq!(shape_decomposition(&[]).unwrap(), (1, 1, 1));
+        assert_eq!(shape_decomposition(&[7]).unwrap(), (1, 7, 7));
+        assert_eq!(shape_decomposition(&[3, 5]).unwrap(), (5, 3, 15));
+        assert_eq!(shape_decomposition(&[2, 3, 4]).unwrap(), (1, 24, 24));
+    }
 
     #[test]
     fn enum_member_names_maps_indices_to_pool() {

--- a/src/mat/matrix.rs
+++ b/src/mat/matrix.rs
@@ -163,16 +163,19 @@ pub struct Matrix<T> {
 impl<T> Matrix<T> {
     /// Build a `Matrix` from a row-major data vector.
     ///
-    /// Panics if `data.len() != rows * cols`.
+    /// Panics if `rows * cols` overflows `usize`, or if `data.len()` does not
+    /// equal it. The overflow is checked separately because a wrapping product
+    /// can equal a short `data.len()`, and the writer transposes this matrix
+    /// through a raw pointer sized from that product.
     pub fn from_row_major(rows: usize, cols: usize, data: Vec<T>) -> Self {
+        let total = rows
+            .checked_mul(cols)
+            .expect("Matrix::from_row_major: rows * cols overflows usize");
         assert_eq!(
             data.len(),
-            rows * cols,
-            "Matrix::from_row_major: data length {} does not match {}×{} = {}",
+            total,
+            "Matrix::from_row_major: data length {} does not match {rows}×{cols} = {total}",
             data.len(),
-            rows,
-            cols,
-            rows * cols
         );
         Self { rows, cols, data }
     }

--- a/src/mat/matrix.rs
+++ b/src/mat/matrix.rs
@@ -203,11 +203,19 @@ impl<T> Matrix<T> {
 
 impl<T: Clone + Default> Matrix<T> {
     /// Build a zero-initialized matrix.
+    ///
+    /// Panics if `rows * cols` overflows `usize`, as [`Matrix::from_row_major`]
+    /// does: a wrapping product would allocate a short `data` vector while
+    /// `rows` and `cols` kept their true values, leaving the three fields
+    /// describing different matrices.
     pub fn zeros(rows: usize, cols: usize) -> Self {
+        let total = rows
+            .checked_mul(cols)
+            .expect("Matrix::zeros: rows * cols overflows usize");
         Self {
             rows,
             cols,
-            data: vec![T::default(); rows * cols],
+            data: vec![T::default(); total],
         }
     }
 }
@@ -258,13 +266,23 @@ impl<'de, T: MatElement + Deserialize<'de>> Deserialize<'de> for Matrix<T> {
                 let rows = rows.ok_or_else(|| de::Error::missing_field("rows"))?;
                 let cols = cols.ok_or_else(|| de::Error::missing_field("cols"))?;
                 let data = data.ok_or_else(|| de::Error::missing_field("data"))?;
-                if data.len() != rows * cols {
+                // `rows` and `cols` are payload fields, so the product is taken
+                // with `checked_mul` and reported as a deserializer error: a
+                // wrapping product can equal a short `data.len()`, and the
+                // length check below would then agree with itself and admit a
+                // matrix whose fields contradict each other.
+                let total = rows.checked_mul(cols).ok_or_else(|| {
+                    de::Error::custom(format!(
+                        "Matrix dimensions {rows}×{cols} overflow the address space"
+                    ))
+                })?;
+                if data.len() != total {
                     return Err(de::Error::custom(format!(
                         "Matrix data length {} does not match {}×{} = {}",
                         data.len(),
                         rows,
                         cols,
-                        rows * cols
+                        total
                     )));
                 }
                 Ok(Matrix { rows, cols, data })
@@ -287,5 +305,49 @@ mod tests {
     #[should_panic]
     fn from_row_major_length_mismatch_panics() {
         let _ = Matrix::from_row_major(2, 3, vec![1.0_f64]);
+    }
+
+    /// `rows` such that `rows * 4` wraps to exactly 4. Derived from `usize::MAX`
+    /// so it wraps at either word width rather than only on 64-bit, and equal to
+    /// the `data` length below so a check written against the wrapping product
+    /// would agree with itself.
+    const WRAPS_TO_FOUR: usize = usize::MAX / 4 + 2;
+
+    #[test]
+    fn the_wrapping_shape_really_does_wrap() {
+        // Pins the premise of the three tests below: if this stopped wrapping to
+        // 4 they would still pass, having stopped testing anything.
+        assert_eq!(WRAPS_TO_FOUR.wrapping_mul(4), 4);
+        assert!(WRAPS_TO_FOUR.checked_mul(4).is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "overflows usize")]
+    fn zeros_refuses_a_shape_whose_product_wraps() {
+        // Without the check this allocates 4 elements and reports 2^62+1 rows.
+        let _ = Matrix::<f64>::zeros(WRAPS_TO_FOUR, 4);
+    }
+
+    #[test]
+    fn deserializing_a_shape_whose_product_wraps_is_an_error() {
+        // The dimensions are payload fields, so this must be an error rather
+        // than a panic out of a `Deserialize` impl.
+        let json = format!(r#"{{"rows":{WRAPS_TO_FOUR},"cols":4,"data":[1.0,2.0,3.0,4.0]}}"#);
+        let err = serde_json::from_str::<Matrix<f64>>(&json).unwrap_err();
+        assert!(
+            err.to_string().contains("overflow the address space"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn deserializing_an_honest_length_mismatch_is_still_an_error() {
+        // The overflow guard must not swallow the ordinary mismatch case.
+        let err =
+            serde_json::from_str::<Matrix<f64>>(r#"{"rows":2,"cols":3,"data":[1.0]}"#).unwrap_err();
+        assert!(
+            err.to_string().contains("does not match"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/src/mat/ser/value_ser.rs
+++ b/src/mat/ser/value_ser.rs
@@ -571,7 +571,15 @@ fn matrix_from_fields(fields: MatrixFields, kind: MatrixKind) -> Result<MatValue
     let data = fields
         .data
         .ok_or_else(|| MatError::MissingField("data".into()))?;
-    let total = rows * cols;
+    // `rows` and `cols` arrive from the serialized input, so the product can
+    // overflow. Refuse it here: a wrapped total would agree with a short data
+    // vector and let the pair through to a writer that transposes through a raw
+    // pointer sized from that same product.
+    let total = rows.checked_mul(cols).ok_or_else(|| {
+        MatError::Custom(format!(
+            "Matrix dimensions {rows}x{cols} overflow the address space"
+        ))
+    })?;
     let length_check = |actual: usize| -> Result<(), MatError> {
         if actual != total {
             return Err(MatError::Custom(format!(

--- a/src/mat/transpose.rs
+++ b/src/mat/transpose.rs
@@ -10,8 +10,20 @@
 ///
 /// Element `(r, c)` at `row_major[r * cols + c]` lands at `out[c * rows + r]`.
 fn transpose_2d<T: Copy>(rows: usize, cols: usize, row_major: &[T]) -> Vec<T> {
-    debug_assert_eq!(row_major.len(), rows * cols);
-    let n = rows * cols;
+    // `rows * cols` must not wrap: the loop below writes to `c * rows + r`
+    // through a raw pointer, so a wrapped `n` would size `out` far below the
+    // largest index written. Checking the length against the *checked* product
+    // is what makes the SAFETY comments hold; comparing against a wrapping
+    // product would agree with itself and prove nothing.
+    let n = rows
+        .checked_mul(cols)
+        .expect("transpose: rows * cols overflows usize");
+    assert_eq!(
+        row_major.len(),
+        n,
+        "transpose: source length {} does not match {rows}x{cols} = {n}",
+        row_major.len()
+    );
     let mut out: Vec<T> = Vec::with_capacity(n);
     if n == 0 {
         return out;
@@ -106,10 +118,13 @@ mod tests {
         }
     }
 
+    /// Uses `(f64, f64)`, the 16-byte pair `ComplexVec` actually instantiates,
+    /// so the raw-pointer scaling is exercised at an element size larger than a
+    /// machine word rather than only at 4 bytes.
     #[test]
     fn pairs_match_the_reference_transpose() {
         for &(rows, cols) in SHAPES {
-            let src: Vec<(u16, u16)> = (0..(rows * cols) as u16).map(|i| (i, !i)).collect();
+            let src: Vec<(f64, f64)> = (0..rows * cols).map(|i| (i as f64, -(i as f64))).collect();
             assert_eq!(
                 transpose_pairs(rows, cols, &src),
                 transpose_reference(rows, cols, &src),
@@ -134,5 +149,36 @@ mod tests {
     fn an_empty_matrix_yields_an_empty_vec() {
         assert!(transpose_scalars::<u8>(0, 0, &[]).is_empty());
         assert!(transpose_pairs::<f64>(4, 0, &[]).is_empty());
+    }
+
+    /// `rows` such that `rows * 4` wraps to exactly 4 — the same value as the
+    /// source length below. That is what makes this the dangerous shape rather
+    /// than merely a large one: a length check written against the wrapping
+    /// product agrees with itself and admits the pair, after which the tiled
+    /// loop writes far past a 4-element allocation. Derived from `usize::MAX`
+    /// rather than written out, so it wraps at either word width.
+    const WRAPS_TO_FOUR: usize = usize::MAX / 4 + 2;
+
+    #[test]
+    fn the_wrapping_shape_really_does_wrap_to_the_source_length() {
+        // Pins the premise of the two refusal tests: if this ever stopped
+        // wrapping to 4 they would still pass, for the wrong reason.
+        assert_eq!(WRAPS_TO_FOUR.wrapping_mul(4), 4);
+        assert!(WRAPS_TO_FOUR.checked_mul(4).is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "overflows usize")]
+    fn a_shape_whose_product_wraps_is_refused() {
+        let src = vec![0u8; 4];
+        let _ = transpose_scalars(WRAPS_TO_FOUR, 4, &src);
+    }
+
+    /// The same refusal on the public constructor, which is the safe entry
+    /// point a caller can reach it through.
+    #[test]
+    #[should_panic(expected = "overflows usize")]
+    fn a_matrix_whose_product_wraps_is_refused() {
+        let _ = crate::mat::Matrix::from_row_major(WRAPS_TO_FOUR, 4, vec![0u8; 4]);
     }
 }

--- a/src/mat/transpose.rs
+++ b/src/mat/transpose.rs
@@ -59,3 +59,80 @@ pub(crate) fn transpose_pairs<T: Copy>(
 ) -> Vec<(T, T)> {
     transpose_2d(rows, cols, row_major)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The definition the raw-pointer writes have to honour, computed the slow
+    /// and obviously-correct way.
+    fn transpose_reference<T: Copy>(rows: usize, cols: usize, row_major: &[T]) -> Vec<T> {
+        let mut out = Vec::with_capacity(rows * cols);
+        for c in 0..cols {
+            for r in 0..rows {
+                out.push(row_major[r * cols + c]);
+            }
+        }
+        out
+    }
+
+    /// Shapes chosen around the 32-element blocking: smaller than one block,
+    /// exactly one block, and straddling a block boundary in each dimension, so
+    /// the partial-block `min` arithmetic is exercised in both directions.
+    const SHAPES: &[(usize, usize)] = &[
+        (0, 0),
+        (0, 5),
+        (5, 0),
+        (1, 1),
+        (1, 7),
+        (7, 1),
+        (3, 4),
+        (32, 32),
+        (33, 32),
+        (32, 33),
+        (33, 47),
+        (65, 3),
+    ];
+
+    #[test]
+    fn scalars_match_the_reference_transpose() {
+        for &(rows, cols) in SHAPES {
+            let src: Vec<u32> = (0..(rows * cols) as u32).collect();
+            assert_eq!(
+                transpose_scalars(rows, cols, &src),
+                transpose_reference(rows, cols, &src),
+                "shape {rows}x{cols}"
+            );
+        }
+    }
+
+    #[test]
+    fn pairs_match_the_reference_transpose() {
+        for &(rows, cols) in SHAPES {
+            let src: Vec<(u16, u16)> = (0..(rows * cols) as u16).map(|i| (i, !i)).collect();
+            assert_eq!(
+                transpose_pairs(rows, cols, &src),
+                transpose_reference(rows, cols, &src),
+                "shape {rows}x{cols}"
+            );
+        }
+    }
+
+    /// Transposing twice is the identity, which pins the index mapping rather
+    /// than just the element multiset.
+    #[test]
+    fn transposing_twice_restores_the_original() {
+        let (rows, cols) = (33usize, 47usize);
+        let src: Vec<u64> = (0..(rows * cols) as u64).map(|i| i * 7 + 1).collect();
+        let once = transpose_scalars(rows, cols, &src);
+        assert_eq!(transpose_scalars(cols, rows, &once), src);
+    }
+
+    /// An empty matrix must not write through the dangling pointer a
+    /// zero-capacity `Vec` hands out.
+    #[test]
+    fn an_empty_matrix_yields_an_empty_vec() {
+        assert!(transpose_scalars::<u8>(0, 0, &[]).is_empty());
+        assert!(transpose_pairs::<f64>(4, 0, &[]).is_empty());
+    }
+}

--- a/tests/edit_free_space.rs
+++ b/tests/edit_free_space.rs
@@ -319,11 +319,10 @@ fn deleting_filtered_chunked_dataset_reclaims_storage() {
 
 #[test]
 fn deleting_unfiltered_chunked_dataset_truncates_fully() {
-    // An unfiltered chunked dataset whose chunk size is a cache-line multiple is
-    // laid out as one contiguous blob (chunk data + Fixed Array index, no
-    // inter-chunk padding). Adding it at end-of-file then deleting it in the same
-    // session reclaims the whole blob as a trailing run, truncating the file back
-    // to essentially its prior size.
+    // An unfiltered chunked dataset is laid out as one contiguous blob (chunk
+    // data followed by the Fixed Array index, nothing between). Adding it at
+    // end-of-file then deleting it in the same session reclaims the whole blob as
+    // a trailing run, truncating the file back to essentially its prior size.
     let path = tmp("hdf5_pure_fs_chunked_unfiltered.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("keep").with_i32_data(&[1, 2, 3]);
@@ -332,7 +331,7 @@ fn deleting_unfiltered_chunked_dataset_truncates_fully() {
 
     {
         let s = File::open_rw(&path).unwrap();
-        // 8 chunks of 512 f64 = 4096 bytes each (a multiple of the cache line).
+        // 8 chunks of 512 f64 = 4096 bytes each.
         s.root()
             .create_dataset("big", |b| {
                 b.with_f64_data(&vec![7.0; 4096]).with_chunks(&[512]);
@@ -370,8 +369,8 @@ fn deleting_unfiltered_chunked_dataset_truncates_fully() {
 fn deleting_paged_fixed_array_dataset_reclaims_storage() {
     // More than 1024 chunks puts the Fixed Array data block into its *paged*
     // layout (a page-init bitmap and per-page checksums). 1100 chunks of 16 f64
-    // (128 bytes, a cache-line multiple) exercise that index-sizing path end to
-    // end: the whole index plus chunk data is reclaimed on delete.
+    // exercise that index-sizing path end to end: the whole index plus chunk
+    // data is reclaimed on delete.
     let path = tmp("hdf5_pure_fs_paged_fa.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("keep").with_i32_data(&[7]);
@@ -466,8 +465,8 @@ fn deleting_single_chunk_dataset_reclaims_storage() {
 
     {
         let s = File::open_rw(&path).unwrap();
-        // 1024 f64 = 8192 bytes (a cache-line multiple), so the single chunk's
-        // blob carries no trailing padding and reclaims as one trailing run.
+        // 1024 f64 = 8192 bytes in a single chunk, whose blob reclaims as one
+        // trailing run.
         s.root()
             .create_dataset("one", |b| {
                 b.with_f64_data(&vec![1.25; 1024]).with_chunks(&[1024]);

--- a/tests/edit_free_space.rs
+++ b/tests/edit_free_space.rs
@@ -395,8 +395,8 @@ fn deleting_paged_fixed_array_dataset_reclaims_storage() {
             "deleting a paged fixed-array dataset should reclaim its storage \
              (was {size_with_paged}, now {size_after_delete})"
         );
-        // Cache-line-aligned chunks + the index form a trailing run, so the file
-        // truncates back near its start.
+        // The chunks and the index form one trailing run, so the file truncates
+        // back near its start.
         assert!(size_after_delete < size_start + 4096);
     }
 


### PR DESCRIPTION
Closes #227.

The writer rounded every chunk's offset up to `CACHE_LINE_SIZE` (128 on aarch64, 64 elsewhere), so the same dataset was larger on one target than another. It never aligned anything: offsets were rounded relative to the data region's base address, which is whatever the allocator returns. Measured across unfiltered and deflated datasets, zero chunk addresses landed on a cache line either way. Chunks and the Fixed/Extensible Array index are now stored back to back, shrinking a 28-chunk unfiltered dataset by 22% and a deflated one by 10%.

No public API change (`CACHE_LINE_SIZE` and `align_to_cache_line` were `pub` inside a `pub(crate)` module). Files written by earlier versions still read: chunk addresses come from the index, which never assumed a stride.

### Also in this PR

**A release-mode UB fix.** `Matrix::from_row_major` took a wrapping `rows * cols`, so a shape whose product wrapped to a short data length passed the length check and the tiled transpose then wrote past its allocation. Every construction site is now guarded, in the register that fits where its values come from: `from_row_major` and `zeros` panic, while the `Deserialize` impl, the `.mat` serializer, and `shape_decomposition` return errors. The last of those reads extents from a file, so a malformed `.mat` could panic `mat::from_bytes`.

**The Miri job was vacuous.** #113 deleted the `unsafe` from `chunk_cache` and left its 11 safe tests, which kept passing. It now interprets `mat::transpose`, the crate's real raw-pointer code, and fails if the unsafe leaves, if the filter matches nothing, or if the tests are selected but not run.

**Documentation corrections.** The `unsafe` inventory named the wrong feature set (`serde` is not a default feature, and `no_std` swaps the transpose out rather than adding to it), and the host-independence claim needed a caveat for `fast-deflate`, which dispatches on runtime CPU features.

Happy to split the last two out if they don't belong here.

### Verification

21/21 CI checks pass. New tests are mutation-verified load-bearing and selective. Two review passes confirmed the buffered and streaming write paths stay byte-identical across 11 shapes, and that a padded file written by the previous version still reads, repacks, and appends correctly, including in a file mixing both layouts.

One gap worth naming: no test pins the backward-compatibility claim, because this PR deletes the only producer of padded files and the repo has no binary-fixture convention.
