### PR TITLE
Write an empty string attribute with a datatype libhdf5 can read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- An attribute holding an empty string is written with a one-byte-wide string datatype rather than a zero-size one, which libhdf5 rejects while iterating an object's attributes — a single empty-string attribute made every attribute on that object unreadable to the C library ([#240](https://github.com/stephenberry/hdf5-pure/pull/240)).
 - `repack` no longer re-encodes an attribute it copies: a variable-length ASCII array stays variable-length, and a fixed-width ASCII string keeps its charset, where both previously came out as UTF-8 fixed-width ([#239](https://github.com/stephenberry/hdf5-pure/pull/239)).
 - A MAT file honors `MATLAB_class` and `MATLAB_empty` whichever integer width, charset, or one-element shape its writer chose, rather than reporting an unexpected attribute type or reading the flag as absent ([#238](https://github.com/stephenberry/hdf5-pure/pull/238), [#239](https://github.com/stephenberry/hdf5-pure/pull/239)).
 

--- a/src/file_writer.rs
+++ b/src/file_writer.rs
@@ -2982,8 +2982,12 @@ mod tests {
     /// An `AsciiString` attribute named `name` whose serialized (v3) size is
     /// exactly `size` bytes, so a bound can be tested on the value it bounds.
     fn dense_attr_of_size(name: &str, size: usize) -> AttributeMessage {
-        let probe = build_attr_message(name, &AttrValue::AsciiString(String::new()));
-        let overhead = probe.serialize_v3(LENGTH_SIZE).len();
+        // Probe with one character and subtract it, rather than probing with an
+        // empty string: a fixed-width string datatype is at least one byte wide,
+        // so an empty value still carries a padding byte and would be measured
+        // as overhead.
+        let probe = build_attr_message(name, &AttrValue::AsciiString("y".to_string()));
+        let overhead = probe.serialize_v3(LENGTH_SIZE).len() - 1;
         let attr = build_attr_message(name, &AttrValue::AsciiString("y".repeat(size - overhead)));
         assert_eq!(attr.serialize_v3(LENGTH_SIZE).len(), size);
         attr

--- a/src/type_builders.rs
+++ b/src/type_builders.rs
@@ -651,34 +651,26 @@ pub(crate) fn build_attr_message(name: &str, value: &AttrValue) -> AttributeMess
             AttributeMessage {
                 name: name.to_string(),
                 datatype: Datatype::String {
-                    #[expect(
-                        clippy::cast_possible_truncation,
-                        reason = "string byte length is stored in the 4-byte fixed-string datatype size field"
-                    )]
-                    size: bytes.len() as u32,
+                    size: fixed_string_size(bytes.len()),
                     padding: StringPadding::NullPad,
                     charset: CharacterSet::Utf8,
                 },
                 dataspace: scalar_ds(),
-                raw_data: bytes.to_vec(),
+                raw_data: pad_to_size(bytes),
             }
         }
         AttrValue::StringArray(arr) => {
-            let max_len = arr.iter().map(|s| s.len()).max().unwrap_or(0);
+            let elem_size = fixed_string_size(arr.iter().map(|s| s.len()).max().unwrap_or(0));
             let mut raw = Vec::new();
             for s in arr {
                 let mut b = s.as_bytes().to_vec();
-                b.resize(max_len, 0);
+                b.resize(elem_size as usize, 0);
                 raw.extend_from_slice(&b);
             }
             AttributeMessage {
                 name: name.to_string(),
                 datatype: Datatype::String {
-                    #[expect(
-                        clippy::cast_possible_truncation,
-                        reason = "max string byte length is stored in the 4-byte fixed-string datatype size field"
-                    )]
-                    size: max_len as u32,
+                    size: elem_size,
                     padding: StringPadding::NullPad,
                     charset: CharacterSet::Utf8,
                 },
@@ -691,34 +683,26 @@ pub(crate) fn build_attr_message(name: &str, value: &AttrValue) -> AttributeMess
             AttributeMessage {
                 name: name.to_string(),
                 datatype: Datatype::String {
-                    #[expect(
-                        clippy::cast_possible_truncation,
-                        reason = "string byte length is stored in the 4-byte fixed-string datatype size field"
-                    )]
-                    size: bytes.len() as u32,
+                    size: fixed_string_size(bytes.len()),
                     padding: StringPadding::NullPad,
                     charset: CharacterSet::Ascii,
                 },
                 dataspace: scalar_ds(),
-                raw_data: bytes.to_vec(),
+                raw_data: pad_to_size(bytes),
             }
         }
         AttrValue::AsciiStringArray(arr) => {
-            let max_len = arr.iter().map(|s| s.len()).max().unwrap_or(0);
+            let elem_size = fixed_string_size(arr.iter().map(|s| s.len()).max().unwrap_or(0));
             let mut raw = Vec::new();
             for s in arr {
                 let mut b = s.as_bytes().to_vec();
-                b.resize(max_len, 0);
+                b.resize(elem_size as usize, 0);
                 raw.extend_from_slice(&b);
             }
             AttributeMessage {
                 name: name.to_string(),
                 datatype: Datatype::String {
-                    #[expect(
-                        clippy::cast_possible_truncation,
-                        reason = "max string byte length is stored in the 4-byte fixed-string datatype size field"
-                    )]
-                    size: max_len as u32,
+                    size: elem_size,
                     padding: StringPadding::NullPad,
                     charset: CharacterSet::Ascii,
                 },
@@ -1058,6 +1042,34 @@ pub(crate) fn patch_vl_refs_masked(
         let addr_offset = offset + 4; // skip sequence_length
         raw_data[addr_offset..addr_offset + 8].copy_from_slice(&address.to_le_bytes());
     }
+}
+
+/// `STRSIZE` for a fixed-width string datatype whose longest value is `len`
+/// bytes, which is never zero.
+///
+/// HDF5 requires a string datatype of at least one byte. libhdf5 rejects a
+/// zero-size one with "invalid datatype size" — and it fails while *iterating*
+/// the object's attributes, so a single empty-string attribute makes every
+/// attribute on that object unreadable to the C library, not just that one.
+///
+/// An empty string is therefore stored as one padding byte, which reads back as
+/// the empty string under any of the three padding rules. Storing it needs no
+/// refusal: the value is representable, it was only the datatype that was not.
+fn fixed_string_size(len: usize) -> u32 {
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "string byte length is stored in the 4-byte fixed-string datatype size field"
+    )]
+    let size = len.max(1) as u32;
+    size
+}
+
+/// A scalar fixed-width string's raw data: its bytes, never empty, so that the
+/// message matches the `STRSIZE` [`fixed_string_size`] declares.
+fn pad_to_size(bytes: &[u8]) -> Vec<u8> {
+    let mut out = bytes.to_vec();
+    out.resize(fixed_string_size(bytes.len()) as usize, 0);
+    out
 }
 
 pub(crate) fn scalar_ds() -> Dataspace {

--- a/tests/hdf5_crosscheck.rs
+++ b/tests/hdf5_crosscheck.rs
@@ -1813,3 +1813,89 @@ fn crosscheck_vlen_strings_span_multiple_heap_collections() {
         assert_eq!(vals[i].as_str(), format!("s{i}"), "element {i} differs");
     }
 }
+
+/// An empty-string attribute must not make the object's *other* attributes
+/// unreadable to the C library.
+///
+/// A fixed-width string datatype has to be at least one byte wide. Writing
+/// `STRSIZE 0` for an empty string made libhdf5 fail with "invalid datatype
+/// size" — and it fails inside `H5Aiterate2`, so every attribute on that object
+/// became unreachable, not only the empty one. The healthy attribute here is
+/// what makes that blast radius visible: a test carrying only the empty string
+/// would pass the moment the empty one alone was fixed.
+#[test]
+fn an_empty_string_attribute_does_not_hide_its_neighbours() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("empty_string_attr.h5");
+
+    let mut builder = FileBuilder::new();
+    builder.set_attr("empty_utf8", AttrValue::String(String::new()));
+    builder.set_attr("empty_ascii", AttrValue::AsciiString(String::new()));
+    builder.set_attr("all_empty", AttrValue::StringArray(vec![String::new(); 2]));
+    builder.set_attr("healthy", AttrValue::AsciiString("v".into()));
+    builder.create_dataset("x").with_f64_data(&[1.0]);
+    builder.write(&path).unwrap();
+
+    let file = hdf5::File::open(&path).unwrap();
+
+    // Iteration is where the zero-size datatype used to fail.
+    let mut names = file.attr_names().unwrap();
+    names.sort();
+    assert_eq!(
+        names,
+        vec![
+            "all_empty".to_string(),
+            "empty_ascii".to_string(),
+            "empty_utf8".to_string(),
+            "healthy".to_string(),
+        ]
+    );
+
+    // The neighbour opens and reads.
+    let healthy = file.attr("healthy").unwrap();
+    assert_eq!(
+        healthy
+            .read_scalar::<hdf5::types::FixedAscii<1>>()
+            .unwrap()
+            .as_str(),
+        "v"
+    );
+
+    // And each empty one is a one-byte-wide string holding nothing. The C
+    // library will not convert between charsets, so each is read as its own.
+    let utf8 = file.attr("empty_utf8").unwrap();
+    assert_eq!(utf8.size(), 1);
+    assert!(
+        utf8.read_scalar::<hdf5::types::FixedUnicode<1>>()
+            .unwrap()
+            .as_str()
+            .is_empty()
+    );
+    let ascii = file.attr("empty_ascii").unwrap();
+    assert_eq!(ascii.size(), 1);
+    assert!(
+        ascii
+            .read_scalar::<hdf5::types::FixedAscii<1>>()
+            .unwrap()
+            .as_str()
+            .is_empty()
+    );
+    let all_empty = file.attr("all_empty").unwrap();
+    assert_eq!(all_empty.size(), 2);
+
+    // hdf5-pure reads its own file back with the values intact.
+    let ours = File::open(&path).unwrap();
+    let attrs = ours.root().attrs().unwrap();
+    assert_eq!(
+        attrs.get("empty_utf8"),
+        Some(&AttrValue::String(String::new()))
+    );
+    assert_eq!(
+        attrs.get("empty_ascii"),
+        Some(&AttrValue::AsciiString(String::new()))
+    );
+    assert_eq!(
+        attrs.get("all_empty"),
+        Some(&AttrValue::StringArray(vec![String::new(); 2]))
+    );
+}


### PR DESCRIPTION
Stacked on #239 — review that first; this PR's diff is against its branch.

A fixed-width HDF5 string datatype must be at least one byte wide. `build_attr_message` derived `STRSIZE` from the value's byte length, so an empty string produced `STRSIZE 0` — and libhdf5 rejects that with `invalid datatype size` **while iterating the object's attributes**, so one empty-string attribute made *every* attribute on that object unreadable to the C library:

```
H5Aiterate2(): error iterating over attributes: invalid datatype size
H5Aopen(): unable to synchronously open attribute: invalid datatype size   // for the healthy one too
```

Found while reviewing #239, where it was also the root cause of a read-side regression: a zero-size datatype decodes to no elements, which the new scalar arms briefly treated as an undecodable attribute.

An empty string is now stored as one padding byte, which reads back empty under any of the three padding rules. No refusal is needed — the value was always representable; only the datatype wasn't.

### All four paths, one helper

The two array paths reach the same zero size whenever *every* element is empty (`max_len` is 0), so `String`, `AsciiString`, `StringArray` and `AsciiStringArray` all go through `fixed_string_size`. That is the complete set: the variable-length paths hardcode a 1-byte base, and no dataset or compound path derives a string size from data.

### Testing

The crosscheck writes four attributes — an empty UTF-8 string, an empty ASCII string, a two-element array whose every element is empty, and one healthy `AsciiString` — then has the C library iterate, open, and read them.

The healthy attribute is the point. A test holding only the empty string would pass the moment that one case worked and would never show the blast radius, which is what makes this bug worth its own PR rather than a one-line clamp. Verified load-bearing: without the write-side change the test fails at `attr_names()`, which is the `H5Aiterate2` call.

One test helper needed adjusting rather than a test itself: `dense_attr_of_size` measured per-attribute overhead by serializing an *empty* `AsciiString`, which now carries one data byte. It probes with one character and subtracts it, which measures the same overhead under either rule; its exact-size assertion is unchanged.

### Version

No bump: the manifest already reads `0.31.0` from #239, and one bump covers every change in the cycle. This is a change to written bytes for a case libhdf5 could not read at all, not a public API break.

Gates run locally: `cargo fmt --all --check`, `cargo clippy --locked --features "serde ndarray" --all-targets -- -D warnings`, and the full suite under `--features serde,provenance` (0 failures).
