### PR TITLE
Carry the datatype in `DType::Other`, not a description of it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
-- **Breaking:** `DType::Other` carries the `Datatype` itself rather than a description of it, so a type the curated view has no name for can be matched on — including one nested in a compound field or an array base, where `Dataset::datatype` is no help. It still writes as a summary, `other(opaque[3] "rgb")` ([#243](https://github.com/stephenberry/hdf5-pure/issues/243)).
+- **Breaking:** `DType::Other` carries the `Datatype` itself rather than a description of it, so a type the curated view has no name for can be matched on — including one nested in a compound field or an array base, where `Dataset::datatype` is no help. It still writes as a summary, `other(opaque[3] "rgb")` ([#244](https://github.com/stephenberry/hdf5-pure/pull/244)).
 - **Breaking:** `DType::Array` writes its shape as `array<f32, 2x3>` rather than `array<f32, [2, 3]>` ([#242](https://github.com/stephenberry/hdf5-pure/pull/242)).
 - **Breaking:** a name a file records — a compound member's, an enum label's, a filter's — is escaped and truncated wherever it is written, and a member list is elided past sixteen ([#242](https://github.com/stephenberry/hdf5-pure/pull/242)).
 - **Breaking:** the `Error::MissingMessage` text names the message — `missing required message: data layout` — instead of its Rust variant, and the unrecognized-chunk-index error reports the index-type byte without a `Some`/`None` around it ([#242](https://github.com/stephenberry/hdf5-pure/pull/242)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
-- **Breaking:** an unclassified datatype reads as a summary instead of the `Debug` record of the whole `Datatype`, so `DType::Other` now carries `opaque[3] "rgb"` where it carried `Opaque { size: 3, tag: [114, 103, 98] }` ([#242](https://github.com/stephenberry/hdf5-pure/pull/242)).
+- **Breaking:** `DType::Other` carries the `Datatype` itself rather than a description of it, so a type the curated view has no name for can be matched on — including one nested in a compound field or an array base, where `Dataset::datatype` is no help. It still writes as a summary, `other(opaque[3] "rgb")` ([#243](https://github.com/stephenberry/hdf5-pure/issues/243)).
 - **Breaking:** `DType::Array` writes its shape as `array<f32, 2x3>` rather than `array<f32, [2, 3]>` ([#242](https://github.com/stephenberry/hdf5-pure/pull/242)).
 - **Breaking:** a name a file records — a compound member's, an enum label's, a filter's — is escaped and truncated wherever it is written, and a member list is elided past sixteen ([#242](https://github.com/stephenberry/hdf5-pure/pull/242)).
 - **Breaking:** the `Error::MissingMessage` text names the message — `missing required message: data layout` — instead of its Rust variant, and the unrecognized-chunk-index error reports the index-type byte without a `Some`/`None` around it ([#242](https://github.com/stephenberry/hdf5-pure/pull/242)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
-- **Breaking:** `DType::Other` carries the `Datatype` itself rather than a description of it, so a type the curated view has no name for can be matched on — including one nested in a compound field or an array base, where `Dataset::datatype` is no help. It still writes as a summary, `other(opaque[3] "rgb")` ([#244](https://github.com/stephenberry/hdf5-pure/pull/244)).
+- **Breaking:** `DType::Other` carries the `Datatype` itself rather than a description of it, so a type the curated view has no name for can be matched on — including one nested in a compound field or an array base, where `Dataset::datatype` is no help. It writes as a summary of that type — `other(opaque[3] "rgb")` where it wrote `other(Opaque { size: 3, tag: [114, 103, 98] })` ([#244](https://github.com/stephenberry/hdf5-pure/pull/244)).
 - **Breaking:** `DType::Array` writes its shape as `array<f32, 2x3>` rather than `array<f32, [2, 3]>` ([#242](https://github.com/stephenberry/hdf5-pure/pull/242)).
 - **Breaking:** a name a file records — a compound member's, an enum label's, a filter's — is escaped and truncated wherever it is written, and a member list is elided past sixteen ([#242](https://github.com/stephenberry/hdf5-pure/pull/242)).
 - **Breaking:** the `Error::MissingMessage` text names the message — `missing required message: data layout` — instead of its Rust variant, and the unrecognized-chunk-index error reports the index-type byte without a `Some`/`None` around it ([#242](https://github.com/stephenberry/hdf5-pure/pull/242)).

--- a/docs/reference/data-types.md
+++ b/docs/reference/data-types.md
@@ -236,7 +236,7 @@ fn load<T: H5Element>(file: &File, name: &str) -> Result<Vec<T>, Error> {
 | `Compound(Vec<(String, DType)>)` | compound with classified fields |
 | `Enum(Vec<String>)` | enumeration with member names |
 | `Array(Box<DType>, Vec<u32>)` | fixed-size array of a base type |
-| `Other(String)` | anything not classified above |
+| `Other(Box<Datatype>)` | anything not classified above, carrying the type itself |
 
 !!! tip
-    Use `DType` for a quick human-readable summary; use `Dataset::datatype()` when you need exact field offsets, bit precision, or byte order.
+    Use `DType` for a quick human-readable summary; use `Dataset::datatype()` when you need exact field offsets, bit precision, or byte order. A type nested in a compound field or an array base has no such fallback, which is why `Other` carries the `Datatype` rather than a description of it.

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -1960,6 +1960,77 @@ mod display_tests {
         assert_eq!(float.to_string(), "f64");
     }
 
+    /// Every width a message writes is `size * 8` over an on-disk `u32`, so a
+    /// crafted size near [`u32::MAX`] overflows a `u32` multiply and panics a
+    /// debug build (issue #140). [`bit_width`] widens first; this holds each
+    /// class that calls it to that, rather than reaching one of them through
+    /// whatever `classify_datatype` happens to route here.
+    #[test]
+    fn a_crafted_size_writes_its_width_instead_of_overflowing() {
+        let bits = u64::from(u32::MAX) * 8;
+        let cases = [
+            (
+                Datatype::FixedPoint {
+                    size: u32::MAX,
+                    byte_order: DatatypeByteOrder::LittleEndian,
+                    signed: true,
+                    bit_offset: 0,
+                    bit_precision: 0,
+                },
+                format!("i{bits}(bits 0..0)"),
+            ),
+            (
+                Datatype::FloatingPoint {
+                    size: u32::MAX,
+                    byte_order: DatatypeByteOrder::LittleEndian,
+                    bit_offset: 0,
+                    bit_precision: 0,
+                    exponent_location: 0,
+                    exponent_size: 0,
+                    mantissa_location: 0,
+                    mantissa_size: 0,
+                    exponent_bias: 0,
+                },
+                format!("f{bits}(bits 0..0)"),
+            ),
+            (
+                Datatype::Time {
+                    size: u32::MAX,
+                    byte_order: DatatypeByteOrder::LittleEndian,
+                    bit_precision: 0,
+                },
+                format!("time{bits}(bits 0..0)"),
+            ),
+            (
+                Datatype::BitField {
+                    size: u32::MAX,
+                    byte_order: DatatypeByteOrder::LittleEndian,
+                    bit_offset: 0,
+                    bit_precision: 0,
+                },
+                format!("bitfield{bits}(bits 0..0)"),
+            ),
+        ];
+
+        for (dtype, expected) in cases {
+            assert_eq!(dtype.to_string(), expected);
+        }
+    }
+
+    /// The bit span adds two `u16`s, which is the other place a crafted field
+    /// could wrap. Both widen, so the end is 131,070 rather than 65,534.
+    #[test]
+    fn a_crafted_bit_span_does_not_wrap() {
+        let dtype = Datatype::FixedPoint {
+            size: 1,
+            byte_order: DatatypeByteOrder::LittleEndian,
+            signed: false,
+            bit_offset: u16::MAX,
+            bit_precision: u16::MAX,
+        };
+        assert_eq!(dtype.to_string(), "u8(bits 65535..131070)");
+    }
+
     /// Only what departs from the ordinary is written, since that is what the
     /// reader of the message is looking for.
     #[test]

--- a/src/mat/de/mcos_reader.rs
+++ b/src/mat/de/mcos_reader.rs
@@ -367,7 +367,7 @@ impl Mcos {
                 let dtype = d.dtype().map_err(MatError::Hdf5)?;
                 if dtype != DType::U64 {
                     return Err(MatError::Custom(format!(
-                        "MCOS saveobj cell {idx} has datatype {dtype:?}; expected uint64"
+                        "MCOS saveobj cell {idx} has datatype {dtype}; expected uint64"
                     )));
                 }
                 d.read_u64().map_err(MatError::Hdf5)

--- a/src/mat/de/reader.rs
+++ b/src/mat/de/reader.rs
@@ -352,7 +352,7 @@ fn read_enum_indices(group: &Group, depth: usize) -> Result<Vec<usize>, MatError
     let dtype = ds.dtype().map_err(MatError::Hdf5)?;
     if dtype != DType::U32 {
         return Err(MatError::Custom(format!(
-            "enum ValueIndices has datatype {dtype:?}; expected uint32"
+            "enum ValueIndices has datatype {dtype}; expected uint32"
         )));
     }
     // Reuse the numeric read path so the column-major HDF5 buffer is transposed

--- a/src/types.rs
+++ b/src/types.rs
@@ -416,24 +416,27 @@ mod tests {
             let classified = classify_datatype(dt);
             assert_eq!(classified, DType::Other(Box::new(dt.clone())));
 
-            let shown = classified.to_string();
-            assert!(
-                shown.starts_with(&format!("other({prefix}{bits}")),
-                "{shown}"
+            // Exact, not a prefix: the right width is a prefix of every wider
+            // wrong one, so `starts_with` would pass a `size * 80`.
+            assert_eq!(
+                classified.to_string(),
+                format!("other({prefix}{bits}(bits 0..0))")
             );
         }
     }
 
-    /// Why `Other` carries the type rather than a rendering of it: a member
-    /// reached this way has no [`Dataset::datatype`](crate::Dataset::datatype)
+    /// Why `Other` carries the type rather than a rendering of it: a type
+    /// reached by recursion has no [`Dataset::datatype`](crate::Dataset::datatype)
     /// to fall back on, so what lands here is the caller's only view of it
-    /// (issue #243).
+    /// (issue #243). Both recursion sites, since either can nest one.
     #[test]
-    fn an_unclassified_member_reaches_the_caller_whole() {
+    fn an_unclassified_type_reaches_the_caller_whole_through_either_recursion() {
         let opaque = Datatype::Opaque {
             size: 3,
             tag: b"rgb".to_vec(),
         };
+        let carried = DType::Other(Box::new(opaque.clone()));
+
         let compound = Datatype::Compound {
             size: 3,
             members: vec![crate::datatype::CompoundMember {
@@ -442,13 +445,18 @@ mod tests {
                 datatype: opaque.clone(),
             }],
         };
-
         let DType::Compound(fields) = classify_datatype(&compound) else {
             panic!("a compound classifies as one");
         };
+        assert_eq!(fields, vec![("pixel".to_string(), carried.clone())]);
+
+        let array = Datatype::Array {
+            base_type: Box::new(opaque),
+            dimensions: vec![2, 3],
+        };
         assert_eq!(
-            fields,
-            vec![("pixel".to_string(), DType::Other(Box::new(opaque)))]
+            classify_datatype(&array),
+            DType::Array(Box::new(carried), vec![2, 3])
         );
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 use std::fmt;
 
+use crate::datatype::Datatype;
 use crate::display::{DISPLAY_MAX_MEMBERS, Dims, EscapedName, write_elided};
 
 pub use crate::file_writer::AttrValue;
@@ -34,7 +35,13 @@ pub enum DType {
     VariableLengthString,
     /// HDF5 object reference (8-byte address).
     ObjectReference,
-    Other(std::string::String),
+    /// A type this curated view has no name for, carrying the type itself.
+    ///
+    /// Reached through a compound field or an array base as well as at the top
+    /// level, where [`Dataset::datatype`](crate::Dataset::datatype) is not an
+    /// escape hatch, so what lands here has to be enough to work with on its
+    /// own.
+    Other(Box<Datatype>),
 }
 
 impl fmt::Display for DType {
@@ -76,23 +83,16 @@ impl fmt::Display for DType {
                 write!(f, "]")
             }
             DType::Array(base, dims) => write!(f, "array<{base}, {}>", Dims(dims)),
-            DType::Other(desc) => write!(f, "other({desc})"),
+            DType::Other(dt) => write!(f, "other({dt})"),
         }
     }
 }
 
 /// Convert a low-level `Datatype` to a simplified `DType`.
-pub(crate) fn classify_datatype(dt: &crate::datatype::Datatype) -> DType {
-    use crate::datatype::Datatype;
-
+pub(crate) fn classify_datatype(dt: &Datatype) -> DType {
     match dt {
         Datatype::FloatingPoint { size: 4, .. } => DType::F32,
         Datatype::FloatingPoint { size: 8, .. } => DType::F64,
-        // Widen before `* 8`: `size` is an on-disk `u32`, so a crafted odd size
-        // near `u32::MAX` would overflow a `u32` bit-width computation (issue #140).
-        Datatype::FloatingPoint { size, .. } => {
-            DType::Other(format!("float{}", u64::from(*size) * 8))
-        }
         Datatype::FixedPoint {
             size: 1,
             signed: true,
@@ -133,10 +133,6 @@ pub(crate) fn classify_datatype(dt: &crate::datatype::Datatype) -> DType {
             signed: false,
             ..
         } => DType::U64,
-        Datatype::FixedPoint { size, signed, .. } => {
-            let prefix = if *signed { "i" } else { "u" };
-            DType::Other(format!("{prefix}{}", u64::from(*size) * 8))
-        }
         Datatype::String { .. } => DType::String,
         Datatype::VariableLength {
             is_string: true, ..
@@ -160,10 +156,10 @@ pub(crate) fn classify_datatype(dt: &crate::datatype::Datatype) -> DType {
             ref_type: crate::datatype::ReferenceType::Object,
             ..
         } => DType::ObjectReference,
-        // The `Datatype` summary, not its `Debug`: this string is what a caller
-        // sees for an unclassified type, and the full record is unreadable in a
-        // message.
-        _ => DType::Other(dt.to_string()),
+        // The type itself, not a rendering of it: this is the only view a
+        // caller gets of a member or an array base that the curated set has no
+        // name for.
+        _ => DType::Other(Box::new(dt.clone())),
     }
 }
 
@@ -390,11 +386,12 @@ mod tests {
     use super::*;
     use crate::datatype::{Datatype, DatatypeByteOrder};
 
+    /// A width the curated set has no name for reaches the caller as the type
+    /// itself, and writing it must not overflow the `size * 8` bit-width
+    /// computation (issue #140) — `size` is an on-disk `u32`, so a crafted one
+    /// near [`u32::MAX`] is what a file can hold.
     #[test]
-    fn classify_unusual_size_does_not_overflow() {
-        // A crafted datatype `size` near `u32::MAX` must not overflow the
-        // `size * 8` bit-width computation used for the `Other(..)` label
-        // (issue #140); the value is widened to `u64` first.
+    fn an_unusual_size_arrives_whole_and_writes_its_width() {
         let int = Datatype::FixedPoint {
             size: u32::MAX,
             byte_order: DatatypeByteOrder::LittleEndian,
@@ -402,11 +399,6 @@ mod tests {
             bit_offset: 0,
             bit_precision: 0,
         };
-        assert_eq!(
-            classify_datatype(&int),
-            DType::Other(format!("i{}", u64::from(u32::MAX) * 8))
-        );
-
         let float = Datatype::FloatingPoint {
             size: u32::MAX,
             byte_order: DatatypeByteOrder::LittleEndian,
@@ -418,9 +410,45 @@ mod tests {
             mantissa_size: 0,
             exponent_bias: 0,
         };
+
+        let bits = u64::from(u32::MAX) * 8;
+        for (dt, prefix) in [(&int, 'i'), (&float, 'f')] {
+            let classified = classify_datatype(dt);
+            assert_eq!(classified, DType::Other(Box::new(dt.clone())));
+
+            let shown = classified.to_string();
+            assert!(
+                shown.starts_with(&format!("other({prefix}{bits}")),
+                "{shown}"
+            );
+        }
+    }
+
+    /// Why `Other` carries the type rather than a rendering of it: a member
+    /// reached this way has no [`Dataset::datatype`](crate::Dataset::datatype)
+    /// to fall back on, so what lands here is the caller's only view of it
+    /// (issue #243).
+    #[test]
+    fn an_unclassified_member_reaches_the_caller_whole() {
+        let opaque = Datatype::Opaque {
+            size: 3,
+            tag: b"rgb".to_vec(),
+        };
+        let compound = Datatype::Compound {
+            size: 3,
+            members: vec![crate::datatype::CompoundMember {
+                name: "pixel".into(),
+                byte_offset: 0,
+                datatype: opaque.clone(),
+            }],
+        };
+
+        let DType::Compound(fields) = classify_datatype(&compound) else {
+            panic!("a compound classifies as one");
+        };
         assert_eq!(
-            classify_datatype(&float),
-            DType::Other(format!("float{}", u64::from(u32::MAX) * 8))
+            fields,
+            vec![("pixel".to_string(), DType::Other(Box::new(opaque)))]
         );
     }
 
@@ -656,10 +684,10 @@ mod display_tests {
         );
     }
 
-    /// An unclassified datatype carries a summary. The whole `Debug` record of
-    /// the `Datatype` is unreadable in the message that quotes it.
+    /// An unclassified datatype carries the type, and writes as the summary of
+    /// it. The whole `Debug` record is unreadable in the message that quotes it.
     #[test]
-    fn an_unclassified_type_carries_a_summary_not_a_debug_record() {
+    fn an_unclassified_type_carries_the_type_and_writes_a_summary() {
         let vax = Datatype::FloatingPoint {
             size: 4,
             byte_order: DatatypeByteOrder::Vax,
@@ -681,7 +709,7 @@ mod display_tests {
             bit_precision: 32,
         };
         let classified = classify_datatype(&time);
-        assert_eq!(classified, DType::Other("time32".into()));
+        assert_eq!(classified, DType::Other(Box::new(time.clone())));
         assert_eq!(classified.to_string(), "other(time32)");
 
         let opaque = Datatype::Opaque {


### PR DESCRIPTION
Closes #243.

`classify_datatype` fell through to `DType::Other(dt.to_string())`. That payload was `Datatype`'s `Display` — a summary written for error messages, not a contract. #242 changed that Display and so changed every `Other` payload with it, which is the tell: a caller matching on those strings was depending on something it could never depend on correctly.

A top-level caller could reach around it via `Dataset::datatype`. A nested one could not. `classify_datatype` recurses into compound members and array base types, so an unclassified type sitting inside an otherwise structured `DType` arrived as a string, and recovering it meant re-walking the raw `Datatype` by hand — at which point `DType` had bought nothing.

## Change

`Other(Box<Datatype>)`. `Datatype` is already public API and derives the same `Debug + Clone + PartialEq`, so nothing new is exposed, and `Display` delegates to the inner type, leaving the wording unchanged: `other(opaque[3] "rgb")`.

The two arms that stringified an odd-width float or integer — `Other(format!("float{}", size * 8))` and its integer twin — collapse into the fallthrough, which is what they were working around. The `size * 8` overflow guarded there (#140) goes with them: the only multiply left is in `Datatype`'s own `bit_width`, which widens to `u64` first. Its regression test follows the computation, now asserting the crafted type reaches `Other` whole and still writes its widened bit count.

## Tests

- `an_unclassified_member_reaches_the_caller_whole` — an opaque type inside a compound comes back as `Other(Box::new(opaque))`, the case with no `Dataset::datatype` fallback.
- `an_unusual_size_arrives_whole_and_writes_its_width` — the #140 guard, repointed.
- `an_unclassified_type_carries_the_type_and_writes_a_summary` — the payload is the type; the rendering is still the summary, not the `Debug` record.

Two mutation probes, each failing as it should: replacing the payload with a constant fails all three, and dropping the `other(..)` wrapper fails the two that pin the rendering.

Breaking, and `Cargo.toml` already reads `0.32.0` against the `0.31.0` release, so the cycle's bump covers it.

Local: `cargo test --lib` 702 pass, `cargo test --doc` 25 pass, `cargo clippy --all-targets` clean, `cargo check --no-default-features` builds, `cargo fmt --check` clean.
